### PR TITLE
Adjust IDs to conventional spellings

### DIFF
--- a/tei/aeschylus-agamemnon.xml
+++ b/tei/aeschylus-agamemnon.xml
@@ -51,7 +51,7 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="fylaks" sex="MALE">
+					<person xml:id="phylax" sex="MALE">
 						<persName>Φύλαξ</persName>
 					</person>
 					<person xml:id="aigisthos" sex="MALE">
@@ -60,13 +60,13 @@
 					<person xml:id="agamemnon" sex="MALE">
 						<persName>Ἀγαμέμνων</persName>
 					</person>
-					<person xml:id="keryks" sex="MALE">
+					<person xml:id="keryx" sex="MALE">
 						<persName>Κῆρυξ</persName>
 					</person>
 					<person xml:id="klytaimestra" sex="FEMALE">
 						<persName>Κλυταιμήστρα</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="UNKNOWN">
+					<personGrp xml:id="choros" sex="UNKNOWN">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="kasandra" sex="FEMALE">
@@ -187,7 +187,7 @@ convert to P3
 		<body>
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>θεοὺς μὲν αἰτῶ τῶνδ’ ἀπαλλαγὴν πόνων</l>
 					<l>φρουρᾶς ἐτείας μῆκος, ἣν κοιμώμενος</l>
@@ -243,7 +243,7 @@ convert to P3
 				</sp>
 				<milestone ed="p" n="40" unit="card"/>
 				<div2 type="anapests">
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="40">δέκατον μὲν ἔτος τόδ’ ἐπεὶ Πριάμου</l>
 						<l>μέγας ἀντίδικος,</l>
@@ -337,7 +337,7 @@ convert to P3
 			<milestone ed="p" n="104" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κύριός εἰμι θροεῖν ὅδιον κράτος αἴσιον ἀνδρῶν</l>
 						<l n="105">ἐκτελέων· ἔτι γὰρ θεόθεν καταπνεύει</l>
@@ -360,7 +360,7 @@ convert to P3
 				</div2>
 				<div2 n="1" type="antistrophe">
 					<milestone ed="p" n="122" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κεδνὸς δὲ στρατόμαντις ἰδὼν δύο λήμασι δισσοὺς</l>
 						<l>Ἀτρεΐδας μαχίμους ἐδάη λαγοδαίτας</l>
@@ -383,7 +383,7 @@ convert to P3
 				</div2>
 				<div2 type="epode">
 					<milestone ed="p" n="140" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="140">“τόσον περ εὔφρων, καλά,</l>
 						<l>δρόσοισι λεπτοῖς μαλερῶν λεόντων</l>
@@ -407,7 +407,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="strophe">
 					<milestone ed="p" n="160" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="160">Ζεύς, ὅστις ποτ’ ἐστίν, εἰ τόδ’ αὐ‐</l>
 						<l>τῷ φίλον κεκλημένῳ,</l>
@@ -420,7 +420,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="antistrophe">
 					<milestone ed="p" n="167" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδ’ ὅστις πάροιθεν ἦν μέγας,</l>
 						<l>παμμάχῳ θράσει βρύων,</l>
@@ -433,7 +433,7 @@ convert to P3
 				</div2>
 				<div2 n="3" type="strophe">
 					<milestone ed="p" n="176" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν φρονεῖν βροτοὺς ὁδώ‐</l>
 						<l>σαντα, τὸν πάθει μάθος</l>
@@ -447,7 +447,7 @@ convert to P3
 				</div2>
 				<div2 n="3" type="antistrophe">
 					<milestone ed="p" n="184" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ τόθ’ ἡγεμὼν ὁ πρέ‐</l>
 						<l n="185">σβυς νεῶν Ἀχαιικῶν,</l>
@@ -461,7 +461,7 @@ convert to P3
 				</div2>
 				<div2 n="4" type="strophe">
 					<milestone ed="p" n="192" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πνοαὶ δ’ ἀπὸ Στρυμόνος μολοῦσαι</l>
 						<l>κακόσχολοι νήστιδες δύσορμοι,</l>
@@ -480,7 +480,7 @@ convert to P3
 				</div2>
 				<div2 n="4" type="antistrophe">
 					<milestone ed="p" n="205" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="205">ἄναξ δ’ ὁ πρέσβυς τότ’ εἶπε φωνῶν·</l>
 						<l>“βαρεῖα μὲν κὴρ τὸ μὴ πιθέσθαι,</l>
@@ -499,7 +499,7 @@ convert to P3
 				</div2>
 				<div2 n="5" type="strophe">
 					<milestone ed="p" n="218" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεὶ δ’ ἀνάγκας ἔδυ λέπαδνον</l>
 						<l>φρενὸς πνέων δυσσεβῆ τροπαίαν</l>
@@ -514,7 +514,7 @@ convert to P3
 				</div2>
 				<div2 n="5" type="antistrophe">
 					<milestone ed="p" n="228" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λιτὰς δὲ καὶ κληδόνας πατρῴους</l>
 						<l>παρ’ οὐδὲν αἰῶ τε παρθένειον</l>
@@ -529,7 +529,7 @@ convert to P3
 				</div2>
 				<div2 n="6" type="strophe">
 					<milestone ed="p" n="238" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βίᾳ χαλινῶν τ’ ἀναύδῳ μένει.</l>
 						<l>κρόκου βαφὰς δ’ ἐς πέδον χέουσα</l>
@@ -545,7 +545,7 @@ convert to P3
 				</div2>
 				<div2 n="6" type="antistrophe">
 					<milestone ed="p" n="248" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὰ δ’ ἔνθεν οὔτ’ εἶδον οὔτ’ ἐννέπω·</l>
 						<l>τέχναι δὲ Κάλχαντος οὐκ ἄκραντοι.</l>
@@ -562,7 +562,7 @@ convert to P3
 			</div1>
 			<milestone ed="p" n="258" unit="card"/>
 			<div1 type="episode">
-				<sp n="Χορός" who="#xoros">
+				<sp n="Χορός" who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἥκω σεβίζων σόν, Κλυταιμήστρα, κράτος·</l>
 					<l>δίκη γάρ ἐστι φωτὸς ἀρχηγοῦ τίειν</l>
@@ -578,7 +578,7 @@ convert to P3
 					<l>πεύσῃ δὲ χάρμα μεῖζον ἐλπίδος κλύειν·</l>
 					<l>Πριάμου γὰρ ᾑρήκασιν Ἀργεῖοι πόλιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς φής; πέφευγε τοὔπος ἐξ ἀπιστίας.</l>
 				</sp>
@@ -586,7 +586,7 @@ convert to P3
 					<speaker>Κλυταιμήστρα</speaker>
 					<l>Τροίαν Ἀχαιῶν οὖσαν· ἦ τορῶς λέγω;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="270">χαρά μ’ ὑφέρπει δάκρυον ἐκκαλουμένη.</l>
 				</sp>
@@ -594,7 +594,7 @@ convert to P3
 					<speaker>Κλυταιμήστρα</speaker>
 					<l>εὖ γὰρ φρονοῦντος ὄμμα σοῦ κατηγορεῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί γὰρ τὸ πιστόν; ἔστι τῶνδέ σοι τέκμαρ;</l>
 				</sp>
@@ -602,7 +602,7 @@ convert to P3
 					<speaker>Κλυταιμήστρα</speaker>
 					<l>ἔστιν· τί δ’ οὐχί; μὴ δολώσαντος θεοῦ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πότερα δ’ ὀνείρων φάσματ’ εὐπιθῆ σέβεις;</l>
 				</sp>
@@ -610,7 +610,7 @@ convert to P3
 					<speaker>Κλυταιμήστρα</speaker>
 					<l n="275">οὐ δόξαν ἂν λάβοιμι βριζούσης φρενός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἦ σ’ ἐπίανέν τις ἄπτερος φάτις;</l>
 				</sp>
@@ -618,7 +618,7 @@ convert to P3
 					<speaker>Κλυταιμήστρα</speaker>
 					<l>παιδὸς νέας ὣς κάρτ’ ἐμωμήσω φρένας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ποίου χρόνου δὲ καὶ πεπόρθηται πόλις;</l>
 				</sp>
@@ -626,7 +626,7 @@ convert to P3
 					<speaker>Κλυταιμήστρα</speaker>
 					<l>τῆς νῦν τεκούσης φῶς τόδ’ εὐφρόνης λέγω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="280">καὶ τίς τόδ’ ἐξίκοιτ’ ἂν ἀγγέλων τάχος;</l>
 				</sp>
@@ -673,7 +673,7 @@ convert to P3
 					<l n="315">τέκμαρ τοιοῦτον σύμβολόν τέ σοι λέγω</l>
 					<l>ἀνδρὸς παραγγείλαντος ἐκ Τροίας ἐμοί.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θεοῖς μὲν αὖθις, ὦ γύναι, προσεύξομαι.</l>
 					<l>λόγους δ’ ἀκοῦσαι τούσδε κἀποθαυμάσαι</l>
@@ -717,7 +717,7 @@ convert to P3
 					<l>τὸ δ’ εὖ κρατοίη μὴ διχορρόπως ἰδεῖν.</l>
 					<l n="350">πολλῶν γὰρ ἐσθλῶν τήνδ’ ὄνησιν εἱλόμην.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>γύναι, κατ’ ἄνδρα σώφρον’ εὐφρόνως λέγεις.</l>
 					<l>ἐγὼ δ’ ἀκούσας πιστά σου τεκμήρια</l>
@@ -748,7 +748,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Διὸς πλαγὰν ἔχουσιν εἰπεῖν,</l>
 						<l>πάρεστιν τοῦτό γ’ ἐξιχνεῦσαι.</l>
@@ -771,7 +771,7 @@ convert to P3
 				</div2>
 				<div2 n="1" type="antistrophe">
 					<milestone ed="p" n="385" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="385">βιᾶται δ’ ἁ τάλαινα πειθώ,</l>
 						<l>προβούλου παῖς ἄφερτος ἄτας.</l>
@@ -794,7 +794,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="strophe">
 					<milestone ed="p" n="403" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λιποῦσα δ’ ἀστοῖσιν ἀσπίστοράς</l>
 						<l>τε καὶ κλόνους λογχίμους</l>
@@ -817,7 +817,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="antistrophe">
 					<milestone ed="p" n="420" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="420">ὀνειρόφαντοι δὲ πενθήμονες</l>
 						<l>πάρεισι δόξαι φέρου‐</l>
@@ -840,7 +840,7 @@ convert to P3
 				</div2>
 				<div2 n="3" type="strophe">
 					<milestone ed="p" n="437" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ χρυσαμοιβὸς δ’ Ἄρης σωμάτων</l>
 						<l>καὶ ταλαντοῦχος ἐν μάχῃ δορὸς</l>
@@ -864,7 +864,7 @@ convert to P3
 				</div2>
 				<div2 n="3" type="antistrophe">
 					<milestone ed="p" n="456" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βαρεῖα δ’ ἀστῶν φάτις ξὺν κότῳ·</l>
 						<l>δημοκράντου δ’ ἀρᾶς τίνει χρέος.</l>
@@ -888,7 +888,7 @@ convert to P3
 				</div2>
 				<div2 type="epode">
 					<milestone ed="p" n="475" unit="card"/>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="475">πυρὸς δ’ ὑπ’ εὐαγγέλου</l>
 						<l>πόλιν διήκει θοὰ</l>
@@ -908,7 +908,7 @@ convert to P3
 			</div1>
 			<milestone ed="p" n="488" unit="card"/>
 			<div1 type="episode">
-				<sp n="Χορός" who="#xoros">
+				<sp n="Χορός" who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τάχ’ εἰσόμεσθα λαμπάδων φαεσφόρων</l>
 					<l n="490">φρυκτωριῶν τε καὶ πυρὸς παραλλαγάς,</l>
@@ -925,7 +925,7 @@ convert to P3
 					<l>ὅστις τάδ’ ἄλλως τῇδ’ ἐπεύχεται πόλει,</l>
 					<l>αὐτὸς φρενῶν καρποῖτο τὴν ἁμαρτίαν.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἰὼ πατρῷον οὖδας Ἀργείας χθονός,</l>
 					<l>δεκάτου σε φέγγει τῷδ’ ἀφικόμην ἔτους,</l>
@@ -964,59 +964,59 @@ convert to P3
 					<l>διπλᾶ δ’ ἔτεισαν Πριαμίδαι θἀμάρτια.</l>
 				</sp>
 				<milestone ed="p" n="538" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>κῆρυξ Ἀχαιῶν χαῖρε τῶν ἀπὸ στρατοῦ.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>χαίρω &lt;γε&gt;· τεθνάναι δ’ οὐκέτ’ ἀντερῶ θεοῖς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="540">ἔρως πατρῴας τῆσδε γῆς σ’ ἐγύμνασεν;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ὥστ’ ἐνδακρύειν γ’ ὄμμασιν χαρᾶς ὕπο.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τερπνῆς ἄρ’ ἦτε τῆσδ’ ἐπήβολοι νόσου.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>πῶς δή; διδαχθεὶς τοῦδε δεσπόσω λόγου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τῶν ἀντερώντων ἱμέρῳ πεπληγμένοι.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="545">ποθεῖν ποθοῦντα τήνδε γῆν στρατὸν λέγεις;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὡς πόλλ’ ἀμαυρᾶς ἐκ φρενός &lt;μ’&gt; ἀναστένειν</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>πόθεν τὸ δύσφρον τοῦτ’ ἐπῆν θυμῷ στύγος;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πάλαι τὸ σιγᾶν φάρμακον βλάβης ἔχω.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>καὶ πῶς; ἀπόντων κοιράνων ἔτρεις τινάς;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="550">ὡς νῦν, τὸ σὸν δή, καὶ θανεῖν πολλὴ χάρις.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>εὖ γὰρ πέπρακται.  ταῦτα δ’ ἐν πολλῷ χρόνῳ</l>
 					<l>τὰ μέν τις ἂν λέξειεν εὐπετῶς ἔχειν,</l>
@@ -1052,7 +1052,7 @@ convert to P3
 					<l>Διὸς τόδ’ ἐκπράξασα.πάντ’ ἔχεις λόγον.</l>
 				</sp>
 				<milestone ed="p" n="583" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>νικώμενος λόγοισιν οὐκ ἀναίνομαι·</l>
 					<l>ἀεὶ γὰρ ἥβη τοῖς γέρουσιν εὖ μαθεῖν.</l>
@@ -1092,12 +1092,12 @@ convert to P3
 					<l>ἄλλου πρὸς ἀνδρὸς μᾶλλον ἢ χαλκοῦ βαφάς.</l>
 					<milestone ed="p" n="613" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>τοιόσδ’ ὁ κόμπος τῆς ἀληθείας γέμων</l>
 					<l>οὐκ αἰσχρὸς ὡς γυναικὶ γενναίᾳ λακεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="615">αὕτη μὲν οὕτως εἶπε μανθάνοντί σοι</l>
 					<l>τοροῖσιν ἑρμηνεῦσιν εὐπρεπῶς λόγον.</l>
@@ -1105,48 +1105,48 @@ convert to P3
 					<l>εἰ νόστιμός τε καὶ σεσωσμένος πάλιν</l>
 					<l>ἥκει σὺν ὑμῖν, τῆσδε γῆς φίλον κράτος.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="620">οὐκ ἔσθ’ ὅπως λέξαιμι τὰ ψευδῆ καλὰ</l>
 					<l>ἐς τὸν πολὺν φίλοισι καρποῦσθαι χρόνον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς δῆτ’ ἂν εἰπὼν κεδνὰ τἀληθῆ τύχοις;</l>
 					<l>σχισθέντα δ’ οὐκ εὔκρυπτα γίγνεται τάδε.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἁνὴρ ἄφαντος ἐξ Ἀχαιικοῦ στρατοῦ,</l>
 					<l n="625">αὐτός τε καὶ τὸ πλοῖον.  οὐ ψευδῆ λέγω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πότερον ἀναχθεὶς ἐμφανῶς ἐξ Ἰλίου,</l>
 					<l>ἢ χεῖμα, κοινὸν ἄχθος, ἥρπασε στρατοῦ;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἔκυρσας ὥστε τοξότης ἄκρος σκοποῦ·</l>
 					<l>μακρὸν δὲ πῆμα συντόμως ἐφημίσω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="630">πότερα γὰρ αὐτοῦ ζῶντος ἢ τεθνηκότος</l>
 					<l>φάτις πρὸς ἄλλων ναυτίλων ἐκλῄζετο;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>οὐκ οἶδεν οὐδεὶς ὥστ’ ἀπαγγεῖλαι τορῶς,</l>
 					<l>πλὴν τοῦ τρέφοντος Ἡλίου χθονὸς φύσιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς γὰρ λέγεις χειμῶνα ναυτικῷ στρατῷ</l>
 					<l n="635">ἐλθεῖν τελευτῆσαί τε δαιμόνων κότῳ;</l>
 					<milestone ed="p" n="636" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>εὔφημον ἦμαρ οὐ πρέπει κακαγγέλῳ</l>
 					<l>γλώσσῃ μιαίνειν· χωρὶς ἡ τιμὴ θεῶν.</l>
@@ -1198,7 +1198,7 @@ convert to P3
 			<milestone ed="p" n="681" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς ποτ’ ὠνόμαζεν ὧδ’</l>
 						<l>ἐς τὸ πᾶν ἐτητύμως—</l>
@@ -1220,7 +1220,7 @@ convert to P3
 				</div2>
 				<div2 n="1" type="antistrophe">
 					<milestone ed="p" n="699" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἰλίῳ δὲ κῆδος ὀρθ‐</l>
 						<l n="700">ώνυμον τελεσσίφρων</l>
@@ -1242,7 +1242,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="strophe">
 					<milestone ed="p" n="716" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔθρεψεν δὲ λέοντος ἶ‐</l>
 						<l>νιν δόμοις ἀγάλακτον οὕ‐</l>
@@ -1258,7 +1258,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="antistrophe">
 					<milestone ed="p" n="727" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χρονισθεὶς δ’  ἀπέδειξεν ἦ‐</l>
 						<l>θος τὸ πρὸς τοκέων· χάριν</l>
@@ -1274,7 +1274,7 @@ convert to P3
 				</div2>
 				<div2 n="3" type="strophe">
 					<milestone ed="p" n="737" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάραυτα δ’ ἐλθεῖν ἐς Ἰλίου πόλιν</l>
 						<l>λέγοιμ’ ἂν φρόνημα μὲν</l>
@@ -1292,7 +1292,7 @@ convert to P3
 				</div2>
 				<div2 n="3" type="antistrophe">
 					<milestone ed="p" n="750" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="750">παλαίφατος δ’ ἐν βροτοῖς γέρων λόγος</l>
 						<l>τέτυκται, μέγαν τελε‐</l>
@@ -1310,7 +1310,7 @@ convert to P3
 				</div2>
 				<div2 n="4" type="strophe">
 					<milestone ed="p" n="763" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φιλεῖ δὲ τίκτειν Ὕβρις</l>
 						<l>μὲν παλαιὰ νεά‐</l>
@@ -1325,7 +1325,7 @@ convert to P3
 				</div2>
 				<div2 n="4" type="antistrophe">
 					<milestone ed="p" n="772" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Δίκα δὲ λάμπει μὲν ἐν</l>
 						<l>δυσκάπνοις δώμασιν,</l>
@@ -1342,7 +1342,7 @@ convert to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγε δή, βασιλεῦ, Τροίας πτολίπορθ’,</l>
 						<l>Ἀτρέως γένεθλον,</l>
@@ -1627,7 +1627,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="975">τίπτε μοι τόδ’ ἐμπέδως</l>
 						<l>δεῖμα προστατήριον</l>
@@ -1645,7 +1645,7 @@ convert to P3
 				</div2>
 				<div2 n="1" type="antistrophe">
 					<milestone ed="p" n="988" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πεύθομαι δ’ ἀπ’ ὀμμάτων</l>
 						<l>νόστον, αὐτόμαρτυς ὤν·</l>
@@ -1663,7 +1663,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="strophe">
 					<milestone ed="p" n="1001" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μάλα γέ τοι τὸ μεγάλας ὑγιείας</l>
 						<l>ἀκόρεστον τέρμα· νόσος γάρ</l>
@@ -1686,7 +1686,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="antistrophe">
 					<milestone ed="p" n="1017" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ δ’ ἐπὶ γᾶν πεσὸν ἅπαξ θανάσιμον</l>
 						<l n="1020">πρόπαρ ἀνδρὸς μέλαν αἷμα τίς ἂν</l>
@@ -1723,7 +1723,7 @@ convert to P3
 					<l n="1045">ὠμοί τε δούλοις πάντα καὶ παρὰ στάθμην.</l>
 					<l>ἔχεις παρ’ ἡμῶν οἷά περ νομίζεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σοί τοι λέγουσα παύεται σαφῆ λόγον.</l>
 					<l>ἐντός δ’ ἂν οὖσα μορσίμων ἀγρευμάτων</l>
@@ -1735,7 +1735,7 @@ convert to P3
 					<l>ἀγνῶτα φωνὴν βάρβαρον κεκτημένη,</l>
 					<l>ἔσω φρενῶν λέγουσα πείθω νιν λόγῳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἕπου.  τὰ λῷστα τῶν παρεστώτων λέγει.</l>
 					<l>πιθοῦ λιποῦσα τόνδ’ ἁμαξήρη θρόνον.</l>
@@ -1750,7 +1750,7 @@ convert to P3
 					<l n="1060">εἰ δ’ ἀξυνήμων οὖσα μὴ δέχῃ λόγον,</l>
 					<l>σὺ δ’ ἀντὶ φωνῆς φράζε καρβάνῳ χερί.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἑρμηνέως ἔοικεν ἡ ξένη τοροῦ</l>
 					<l>δεῖσθαι· τρόπος δὲ θηρὸς ὡς νεαιρέτου.</l>
@@ -1763,7 +1763,7 @@ convert to P3
 					<l>πρὶν αἱματηρὸν ἐξαφρίζεσθαι μένος.</l>
 					<l>οὐ μὴν πλέω ῥίψασ’ ἀτιμασθήσομαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐγὼ δ’, ἐποικτίρω γάρ, οὐ θυμώσομαι.</l>
 					<l n="1070">ἴθ’, ὦ τάλαινα, τόνδ’ ἐρημώσασ’ ὄχον,</l>
@@ -1778,7 +1778,7 @@ convert to P3
 						<l>ὀτοτοτοῖ πόποι δᾶ.</l>
 						<l>Ὦπολλον Ὦπολλον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί ταῦτ’ ἀνωτότυξας ἀμφὶ Λοξίου;</l>
 						<l n="1075">οὐ γὰρ τοιοῦτος ὥστε θρηνητοῦ τυχεῖν.</l>
@@ -1791,7 +1791,7 @@ convert to P3
 						<l>ὀτοτοτοῖ πόποι δᾶ.</l>
 						<l>Ὦπολλον Ὦπολλον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἡ δ’ αὖτε δυσφημοῦσα τὸν θεὸν καλεῖ</l>
 						<l>οὐδὲν προσήκοντ’ ἐν γόοις παραστατεῖν.</l>
@@ -1805,7 +1805,7 @@ convert to P3
 						<l>ἀγυιᾶτ’, ἀπόλλων ἐμός.</l>
 						<l>ἀπώλεσας γὰρ οὐ μόλις τὸ δεύτερον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χρήσειν ἔοικεν ἀμφὶ τῶν αὑτῆς κακῶν.</l>
 						<l>μένει τὸ θεῖον δουλίᾳ περ ἐν φρενί.</l>
@@ -1819,7 +1819,7 @@ convert to P3
 						<l>ἀγυιᾶτ’, ἀπόλλων ἐμός.</l>
 						<l>ἆ ποῖ ποτ’ ἤγαγές με; πρὸς ποίαν στέγην;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρὸς τὴν Ἀτρειδῶν· εἰ σὺ μὴ τόδ’ ἐννοεῖς,</l>
 						<l>ἐγὼ λέγω σοι· καὶ τάδ’ οὐκ ἐρεῖς ψύθη.</l>
@@ -1833,7 +1833,7 @@ convert to P3
 						<l>αὐτόφονα κακὰ καρατόμα,</l>
 						<l>ἀνδροσφαγεῖον καὶ πεδορραντήριον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔοικεν εὔρις ἡ ξένη κυνὸς δίκην</l>
 						<l>εἶναι, ματεύει δ’ ὧν ἀνευρήσει φόνον.</l>
@@ -1847,7 +1847,7 @@ convert to P3
 						<l>κλαιόμενα τάδε βρέφη σφαγάς,</l>
 						<l>ὀπτάς τε σάρκας πρὸς πατρὸς βεβρωμένας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ μὲν κλέος σοῦ μαντικὸν πεπυσμένοι</l>
 						<l>ἦμεν· προφήτας δ’ οὔτινας ματεύομεν.</l>
@@ -1863,7 +1863,7 @@ convert to P3
 						<l>ἄφερτον φίλοισιν, δυσίατον; ἀλκὰ δ’</l>
 						<l>ἑκὰς ἀποστατεῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1105">τούτων ἄιδρίς εἰμι τῶν μαντευμάτων.</l>
 						<l>ἐκεῖνα δ’ ἔγνων·  πᾶσα γὰρ πόλις βοᾷ.</l>
@@ -1879,7 +1879,7 @@ convert to P3
 						<l n="1110">τάχος γὰρ τόδ’ ἔσται· προτείνει δὲ χεὶρ ἐκ</l>
 						<l>χερὸς ὀρέγματα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔπω ξυνῆκα·  νῦν γὰρ ἐξ αἰνιγμάτων</l>
 						<l>ἐπαργέμοισι θεσφάτοις ἀμηχανῶ.</l>
@@ -1895,7 +1895,7 @@ convert to P3
 						<l>φόνου.  στάσις δ’ ἀκόρετος γένει</l>
 						<l>κατολολυξάτω θύματος λευσίμου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποίαν Ἐρινὺν τήνδε δώμασιν κέλῃ</l>
 						<l n="1120">ἐπορθιάζειν; οὔ με φαιδρύνει λόγος.</l>
@@ -1915,7 +1915,7 @@ convert to P3
 						<l>τύπτει· πίτνει δ’ &lt;ἐν&gt; ἐνύδρῳ τεύχει.</l>
 						<l>δολοφόνου λέβητος τύχαν σοι λέγω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1130">οὐ κομπάσαιμ’ ἂν θεσφάτων γνώμων ἄκρος</l>
 						<l>εἶναι, κακῷ δέ τῳ προσεικάζω τάδε.</l>
@@ -1934,7 +1934,7 @@ convert to P3
 						<l>ποῖ δή με δεῦρο τὴν τάλαιναν ἤγαγες;</l>
 						<l>οὐδέν ποτ’ εἰ μὴ ξυνθανουμένην.  τί γάρ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1140">φρενομανής τις εἶ θεοφόρητος, ἀμ‐</l>
 						<l>φὶ δ’ αὑτᾶς θροεῖς</l>
@@ -1953,7 +1953,7 @@ convert to P3
 						<l>θεοὶ γλυκύν τ’ αἰῶνα κλαυμάτων ἄτερ·</l>
 						<l>ἐμοὶ δὲ μίμνει σχισμὸς ἀμφήκει δορί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1150">πόθεν ἐπισσύτους θεοφόρους [τ’] ἔχεις</l>
 						<l>ματαίους δύας,</l>
@@ -1974,7 +1974,7 @@ convert to P3
 						<l n="1160">νῦν δ’ ἀμφὶ Κωκυτόν τε κἀχερουσίους</l>
 						<l>ὄχθας ἔοικα θεσπιῳδήσειν τάχα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί τόδε τορὸν ἄγαν ἔπος ἐφημίσω;</l>
 						<l>νεόγονος ἂν ἀΐων μάθοι.</l>
@@ -1994,7 +1994,7 @@ convert to P3
 						<l>τὸ μὴ πόλιν μὲν ὥσπερ οὖν ἔχει παθεῖν.</l>
 						<l>ἐγὼ δὲ θερμόνους τάχ’ ἐν πέδῳ βαλῶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἑπόμενα προτέροισι τάδ’ ἐφημίσω.</l>
 						<l>καί τίς σε κακοφρονῶν τίθη‐</l>
@@ -2029,7 +2029,7 @@ convert to P3
 					<l>ἐκμαρτύρησον προυμόσας τό μ’ εἰδέναι</l>
 					<l>λόγῳ παλαιὰς τῶνδ’ ἁμαρτίας δόμων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ πῶς ἂν ὅρκος, πῆγμα γενναίως παγέν,</l>
 					<l>παιώνιον γένοιτο; θαυμάζω δέ σου,</l>
@@ -2041,7 +2041,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>μάντις μ’ Ἀπόλλων τῷδ’ ἐπέστησεν τέλει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1204">μῶν καὶ θεός περ ἱμέρῳ πεπληγμένος;</l>
 				</sp>
@@ -2049,7 +2049,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l n="1203">προτοῦ μὲν αἰδὼς ἦν ἐμοὶ λέγειν τάδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1205">ἁβρύνεται γὰρ πᾶς τις εὖ πράσσων πλέον.</l>
 				</sp>
@@ -2057,7 +2057,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>ἀλλ’ ἦν παλαιστὴς κάρτ’ ἐμοὶ πνέων χάριν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἦ καὶ τέκνων εἰς ἔργον ἤλθετον νόμῳ;</l>
 				</sp>
@@ -2065,7 +2065,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>ξυναινέσασα Λοξίαν ἐψευσάμην.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἤδη τέχναισιν ἐνθέοις ᾑρημένη;</l>
 				</sp>
@@ -2073,7 +2073,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l n="1210">ἤδη πολίταις πάντ’ ἐθέσπιζον πάθη.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς δῆτ’ ἄνατος ἦσθα Λοξίου κότῳ;</l>
 				</sp>
@@ -2081,7 +2081,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>ἔπειθον οὐδέν’ οὐδέν, ὡς τάδ’ ἤμπλακον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμῖν γε μὲν δὴ πιστὰ θεσπίζειν δοκεῖς.</l>
 				</sp>
@@ -2117,7 +2117,7 @@ convert to P3
 					<l>ἄγαν γ’ ἀληθόμαντιν οἰκτίρας ἐρεῖς.</l>
 					<milestone ed="p" n="1242" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τὴν μὲν Θυέστου δαῖτα παιδείων κρεῶν</l>
 					<l>ξυνῆκα καὶ πέφρικα, καὶ φόβος μ’ ἔχει</l>
@@ -2128,7 +2128,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>Ἀγαμέμνονός σέ φημ’ ἐπόψεσθαι μόρον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εὔφημον, ὦ τάλαινα, κοίμησον στόμα.</l>
 				</sp>
@@ -2136,7 +2136,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>ἀλλ’ οὔτι παιὼν τῷδ’ ἐπιστατεῖ λόγῳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὔκ, εἴπερ ἔσται γ’· ἀλλὰ μὴ γένοιτό πως.</l>
 				</sp>
@@ -2144,7 +2144,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l n="1250">σὺ μὲν κατεύχῃ, τοῖς δ’ ἀποκτείνειν μέλει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τίνος πρὸς ἀνδρὸς τοῦτ’ ἄγος πορσύνεται;</l>
 				</sp>
@@ -2152,7 +2152,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>ἦ κάρτα τἄρ’ ἂν παρεκόπης χρησμῶν ἐμῶν</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τοῦ γὰρ τελοῦντος οὐ ξυνῆκα μηχανήν.</l>
 				</sp>
@@ -2160,7 +2160,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>καὶ μὴν ἄγαν γ’ Ἕλλην’ ἐπίσταμαι φάτιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1255">καὶ γὰρ τὰ πυθόκραντα· δυσμαθῆ δ’ ὅμως.</l>
 				</sp>
@@ -2207,7 +2207,7 @@ convert to P3
 					<l>ἀπορρυέντων, ὄμμα συμβάλω τόδε.</l>
 					<milestone ed="p" n="1295" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1295">ὦ πολλὰ μὲν τάλαινα, πολλὰ δ’ αὖ σοφὴ</l>
 					<l>γύναι, μακρὰν ἔτεινας.  εἰ δ’ ἐτητύμως</l>
@@ -2218,7 +2218,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>οὐκ ἔστ’ ἄλυξις, οὔ, ξένοι, χρόνον πλέω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1300">ὁ δ’ ὕστατός γε τοῦ χρόνου πρεσβεύεται,</l>
 				</sp>
@@ -2226,7 +2226,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>ἥκει τόδ’ ἦμαρ· σμικρὰ κερδανῶ φυγῇ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἴσθι τλήμων οὖσ’ ἀπ’ εὐτόλμου φρενός.</l>
 				</sp>
@@ -2234,7 +2234,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>οὐδεὶς ἀκούει ταῦτα τῶν εὐδαιμόνων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εὐκλεῶς τοι κατθανεῖν χάρις βροτῷ.</l>
 				</sp>
@@ -2242,7 +2242,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l n="1305">ἰὼ πάτερ σοῦ σῶν τε γενναίων τέκνων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἐστὶ χρῆμα; τίς σ’ ἀποστρέφει φόβος;</l>
 				</sp>
@@ -2250,7 +2250,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>φεῦ φεῦ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί τοῦτ’ ἔφευξας; εἴ τι μὴ φρενῶν στύγος.</l>
 				</sp>
@@ -2258,7 +2258,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>φόνον δόμοι πνέουσιν αἱματοσταγῆ,</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1310">καί πῶς;τόδ’ ὄζει θυμάτων ἐφεστίων.</l>
 				</sp>
@@ -2266,7 +2266,7 @@ convert to P3
 					<speaker>Κασάνδρα</speaker>
 					<l>ὅμοιος ἀτμὸς ὥσπερ ἐκ τάφου πρέπει,</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐ Σύριον ἀγλάισμα δώμασιν λέγεις.</l>
 				</sp>
@@ -2281,7 +2281,7 @@ convert to P3
 					<l>ἀνήρ τε δυσδάμαρτος ἀντ’ ἀνδρὸς πέσῃ.</l>
 					<l n="1320">ἐπιξενοῦμαι ταῦτα δ’  ὡς θανουμένη.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ τλῆμον, οἰκτίρω σε θεσφάτου μόρου.</l>
 				</sp>
@@ -2299,7 +2299,7 @@ convert to P3
 					<milestone ed="p" n="1331" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ μὲν εὖ πράσσειν ἀκόρεστον ἔφυ</l>
 						<l>πᾶσι βροτοῖσιν· δακτυλοδείκτων δ’</l>
@@ -2320,7 +2320,7 @@ convert to P3
 						<l>ὤμοι, πέπληγμαι καιρίαν πληγὴν ἔσω.</l>
 						<milestone ed="p" n="1344" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						 
 						<!-- trochees marked here -->
 						<speaker>Χορός</speaker>
@@ -2332,7 +2332,7 @@ convert to P3
 						<l n="1345">ὤμοι μάλ’ αὖθις, δευτέραν πεπληγμένος.</l>
 						<milestone ed="p" n="1346" unit="card"/>
 					</sp>
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						 
 						<!-- trochees marked here -->
 						<speaker>Χορός</speaker>
@@ -2398,7 +2398,7 @@ convert to P3
 						<l>τοσῶνδε κρατῆρ’ ἐν δόμοις κακῶν ὅδε</l>
 						<l>πλήσας ἀραίων αὐτὸς ἐκπίνει μολών.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θαυμάζομέν σου γλῶσσαν, ὡς θρασύστομος,</l>
 						<l n="1400">ἥτις τοιόνδ’ ἐπ’ ἀνδρὶ κομπάζεις λόγον.</l>
@@ -2417,7 +2417,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί κακόν, ὦ γύναι,</l>
 						<l>χθονοτρεφὲς ἐδανὸν ἢ ποτὸν</l>
@@ -2447,7 +2447,7 @@ convert to P3
 				</div2>
 				<div2 n="1" type="antistrophe">
 					<milestone ed="p" n="1426" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μεγαλόμητις εἶ,</l>
 						<l>περίφρονα δ’ ἔλακες. ὥσπερ οὖν</l>
@@ -2484,7 +2484,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φεῦ, τίς ἂν ἐν τάχει, μὴ περιώδυνος,</l>
 						<l>μηδὲ δεμνιοτήρης,</l>
@@ -2497,7 +2497,7 @@ convert to P3
 				</div2>
 				<div2 n="1" type="ephymn.">
 					<milestone ed="p" n="1455" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1455">ἰὼ &lt;ἰὼ&gt; παράνους Ἑλένα</l>
 						<l>μία τὰς πολλάς, τάς πάνυ πολλὰς</l>
@@ -2521,7 +2521,7 @@ convert to P3
 				</div2>
 				<div2 n="1" type="antistrophe">
 					<milestone ed="p" n="1468" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δαῖμον, ὃς ἐμπίτνεις δώμασι καὶ διφυί‐</l>
 						<l>οισι Τανταλίδαισιν,</l>
@@ -2546,7 +2546,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="strophe">
 					<milestone ed="p" n="1481" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ μέγαν οἰκονόμον</l>
 						<l>δαίμονα καὶ βαρύμηνιν αἰνεῖς,</l>
@@ -2560,7 +2560,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="ephymn.">
 					<milestone ed="p" n="1489" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰὼ βασιλεῦ βασιλεῦ,</l>
 						<l n="1490">πῶς σε δακρύσω;</l>
@@ -2588,7 +2588,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="antistrophe">
 					<milestone ed="p" n="1505" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1505">ὡς μὲν ἀναίτιος εἶ</l>
 						<l>τοῦδε φόνου τίς ὁ μαρτυρήσων;</l>
@@ -2602,7 +2602,7 @@ convert to P3
 				</div2>
 				<div2 n="2" type="ephymn">
 					<milestone ed="p" n="1513" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰὼ βασιλεῦ βασιλεῦ,</l>
 						<l>πῶς σε δακρύσω;</l>
@@ -2632,7 +2632,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1530">ἀμηχανῶ φροντίδος στερηθεὶς</l>
 						<l>εὐπάλαμον μέριμναν</l>
@@ -2645,7 +2645,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ γᾶ γᾶ, εἴθ’ ἔμ’ ἐδέξω,</l>
 						<l>πρὶν τόνδ’ ἐπιδεῖν ἀργυροτοίχου</l>
@@ -2677,7 +2677,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1560">ὄνειδος ἥκει τόδ’ ἀντ’ ὀνείδους.</l>
 						<l>δύσμαχα δ’ ἔστι κρῖναι.</l>
@@ -2753,7 +2753,7 @@ convert to P3
 					<l n="1610">οὕτω καλὸν δὴ καὶ τὸ κατθανεῖν ἐμοί,</l>
 					<l>ἰδόντα τοῦτον τῆς δίκης ἐν ἕρκεσιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Αἴγισθ’, ὑβρίζειν ἐν κακοῖσιν οὐ σέβω.</l>
 					<l>σὺ δ’ ἄνδρα τόνδε φὴς ἑκὼν κατακτανεῖν,</l>
@@ -2773,7 +2773,7 @@ convert to P3
 					<l>ἰατρομάντεις.  οὐχ ὁρᾷς ὁρῶν τάδε;</l>
 					<l>πρὸς κέντρα μὴ λάκτιζε, μὴ παίσας μογῇς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1625">γύναι, σὺ τοὺς ἥκοντας ἐκ μάχης μένων</l>
 					<l>οἰκουρὸς εὐνὴν ἀνδρὸς αἰσχύνων ἅμα</l>
@@ -2787,7 +2787,7 @@ convert to P3
 					<l>σὺ δ’ ἐξορίνας νηπίοις ὑλάγμασιν</l>
 					<l>ἄξῃ· κρατηθεὶς δ’ ἡμερώτερος φανῇ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὡς δὴ σύ μοι τύραννος Ἀργείων ἔσῃ,</l>
 					<l>ὃς οὐκ, ἐπειδὴ τῷδ’ ἐβούλευσας μόρον,</l>
@@ -2803,7 +2803,7 @@ convert to P3
 					<l>κριθῶντα πῶλον· ἀλλ’ ὁ δυσφιλὴς σκότῳ</l>
 					<l>λιμὸς ξύνοικος μαλθακόν σφ’ ἐπόψεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δὴ τὸν ἄνδρα τόνδ’ ἀπὸ ψυχῆς κακῆς</l>
 					<l>οὐκ αὐτὸς ἠνάριζες, ἀλλά νιν γυνὴ</l>
@@ -2819,7 +2819,7 @@ convert to P3
 						<l>ἀλλ’ ἐπεὶ δοκεῖς τάδ’ ἔρδειν καὶ λέγειν, γνώσῃ τάχα</l>
 						<l n="1650">εἶα δή, φίλοι λοχῖται, τοὔργον οὐχ ἑκὰς τόδε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἶα δή, ξίφος πρόκωπον πᾶς τις εὐτρεπιζέτω.</l>
 					</sp>
@@ -2827,7 +2827,7 @@ convert to P3
 						<speaker>Αἴγισθος</speaker>
 						<l>ἀλλὰ κἀγὼ μὴν πρόκωπος οὐκ ἀναίνομαι θανεῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεχομένοις λέγεις θανεῖν σε· τὴν τύχην δ’ αἱρούμεθα.</l>
 					</sp>
@@ -2848,7 +2848,7 @@ convert to P3
 						<l>κἀκβαλεῖν ἔπη τοιαῦτα δαίμονος πειρωμένους,</l>
 						<l>σώφρονος γνώμης θ’ ἁμαρτεῖν τὸν κρατοῦντά &lt;θ’ ὑβρίσαι&gt;.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1665">οὐκ ἂν Ἀργείων τόδ’ εἴη, φῶτα προσσαίνειν κακόν.</l>
 					</sp>
@@ -2856,7 +2856,7 @@ convert to P3
 						<speaker>Αἴγισθος</speaker>
 						<l>ἀλλ’ ἐγώ σ’ ἐν ὑστέραισιν ἡμέραις μέτειμ’ ἔτι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔκ, ἐὰν δαίμων, Ὀρέστην δεῦρ’ ἀπευθύνῃ μολεῖν.</l>
 					</sp>
@@ -2864,7 +2864,7 @@ convert to P3
 						<speaker>Αἴγισθος</speaker>
 						<l>οἶδ’ ἐγὼ φεύγοντας ἄνδρας ἐλπίδας σιτουμένους.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρᾶσσε, πιαίνου, μιαίνων τὴν δίκην, ἐπεὶ πάρα.</l>
 					</sp>
@@ -2872,7 +2872,7 @@ convert to P3
 						<speaker>Αἴγισθος</speaker>
 						<l n="1670">ἴσθι μοι δώσων ἄποινα τῆσδε μωρίας χάριν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κόμπασον θαρσῶν, ἀλέκτωρ ὥστε θηλείας πέλας.</l>
 					</sp>

--- a/tei/aeschylus-eumenides.xml
+++ b/tei/aeschylus-eumenides.xml
@@ -54,7 +54,7 @@
 					<person xml:id="pythias" sex="FEMALE">
 						<persName>Πυθιάς</persName>
 					</person>
-					<person xml:id="klytaimestraseidolon" sex="FEMALE">
+					<person xml:id="klytaimestras_eidolon" sex="FEMALE">
 						<persName>Κλυταιμήστρας Εἴδωλον</persName>
 					</person>
 					<person xml:id="orestes" sex="MALE">
@@ -63,7 +63,7 @@
 					<person xml:id="athena" sex="FEMALE">
 						<persName>Ἀθηνᾶ</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="UNKNOWN">
+					<personGrp xml:id="choros" sex="UNKNOWN">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="propompoi" sex="UNKNOWN">
@@ -284,7 +284,7 @@ convert to P3
 					<l>ὁρμώμενον βροτοῖσιν εὐπόμπῳ τύχῃ.</l>
 					<milestone ed="p" n="94" unit="card"/>
 				</sp>
-				<sp who="#klytaimestraseidolon">
+				<sp who="#klytaimestras_eidolon">
 					<speaker>Κλυταιμήστρας Εἴδωλον</speaker>
 					<l>εὕδοιτ’ ἄν, ὠή, καὶ καθευδουσῶν τί δεῖ;</l>
 					<l n="95">ἐγὼ δ’ ὑφ’ ὑμῶν ὧδ’ ἀπητιμασμένη</l>
@@ -313,49 +313,49 @@ convert to P3
 					<l n="115">ψυχῆς, φρονήσατ’, ὦ κατὰ χθονὸς θεαί.</l>
 					<l>ὄναρ γὰρ ὑμᾶς νῦν Κλυταιμήστρα καλῶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>(μυγμός.)</l>
 				</sp>
-				<sp who="#klytaimestraseidolon">
+				<sp who="#klytaimestras_eidolon">
 					<speaker>Κλυταιμήστρας Εἴδωλον</speaker>
 					<l>μύζοιτ’ ἄν, ἁνὴρ δ’ οἴχεται φεύγων πρόσω·</l>
 					<l>φίλοι γάρ εἰσιν οὐκ ἐμοῖς προσεικότες.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="120">(μυγμός.)</l>
 				</sp>
-				<sp who="#klytaimestraseidolon">
+				<sp who="#klytaimestras_eidolon">
 					<speaker>Κλυταιμήστρας Εἴδωλον</speaker>
 					<l>ἄγαν ὑπνώσσεις κοὐ κατοικτίζεις πάθος·</l>
 					<l>φονεὺς δ’ Ὀρέστης τῆσδε μητρὸς οἴχεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>(ὠγμός.)</l>
 				</sp>
-				<sp who="#klytaimestraseidolon">
+				<sp who="#klytaimestras_eidolon">
 					<speaker>Κλυταιμήστρας Εἴδωλον</speaker>
 					<l>ᾤζεις, ὑπνώσσεις· οὐκ ἀναστήσῃ τάχος;</l>
 					<l n="125">τί σοι πέπρωται πρᾶγμα πλὴν τεύχειν κακά;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>(ὠγμός.)</l>
 				</sp>
-				<sp who="#klytaimestraseidolon">
+				<sp who="#klytaimestras_eidolon">
 					<speaker>Κλυταιμήστρας Εἴδωλον</speaker>
 					<l>ὕπνος πόνος τε κύριοι συνωμόται</l>
 					<l>δεινῆς δρακαίνης ἐξεκήραναν μένος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>(μυγμὸς διπλοῦς ὀξύς.)</l>
 					<l n="130">λαβὲ λαβὲ λαβὲ λαβέ, φράζου.</l>
 					<milestone ed="p" n="131" unit="card"/>
 				</sp>
-				<sp who="#klytaimestraseidolon">
+				<sp who="#klytaimestras_eidolon">
 					<speaker>Κλυταιμήστρας Εἴδωλον</speaker>
 					<l>ὄναρ διώκεις θῆρα, κλαγγαίνεις δ’ ἅπερ</l>
 					<l>κύων μέριμναν οὔποτ’ ἐκλείπων πόνου.</l>
@@ -367,7 +367,7 @@ convert to P3
 					<l>ἀτμῷ κατισχναίνουσα, νηδύος πυρί,</l>
 					<l>ἕπου, μάραινε δευτέροις διώγμασιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="140">ἔγειρ’, ἔγειρε καὶ σὺ τήνδ’, ἐγὼ δὲ σέ.</l>
 					<l>εὕδεις; ἀνίστω, κἀπολακτίσασ’ ὕπνον,</l>
@@ -377,7 +377,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰοὺ ἰοὺ πύπαξ. ἐπάθομεν, φίλαι,—</l>
 						<l>ἦ πολλὰ δὴ παθοῦσα καὶ μάτην ἐγώ,—</l>
@@ -389,7 +389,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ παῖ Διός, ἐπίκλοπος πέλῃ,—</l>
 						<l n="150">νέος δὲ γραίας δαίμονας καθιππάσω,—</l>
@@ -401,7 +401,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="155">ἐμοὶ δ’ ὄνειδος ἐξ ὀνειράτων μολὸν</l>
 						<l>ἔτυψεν δίκαν διφρηλάτου</l>
@@ -413,7 +413,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοιαῦτα δρῶσιν οἱ νεώτεροι θεοί,</l>
 						<l>κρατοῦντες τὸ πᾶν δίκας πλέον</l>
@@ -425,7 +425,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐφεστίῳ δὲ μάντις ὢν μιάσματι</l>
 						<l n="170">μυχὸν ἐχράνατ’ αὐτόσσυτος, αὐτόκλητος,</l>
@@ -435,7 +435,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κἀμοί γε λυπρός, καὶ τὸν οὐκ ἐκλύσεται,</l>
 						<l n="175">ὑπό τε γᾶν φυγὼν οὔ ποτ’ ἐλευθεροῦται.</l>
@@ -468,7 +468,7 @@ convert to P3
 					<l>χωρεῖτ’ ἄνευ βοτῆρος αἰπολούμεναι.</l>
 					<l>ποίμνης τοιαύτης δ’ οὔτις εὐφιλὴς θεῶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄναξ Ἄπολλον, ἀντάκουσον ἐν μέρει.</l>
 					<l>αὐτὸς σὺ τούτων οὐ μεταίτιος πέλῃ,</l>
@@ -478,7 +478,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l>πῶς δή; τοσοῦτο μῆκος ἔκτεινον λόγου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔχρησας ὥστε τὸν ξένον μητροκτονεῖν.</l>
 				</sp>
@@ -486,7 +486,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l>ἔχρησα ποινὰς τοῦ πατρὸς πρᾶξαι. τί μήν ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>κἄπειθ’ ὑπέστης αἵματος δέκτωρ νέου.</l>
 				</sp>
@@ -494,7 +494,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l n="205">καὶ προστραπέσθαι τούσδ’ ἐπέστελλον δόμους.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ τὰς προπομποὺς δῆτα τάσδε λοιδορεῖς;</l>
 				</sp>
@@ -502,7 +502,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l>οὐ γὰρ δόμοισι τοῖσδε πρόσφορον μολεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἔστιν ἡμῖν τοῦτο προστεταγμένον.</l>
 				</sp>
@@ -510,7 +510,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l>τίς ἥδε τιμή; κόμπασον γέρας καλόν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="210">τοὺς μητραλοίας ἐκ δόμων ἐλαύνομεν.</l>
 				</sp>
@@ -518,7 +518,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l>τί γὰρ γυναικὸς ἥτις ἄνδρα νοσφίσῃ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ ἂν γένοιθ’ ὅμαιμος αὐθέντης φόνος.</l>
 					<milestone ed="p" n="213" unit="card"/>
@@ -538,7 +538,7 @@ convert to P3
 					<l>τὰ δ’ ἐμφανῶς πράσσουσαν ἡσυχαιτέραν.</l>
 					<l>δίκας δὲ Παλλὰς τῶνδ’ ἐποπτεύσει θεά.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="225">τὸν ἄνδρ’ ἐκεῖνον οὔ τι μὴ λίπω ποτέ.</l>
 				</sp>
@@ -546,7 +546,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l>σὺ δ’ οὖν δίωκε καὶ πόνον πλείω τίθου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τιμὰς σὺ μὴ σύντεμνε τὰς ἐμὰς λόγῳ.</l>
 				</sp>
@@ -554,7 +554,7 @@ convert to P3
 					<speaker>Ἀπόλλων</speaker>
 					<l>οὐδ’ ἂν δεχοίμην ὥστ’ ἔχειν τιμὰς σέθεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μέγας γὰρ ἔμπας πὰρ Διὸς θρόνοις λέγῃ.</l>
 					<l n="230">ἐγὼ δ’, ἄγει γὰρ αἷμα μητρῷον, δίκας</l>
@@ -578,7 +578,7 @@ convert to P3
 					<l>πρόσειμι δῶμα καὶ βρέτας τὸ σόν, θεά.</l>
 					<l>αὐτοῦ φυλάσσων ἀναμένω τέλος δίκης.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἶεν· τόδ’ ἐστὶ τἀνδρὸς ἐκφανὲς τέκμαρ.</l>
 					<l n="245">ἕπου δὲ μηνυτῆρος ἀφθέγκτου φραδαῖς.</l>
@@ -595,7 +595,7 @@ convert to P3
 				<div2 type="lyric">
 					 
 
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅρα ὅρα μάλ’ αὖ,</l>
 						<l n="255">λεύσσετε πάντα, μὴ</l>
@@ -654,7 +654,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="choral">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὔτοι σ’ Ἀπόλλων οὐδ’ Ἀθηναίας σθένος</l>
 					<l n="300">ῥύσαιτ’ ἂν ὥστε μὴ οὐ παρημελημένον</l>
@@ -667,7 +667,7 @@ convert to P3
 					<milestone ed="p" n="307" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγε δὴ καὶ χορὸν ἅψωμεν, ἐπεὶ</l>
 						<l>μοῦσαν στυγερὰν</l>
@@ -687,7 +687,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μᾶτερ ἅ μ’ ἔτικτες, ὦ μᾶτερ</l>
 						<l>Νύξ, ἀλαοῖσι καὶ δεδορκόσιν</l>
@@ -700,7 +700,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπὶ δὲ τῷ τεθυμένῳ</l>
 						<l>τόδε μέλος, παρακοπά,</l>
@@ -712,7 +712,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοῦτο γὰρ λάχος διανταία</l>
 						<l n="335">Μοῖρ’ ἐπέκλωσεν ἐμπέδως ἔχειν,</l>
@@ -725,7 +725,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπὶ δὲ τῷ τεθυμένῳ</l>
 						<l>τόδε μέλος, παρακοπά,</l>
@@ -737,7 +737,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>γιγνομέναισι λάχη τάδ’ ἐφ’ ἁμὶν ἐκράνθη·</l>
 						<l n="350">ἀθανάτων δ’ ἀπέχειν χέρας, οὐδέ τις ἐστί</l>
@@ -751,7 +751,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="354">&lt;δωμάτων γὰρ εἱλόμαν</l>
 						<l n="355">ἀνατροπάς, ὅταν Ἄρης</l>
@@ -763,7 +763,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="360">σπεύδομεν αἵδ’ ἀφελεῖν τινὰ τάσδε μερίμνας,</l>
 						<l>θεῶν δ’ ἀτέλειαν ἐμαῖς μελέταις ἐπικραίνειν,</l>
@@ -774,7 +774,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="354a">&lt;δωμάτων γὰρ εἱλόμαν</l>
 						<l n="355a">ἀνατροπάς, ὅταν Ἄρης</l>
@@ -786,7 +786,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="368">δόξαι τ’ ἀνδρῶν καὶ μάλ’ ὑπ’ αἰθέρι σεμναὶ</l>
 						<l>τακόμεναι κατὰ γᾶν μινύθουσιν ἄτιμοι</l>
@@ -796,7 +796,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>&lt;μάλα γὰρ οὖν ἁλομένα</l>
 						<l>ἀνέκαθεν βαρυπεσῆ</l>
@@ -807,7 +807,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πίπτων δ’ οὐκ οἶδεν τόδ’ ὑπ’ ἄφρονι λύμᾳ·</l>
 						<l>τοῖον [γὰρ] ἐπὶ κνέφας ἀνδρὶ μύσος πεπόταται,</l>
@@ -817,7 +817,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="372a">&lt;μάλα γὰρ οὖν ἁλομένα</l>
 						<l n="373a">ἀνέκαθεν βαρυπεσῆ</l>
@@ -828,7 +828,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="381">μένει γάρ. εὐμήχανοί</l>
 						<l>τε καὶ τέλειοι, κακῶν</l>
@@ -842,7 +842,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς οὖν τάδ’ οὐχ ἅζεταί</l>
 						<l n="390">τε καὶ δέδοικεν βροτῶν,</l>
@@ -878,7 +878,7 @@ convert to P3
 					<l>λέγειν δ’ ἄμομφον ὄντα τοὺς πέλας κακῶς</l>
 					<l>πρόσω δικαίων ἠδ’ ἀποστατεῖ θέμις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="415">πεύσῃ τὰ πάντα συντόμως, Διὸς κόρη.</l>
 					<l>ἡμεῖς γάρ ἐσμεν Νυκτὸς αἰανῆ τέκνα.</l>
@@ -888,7 +888,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>γένος μὲν οἶδα κληδόνας τ’ ἐπωνύμους.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τιμάς γε μὲν δὴ τὰς ἐμὰς πεύσῃ τάχα.</l>
 				</sp>
@@ -896,7 +896,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l n="420">μάθοιμ’ ἄν, εἰ λέγοι τις ἐμφανῆ λόγον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>βροτοκτονοῦντας ἐκ δόμων ἐλαύνομεν.</l>
 				</sp>
@@ -904,7 +904,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>καὶ τῷ κτανόντι ποῦ τὸ τέρμα τῆς φυγῆς;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅπου τὸ χαίρειν μηδαμοῦ νομίζεται.</l>
 				</sp>
@@ -912,7 +912,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>ἦ καὶ τοιαύτας τῷδ’ ἐπιρροιζεῖς φυγάς;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="425">φονεὺς γὰρ εἶναι μητρὸς ἠξιώσατο.</l>
 				</sp>
@@ -920,7 +920,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>ἄλλαις ἀνάγκαις, ἤ τινος τρέων κότον;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ποῦ γὰρ τοσοῦτο κέντρον ὡς μητροκτονεῖν;</l>
 				</sp>
@@ -928,7 +928,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>δυοῖν παρόντοιν ἥμισυς λόγου πάρα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ὅρκον οὐ δέξαιτ’ ἄν, οὐ δοῦναι θέλοι.</l>
 				</sp>
@@ -936,7 +936,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l n="430">κλύειν δίκαιος μᾶλλον ἢ πρᾶξαι θέλεις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς δή; δίδαξον· τῶν σοφῶν γὰρ οὐ πένῃ.</l>
 				</sp>
@@ -944,7 +944,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>ὅρκοις τὰ μὴ δίκαια μὴ νικᾶν λέγω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἐξέλεγχε, κρῖνε δ’ εὐθεῖαν δίκην.</l>
 				</sp>
@@ -952,7 +952,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>ἦ κἀπ’ ἐμοὶ τρέποιτ’ ἂν αἰτίας τέλος;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="435">πῶς δ’ οὔ; σέβουσαί γ’ ἀξίαν κἀπ’ ἀξίων.</l>
 					<milestone ed="p" n="436" unit="card"/>
@@ -1031,7 +1031,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="490">νῦν καταστροφαὶ νέων</l>
 						<l>θεσμίων, εἰ κρατή‐</l>
@@ -1046,7 +1046,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδὲ γὰρ βροτοσκόπων</l>
 						<l n="500">μαινάδων τῶνδ’ ἐφέρ‐</l>
@@ -1061,7 +1061,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδέ τις κικλῃσκέτω</l>
 						<l>ξυμφορᾷ τετυμμένος,</l>
@@ -1076,7 +1076,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔσθ’ ὅπου τὸ δεινὸν εὖ,</l>
 						<l>καὶ φρενῶν ἐπίσκοπον</l>
@@ -1091,7 +1091,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μήτ’ ἀνάρχετον βίον</l>
 						<l>μήτε δεσποτούμενον</l>
@@ -1109,7 +1109,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐς τὸ πᾶν δέ σοι λέγω,</l>
 						<l>βωμὸν αἴδεσαι Δίκας·</l>
@@ -1127,7 +1127,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="550">ἑκὼν δ’ ἀνάγκας ἄτερ δίκαιος ὢν</l>
 						<l>οὐκ ἄνολβος ἔσται·</l>
@@ -1141,7 +1141,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καλεῖ δ’ ἀκούοντας οὐδὲν &lt;ἐν&gt; μέσᾳ</l>
 						<l>δυσπαλεῖ τε δίνᾳ·</l>
@@ -1167,7 +1167,7 @@ convert to P3
 					<l>πόλιν τε πᾶσαν εἰς τὸν αἰανῆ χρόνον</l>
 					<l>καὶ τούσδ’ ὅπως ἂν εὖ καταγνωσθῇ δίκη.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄναξ Ἄπολλον, ὧν ἔχεις αὐτὸς κράτει.</l>
 					<l n="575">τί τοῦδε σοὶ μέτεστι πράγματος λέγε.</l>
@@ -1187,7 +1187,7 @@ convert to P3
 					<l>ὁ γὰρ διώκων πρότερος ἐξ ἀρχῆς λέγων</l>
 					<l>γένοιτ’ ἂν ὀρθῶς πράγματος διδάσκαλος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορος</speaker>
 					<l n="585">πολλαὶ μέν ἐσμεν, λέξομεν δὲ συντόμως.</l>
 					<l>ἔπος δ’ ἀμείβου πρὸς ἔπος ἐν μέρει τιθείς</l>
@@ -1197,7 +1197,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>ἔκτεινα· τούτου δ’ οὔτις ἄρνησις πέλει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἓν μὲν τόδ’ ἤδη τῶν τριῶν παλαισμάτων.</l>
 				</sp>
@@ -1205,7 +1205,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l n="590">οὐ κειμένῳ πω τόνδε κομπάζεις λόγον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἰπεῖν γε μέντοι δεῖ σ’ ὅπως κατέκτανες.</l>
 				</sp>
@@ -1213,7 +1213,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>λέγω· ξιφουλκῷ χειρὶ πρὸς δέρην τεμών.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πρὸς τοῦ δ’ ἐπείσθης καὶ τίνος βουλεύμασιν;</l>
 				</sp>
@@ -1221,7 +1221,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>τοῖς τοῦδε θεσφάτοισι· μαρτυρεῖ δέ μοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="595">ὁ μάντις ἐξηγεῖτό σοι μητροκτονεῖν;</l>
 				</sp>
@@ -1229,7 +1229,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>καὶ δεῦρό γ’ ἀεὶ τὴν τύχην οὐ μέμφομαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εἴ σε μάρψει ψῆφος, ἄλλ’ ἐρεῖς τάχα.</l>
 				</sp>
@@ -1237,7 +1237,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>πέποιθ’. ἀρωγὰς δ’ ἐκ τάφου πέμψει πατήρ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>νεκροῖσί νυν πέπισθι μητέρα κτανών.</l>
 				</sp>
@@ -1245,7 +1245,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l n="600">δυοῖν γὰρ εἶχε προσβολὰς μιασμάτοιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς δή; δίδαξον τοὺς δικάζοντας τάδε.</l>
 				</sp>
@@ -1253,7 +1253,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>ἀνδροκτονοῦσα πατέρ’ ἐμὸν κατέκτανεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τοιγὰρ σὺ μὲν ζῇς, ἡ δ’ ἐλευθέρα φόνῳ.</l>
 				</sp>
@@ -1261,7 +1261,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>τί δ’ οὐκ ἐκείνην ζῶσαν ἤλαυνες φυγῇ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="605">οὐκ ἦν ὅμαιμος φωτὸς ὃν κατέκτανεν.</l>
 				</sp>
@@ -1270,7 +1270,7 @@ convert to P3
 					<l>ἐγὼ δὲ μητρὸς τῆς ἐμῆς ἐν αἵματι;</l>
 					<milestone ed="p" n="607" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς γάρ σ’ ἔθρεψ’ ἂν ἐντός, ὦ μιαιφόνε,</l>
 					<l>ζώνης; ἀπεύχῃ μητρὸς αἷμα φίλτατον;</l>
@@ -1297,7 +1297,7 @@ convert to P3
 					<l n="620">βουλῇ πιφαύσκω δ’ ὔμμ’ ἐπισπέσθαι πατρός·</l>
 					<l>ὅρκος γὰρ οὔτι Ζηνὸς ἰσχύει πλέον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Ζεύς, ὡς λέγεις σύ, τόνδε χρησμὸν ὤπασε,</l>
 					<l>φράζειν Ὀρέστῃ τῷδε, τὸν πατρὸς φόνον</l>
@@ -1328,7 +1328,7 @@ convert to P3
 					<l>ὅσπερ τέτακται τήνδε κυρῶσαι δίκην.</l>
 					<milestone ed="p" n="640" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="640">πατρὸς προτιμᾷ Ζεὺς μόρον τῷ σῷ λόγῳ·</l>
 					<l>αὐτὸς δ’ ἔδησε πατέρα πρεσβύτην Κρόνον.</l>
@@ -1346,7 +1346,7 @@ convert to P3
 					<l n="650">οὑμός, τὰ δ’ ἄλλα πάντ’ ἄνω τε καὶ κάτω</l>
 					<l>στρέφων τίθησιν οὐδὲν ἀσθμαίνων μένει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς γὰρ τὸ φεύγειν τοῦδ’ ὑπερδικεῖς ὅρα·</l>
 					<l>τὸ μητρὸς αἷμ’ ὅμαιμον ἐκχέας πέδοι</l>
@@ -1383,7 +1383,7 @@ convert to P3
 					<l>ἤδη κελεύω τούσδ’ ἀπὸ γνώμης φέρειν</l>
 					<l n="675">ψῆφον δικαίαν, ὡς ἅλις λελεγμένων;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμῖν μὲν ἤδη πᾶν τετόξευται βέλος.</l>
 					<l>μένω δ’ ἀκοῦσαι πῶς ἀγὼν κριθήσεται.</l>
@@ -1437,7 +1437,7 @@ convert to P3
 					<l n="710">αἰδουμένους τὸν ὅρκον. εἴρηται λόγος.</l>
 					<milestone ed="p" n="711" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ μὴν βαρεῖαν τήνδ’ ὁμιλίαν χθονὸς</l>
 					<l>ξύμβουλός εἰμι μηδαμῶς ἀτιμάσαι.</l>
@@ -1447,7 +1447,7 @@ convert to P3
 					<l>κἄγωγε χρησμοὺς τοὺς ἐμούς τε καὶ Διὸς</l>
 					<l>ταρβεῖν κελεύω μηδ’ ἀκαρπώτους κτίσαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="715">ἀλλ’ αἱματηρὰ πράγματ’ οὐ λαχὼν σέβεις,</l>
 					<l>μαντεῖα δ’ οὐκέθ’ ἁγνὰ μαντεύσῃ νέμων.</l>
@@ -1457,7 +1457,7 @@ convert to P3
 					<l>ἦ καὶ πατήρ τι σφάλλεται βουλευμάτων</l>
 					<l>πρωτοκτόνοισι προστροπαῖς Ἰξίονος;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>λέγεις· ἐγὼ δὲ μὴ τυχοῦσα τῆς δίκης</l>
 					<l n="720">βαρεῖα χώρᾳ τῇδ’ ὁμιλήσω πάλιν.</l>
@@ -1467,7 +1467,7 @@ convert to P3
 					<l>ἀλλ’ ἔν τε τοῖς νέοισι καὶ παλαιτέροις</l>
 					<l>θεοῖς ἄτιμος εἶ σύ· νικήσω δ’ ἐγώ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τοιαῦτ’ ἔδρασας καὶ Φέρητος ἐν δόμοις·</l>
 					<l>Μοίρας ἔπεισας ἀφθίτους θεῖναι βροτούς.</l>
@@ -1477,7 +1477,7 @@ convert to P3
 					<l n="725">οὔκουν δίκαιον τὸν σέβοντ’ εὐεργετεῖν,</l>
 					<l>ἄλλως τε πάντως χὤτε δεόμενος τύχοι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σύ τοι παλαιὰς διανομὰς καταφθίσας</l>
 					<l>οἴνῳ παρηπάτησας ἀρχαίας θεάς.</l>
@@ -1487,7 +1487,7 @@ convert to P3
 					<l>σύ τοι τάχ’ οὐκ ἔχουσα τῆς δίκης τέλος</l>
 					<l n="730">ἐμῇ τὸν ἰὸν οὐδὲν ἐχθροῖσιν βαρύν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐπεὶ καθιππάζῃ με πρεσβῦτιν νέος,</l>
 					<l>δίκης γενέσθαι τῆσδ’ ἐπήκοος μένω,</l>
@@ -1514,7 +1514,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>ὦ Φοῖβ’ Ἄπολλον, πῶς ἀγὼν κριθήσεται;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="745">ὦ Νὺξ μέλαινα μῆτερ, ἆρ’ ὁρᾷς τάδε;</l>
 				</sp>
@@ -1522,7 +1522,7 @@ convert to P3
 					<speaker>Ὀρέστης</speaker>
 					<l>νῦν ἀγχόνης μοι τέρματ’, ἢ φάος βλέπειν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμῖν γὰρ ἔρρειν, ἢ πρόσω τιμὰς νέμειν.</l>
 				</sp>
@@ -1575,7 +1575,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ θεοὶ νεώτεροι, παλαιοὺς νόμους</l>
 						<l>καθιππάσασθε κἀκ χερῶν εἵλεσθέ μου.</l>
@@ -1614,7 +1614,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ θεοὶ νεώτεροι, παλαιοὺς νόμους</l>
 						<l>καθιππάσασθε κἀκ χερῶν εἵλεσθέ μου.</l>
@@ -1652,7 +1652,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐμὲ παθεῖν τάδε, φεῦ,</l>
 						<l>ἐμὲ παλαιόφρονα κατά τε γᾶς οἰκεῖν,</l>
@@ -1697,7 +1697,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="870">ἐμὲ παθεῖν τάδε, φεῦ,</l>
 						<l>ἐμὲ παλαιόφρονα κατά τε γᾶς οἰκεῖν,</l>
@@ -1728,7 +1728,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄνασσ’ Ἀθάνα, τίνα με φὴς ἔχειν ἕδραν;</l>
 				</sp>
@@ -1736,7 +1736,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>πάσης ἀπήμον’ οἰζύος· δέχου δὲ σύ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ δὴ δέδεγμαι· τίς δέ μοι τιμὴ μένει;</l>
 				</sp>
@@ -1744,7 +1744,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l n="895">ὡς μή τιν’ οἶκον εὐθενεῖν ἄνευ σέθεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σὺ τοῦτο πράξεις, ὥστε με σθένειν τόσον;</l>
 				</sp>
@@ -1752,7 +1752,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>τῷ γὰρ σέβοντι συμφορὰς ὀρθώσομεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καί μοι πρόπαντος ἐγγύην θήσῃ χρόνου;</l>
 				</sp>
@@ -1760,7 +1760,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>ἔξεστι γάρ μοι μὴ λέγειν ἃ μὴ τελῶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="900">θέλξειν μ’ ἔοικας καὶ μεθίσταμαι κότου.</l>
 				</sp>
@@ -1768,7 +1768,7 @@ convert to P3
 					<speaker>Ἀθηνᾶ</speaker>
 					<l>τοιγὰρ κατὰ χθόν’ οὖσ’ ἐπικτήσῃ φίλους.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί οὖν μ’ ἄνωγας τῇδ’ ἐφυμνῆσαι χθονί;</l>
 				</sp>
@@ -1795,7 +1795,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δέξομαι Παλλάδος ξυνοικίαν,</l>
 						<l>οὐδ’ ἀτιμάσω πόλιν,</l>
@@ -1828,7 +1828,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δενδροπήμων δὲ μὴ πνέοι βλάβα,</l>
 						<l>τὰν ἐμὰν χάριν λέγω·</l>
@@ -1857,7 +1857,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀνδροκμῆτας δ’ ἀώρ‐</l>
 						<l>ους ἀπεννέπω τύχας,</l>
@@ -1889,7 +1889,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὰν δ’ ἄπληστον κακῶν</l>
 						<l>μήποτ’ ἐν πόλει στάσιν</l>
@@ -1921,7 +1921,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>&lt;χαίρετε&gt; χαίρετ’ ἐν αἰσιμίαισι πλούτου.</l>
 						<l>χαίρετ’ ἀστικὸς λεώς,</l>
@@ -1951,7 +1951,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαίρετε, χαίρετε δ’ αὖθις, ἐπανδιπλάζω,</l>
 						<l n="1015">πάντες οἱ κατὰ πτόλιν,</l>

--- a/tei/aeschylus-libation-bearers.xml
+++ b/tei/aeschylus-libation-bearers.xml
@@ -51,7 +51,7 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="trofos" sex="UNKNOWN">
+					<person xml:id="trophos" sex="UNKNOWN">
 						<persName>Τροφός</persName>
 					</person>
 					<person xml:id="orestes" sex="MALE">
@@ -66,7 +66,7 @@
 					<person xml:id="klytaimnestra" sex="FEMALE">
 						<persName>Κλυταιμνήστρα</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="UNKNOWN">
+					<personGrp xml:id="choros" sex="UNKNOWN">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="aigisthos" sex="MALE">
@@ -223,7 +223,7 @@ convert to p3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰαλτὸς ἐκ δόμων ἔβαν</l>
 						<l>χοὰς προπομπὸς ὀξύχειρι σὺν κτύπῳ.</l>
@@ -239,7 +239,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τορὸς δὲ  Φοῖβος ὀρθόθριξ</l>
 						<l>δόμων ὀνειρόμαντις, ἐξ ὕπνου κότον</l>
@@ -255,7 +255,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοιάνδε χάριν  ἀχάριτον ἀπότροπον κακῶν,</l>
 						<l>ἰὼ γαῖα μαῖα,</l>
@@ -272,7 +272,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="55">σέβας δ’ ἄμαχον ἀδάματον  ἀπόλεμον τὸ πρὶν</l>
 						<l>δῑ ὤτων φρενός  τε</l>
@@ -289,7 +289,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δῑ αἵματ’ ἐκποθένθ’  ὑπὸ χθονὸς τροφοῦ</l>
 						<l>τίτας φόνος πέπηγεν οὐ διαρρύδαν.</l>
@@ -299,7 +299,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θιγόντι  δ’ οὔτι νυμφικῶν ἑδωλίων</l>
 						<l>ἄκος, πόροι τε πάντες ἐκ μιᾶς ὁδοῦ</l>
@@ -309,7 +309,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="75">ἐμοὶ δ’ —ἀνάγκαν γὰρ ἀμφίπτολιν</l>
 						<l>θεοὶ προσήνεγκαν· (ἐκ γὰρ οἴκων</l>
@@ -357,7 +357,7 @@ convert to p3
 					<l n="105">λέγοις ἄν, εἴ τι τῶνδ’ ἔχοις ὑπέρτερον.</l>
 					<milestone ed="p" n="106" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>αἰδουμένη σοι βωμὸν ὡς τύμβον πατρὸς</l>
 					<l>λέξω, κελεύεις γάρ, τὸν ἐκ φρενὸς λόγον.</l>
@@ -366,7 +366,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>λέγοις ἄν, ὥσπερ ᾐδέσω τάφον πατρός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>φθέγγου χέουσα κεδνὰ  τοῖσιν εὔφροσιν.</l>
 				</sp>
@@ -374,7 +374,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="110">τίνας δὲ τούτους τῶν φίλων προσεννέπω;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πρῶτον μὲν αὑτὴν χὤστις Αἴγισθον στυγεῖ.</l>
 				</sp>
@@ -382,7 +382,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἐμοί τε καὶ σοί τἄρ’ ἐπεύξομαι τάδε;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>αὐτὴ σὺ ταῦτα μανθάνουσ’ ἤδη φράσαι.</l>
 				</sp>
@@ -390,7 +390,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τίν’ οὖν ἔτ’ ἄλλον τῇδε προστιθῶ στάσει;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="115">μέμνησ’ Ὀρέστου, κεἰ θυραῖός ἐσθ’ ὅμως.</l>
 				</sp>
@@ -398,7 +398,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>εὖ τοῦτο, κἀφρένωσας οὐχ ἥκιστά με.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τοῖς αἰτίοις νῦν τοῦ φόνου μεμνημένη—</l>
 				</sp>
@@ -406,7 +406,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τί φῶ; δίδασκ’ ἄπειρον ἐξηγουμένη.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐλθεῖν τιν’ αὐτοῖς δαίμον’ ἢ βροτῶν τινα—</l>
 				</sp>
@@ -414,7 +414,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="120">πότερα δικαστὴν ἢ δικηφόρον λέγεις;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἅπλῶς τι φράζουσ’, ὅστις ἀνταποκτενεῖ.</l>
 				</sp>
@@ -422,7 +422,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>καὶ ταῦτά μοὐστὶν εὐσεβῆ θεῶν πάρα;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς δ’ οὐ τὸν ἐχθρὸν ἀνταμείβεσθαι κακοῖς;</l>
 				</sp>
@@ -465,7 +465,7 @@ convert to p3
 					<l>παιᾶνα τοῦ θανόντος ἐξαυδωμένας.</l>
 					<milestone ed="p" n="152" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἵετε δάκρυ καναχὲς ὀλόμενον</l>
 					<l>ὀλομένῳ δεσπότᾳ</l>
@@ -486,7 +486,7 @@ convert to p3
 					<l>ἔχει μὲν ἤδη γαπότους  χοὰς πατήρ·</l>
 					<l n="165">νέου δὲ μύθου τοῦδε κοινωνήσατε·</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>λέγοις ἄν· ὀρχεῖται  δὲ καρδία φόβῳ.</l>
 				</sp>
@@ -494,7 +494,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ὁρῶ τομαῖον τόνδε βόστρυχον τάφῳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τίνος ποτ’ ἀνδρός, ἢ βαθυζώνου κόρης;</l>
 				</sp>
@@ -502,7 +502,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="170">εὐξύμβολον τόδ’ ἐστὶ παντὶ δοξάσαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς οὖν; παλαιὰ παρὰ νεωτέρας μάθω.</l>
 				</sp>
@@ -510,7 +510,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>οὐκ ἔστιν ὅστις πλὴν ἐμοῦ κείραιτό νιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐχθροὶ γὰρ οἷς προσῆκε πενθῆσαι τριχί.</l>
 				</sp>
@@ -518,7 +518,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>καὶ μὴν ὅδ’ ἐστὶ κάρτ’ ἰδεῖν ὁμόπτερος—</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="175">ποίαις ἐθείραις; τοῦτο γὰρ θέλω μαθεῖν.</l>
 				</sp>
@@ -526,7 +526,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>αὐτοῖσιν ἡμῖν κάρτα προσφερὴς ἰδεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μῶν οὖν Ὀρέστου κρύβδα δῶρον ἦν  τόδε;</l>
 				</sp>
@@ -534,7 +534,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>μάλιστ’ ἐκείνου βοστρύχοις προσείδεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ πῶς ἐκεῖνος δεῦρ’ ἐτόλμησεν μολεῖν;</l>
 				</sp>
@@ -542,7 +542,7 @@ convert to p3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="180">ἔπεμψε χαίτην  κουρίμην χάριν πατρός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐχ ἧσσον εὐδάκρυτά μοι λέγεις τάδε,</l>
 					<l>εἰ τῆσδε χώρας μήποτε ψαύσει  ποδί.</l>
@@ -688,7 +688,7 @@ convert to p3
 					<l>δόμον, δοκοῦντα κάρτα νῦν πεπτωκέναι.</l>
 					<milestone ed="p" n="264" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ παῖδες, ὦ σωτῆρες ἑστίας πατρός,</l>
 					<l n="265">σιγᾶθ’, ὅπως μὴ πεύσεταί τις, ὦ τέκνα,</l>
@@ -741,7 +741,7 @@ convert to p3
 					<milestone ed="p" n="306" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ὦ μεγάλαι Μοῖραι, Διόθεν</l>
 						<l>τῇδε τελευτᾶν,</l>
@@ -772,7 +772,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τέκνον, φρόνημα τοῦ</l>
 						<l>θανόντος οὐ δαμάζει</l>
@@ -801,7 +801,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="340">ἀλλ’ ἔτ’ ἂν ἐκ τῶνδε θεὸς χρῄζων</l>
 						<l>θείη  κελάδους εὐφθογγοτέρους·</l>
@@ -827,7 +827,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φίλος φίλοισι τοῖς</l>
 						<l n="355">ἐκεῖ καλῶς θανοῦσιν</l>
@@ -857,7 +857,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ταῦτα μέν, ὦ παῖ, κρείσσονα χρυσοῦ,</l>
 						<l>μεγάλης δὲ τύχης καὶ ὑπερβορέου</l>
@@ -883,7 +883,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐφυμνῆσαι γένοιτό μοι πυκά‐</l>
 						<l>εντ’  ὀλολυγμὸν ἀνδρὸς</l>
@@ -908,7 +908,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="400">ἀλλὰ νόμος  μὲν φονίας σταγόνας</l>
 						<l>χυμένας ἐς πέδον ἄλλο προσαιτεῖν</l>
@@ -930,7 +930,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="5" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="410">πέπαλται  δαὖτὲ  μοι φίλον κέαρ</l>
 						<l>τόνδε κλύουσαν οἶκτον</l>
@@ -955,7 +955,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="7" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔκοψα κομμὸν Ἄριον  ἔν τε  Κισσίας</l>
 						<l>νόμοις ἰηλεμιστρίας,</l>
@@ -989,7 +989,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="9" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐμασχαλίσθη  δέ γ’, ὡς τόδ’ εἰδῇς·</l>
 						<l n="440">ἔπρασσε δ’, ᾇπέρ  νιν ὧδε θάπτει,</l>
@@ -1012,7 +1012,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="8" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δῑ ὤτων δὲ συν‐</l>
 						<l>τέτραινε μῦθον ἡσύχῳ φρενῶν  βάσει.</l>
@@ -1031,7 +1031,7 @@ convert to p3
 						<speaker>Ἠλέκτρα</speaker>
 						<l>ἐγὼ δ’ ἐπιφθέγγομαι κεκλαυμένα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στάσις δὲ πάγκοινος ἅδ’ ἐπιρροθεῖ·</l>
 						<l>ἄκουσον ἐς φάος μολών,</l>
@@ -1048,7 +1048,7 @@ convert to p3
 						<speaker>Ἠλέκτρα</speaker>
 						<l>ἰὼ θεοί, κραίνετ’ ἐνδίκως &lt;δίκας.&gt;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τρόμος μ’ ὑφέρπει κλύουσαν εὐγμάτων.</l>
 						<l>τὸ μόρσιμον μένει πάλαι,</l>
@@ -1057,7 +1057,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="11" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ  πόνος ἐγγενὴς</l>
 						<l>καὶ παράμουσος Ἄτας</l>
@@ -1068,7 +1068,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="11" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δώμασιν ἔμμοτον</l>
 						<l>τῶνδ’ ἄκος, οὐδ’ ἀπ’ ἄλλων</l>
@@ -1079,7 +1079,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ κλύοντες, μάκαρες χθόνιοι,</l>
 						<l>τῆσδε κατευχῆς πέμπετ’ ἀρωγὴν</l>
@@ -1163,7 +1163,7 @@ convert to p3
 					<l>αὐτὸς δὲ σῴζῃ τόνδε τιμήσας λόγον.</l>
 					<milestone ed="p" n="510" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="510">καὶ μὴν ἀμεμφῆ τόνδ’ ἐτείνατον  λόγον,</l>
 					<l>τίμημα τύμβου τῆς ἀνοιμώκτου τύχης.</l>
@@ -1182,7 +1182,7 @@ convert to p3
 					<l>ἑνός, μάτην ὁ μόχθος· ὧδ’ ἔχει λόγος.</l>
 					<l>θέλοντι δ’, εἴπερ οἶσθ’, ἐμοὶ φράσον τάδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οἶδ’, ὦ τέκνον, παρῆ  γάρ· ἔκ τ’ ὀνειράτων</l>
 					<l>καὶ νυκτιπλάγκτων δειμάτων πεπαλμένη</l>
@@ -1192,7 +1192,7 @@ convert to p3
 					<speaker>Ὀρέστης</speaker>
 					<l>ἦ καὶ πέπυσθε τοὔναρ, ὥστ’ ὀρθῶς φράσαι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τεκεῖν δράκοντ’ ἔδοξεν, ὡς αὐτὴ λέγει.</l>
 				</sp>
@@ -1200,7 +1200,7 @@ convert to p3
 					<speaker>Ὀρέστης</speaker>
 					<l>καὶ ποῖ τελευτᾷ καὶ καρανοῦται λόγος;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<!-- the bracketed word was marked "noparse", presumably as a flag to the morphology code? -->
 					<l>ἐν [ι] παιδὸς ὁρμίσαι δίκην.</l>
@@ -1209,7 +1209,7 @@ convert to p3
 					<speaker>Ὀρέστης</speaker>
 					<l n="530">τίνος  βορᾶς χρῄζοντα, νεογενὲς  δάκος;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>αὐτὴ προσέσχε μαζὸν ἐν τὠνείρατι.</l>
 				</sp>
@@ -1217,7 +1217,7 @@ convert to p3
 					<speaker>Ὀρέστης</speaker>
 					<l>καὶ πῶς ἄτρωτον οὖθαρ ἦν  ὑπὸ στύγους;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὥστ’ ἐν γάλακτι θρόμβον αἵματος σπάσαι.</l>
 				</sp>
@@ -1225,7 +1225,7 @@ convert to p3
 					<speaker>Ὀρέστης</speaker>
 					<l>οὔτοι μάταιον· ἀνδρὸς ὄψανον πέλει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="535">ἡ δ’ ἐξ ὕπνου κέκλαγγεν  ἐπτοημένη.</l>
 					<l>πολλοὶ δ’ ἀνῇθον, ἐκτυφλωθέντες σκότῳ,</l>
@@ -1248,7 +1248,7 @@ convert to p3
 					<l>θανεῖν βιαίως· ἐκδρακοντωθεὶς δ’ ἐγὼ</l>
 					<l n="550">κτείνω νιν, ὡς τοὔνειρον ἐννέπει τόδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τερασκόπον δὴ  τῶνδέ σ’ αἱροῦμαι πέρι.</l>
 					<l>γένοιτο δ’ οὕτως.  τἄλλα δ’ ἐξηγοῦ φίλοις,</l>
@@ -1301,7 +1301,7 @@ convert to p3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="585">πολλὰ μὲν γᾶ  τρέφει</l>
 						<l>δεινὰ [καὶ]  δειμάτων ἄχη,</l>
@@ -1316,7 +1316,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ὑπέρτολμον ἀν‐</l>
 						<l n="595">δρὸς φρόνημα τίς λέγοι</l>
@@ -1331,7 +1331,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴστω δ’, ὅστις οὐχ ὑπόπτερος</l>
 						<l>φροντίσιν, δαεὶς</l>
@@ -1347,7 +1347,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄλλαν  δεῖ τιν’  ἐν λόγοις στυγεῖν</l>
 						<l>φοινίαν κόραν,</l>
@@ -1363,7 +1363,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεὶ δ’ ἐπεμνασάμαν  ἀμειλίχων</l>
 						<l>πόνων, ὁ καιρὸς δὲ δυσφιλὲς γαμή‐</l>
@@ -1377,7 +1377,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κακῶν δὲ πρεσβεύεται τὸ Λήμνιον</l>
 						<l>λόγῳ· γοᾶται δὲ δὴ πάθος κατά‐</l>
@@ -1391,7 +1391,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ δ’ ἄγχι πλευμόνων ξίφος</l>
 						<l n="640">διανταίαν ὀξυπευκὲς οὐτᾷ</l>
@@ -1402,7 +1402,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Δίκας  δ’ ἐρείδεται πυθμήν·</l>
 						<l>προχαλκεύει  δ’ Αἶσα φασγανουργός·</l>
@@ -1507,7 +1507,7 @@ convert to p3
 					<milestone ed="p" n="719" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἶεν, φίλιαι δμωίδες  οἴκων,</l>
 						<l n="720">πότε δὴ στομάτων</l>
@@ -1528,7 +1528,7 @@ convert to p3
 						<l>ποῖ δὴ πατεῖς, Κίλισσα, δωμάτων πύλας;</l>
 						<l>λύπη δ’ ἄμισθός ἐστί σοι ξυνέμπορος;</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>Αἴγισθον ἡ κρατοῦσα τοῖς ξένοις  καλεῖν</l>
 						<l n="735">ὅπως τάχιστ’ ἄνωγεν, ὡς σαφέστερον</l>
@@ -1564,55 +1564,55 @@ convert to p3
 						<l n="765">οἴκων, θέλων δὲ τόνδε πεύσεται λόγον.</l>
 						<milestone ed="p" n="766" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς οὖν κελεύει νιν μολεῖν ἐσταλμένον;</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>ἦ  πῶς; λέγ’ αὖθις, ὡς μάθω σαφέστερον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ  ξὺν λοχίταις εἴτε καὶ μονοστιβῆ.</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>ἄγειν κελεύει δορυφόρους ὀπάονας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="770">μή νυν σὺ ταῦτ’ ἄγγελλε  δεσπότου στύγει·</l>
 						<l>ἀλλ’ αὐτὸν ἐλθεῖν, ὡς ἀδειμάντως κλύῃ,</l>
 						<l>ἄνωχθ’ ὅσον τάχιστα γηθούσῃ  φρενί.</l>
 						<l>ἐν ἀγγέλῳ γὰρ κυπτὸς ὀρθοῦται λόγος.</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>ἀλλ’ ἦ φρονεῖς εὖ τοῖσι νῦν ἠγγελμένοις;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="775">ἀλλ’ εἰ τροπαίαν Ζεὺς κακῶν θήσει ποτέ.</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>καὶ πῶς; Ὀρέστης ἐλπὶς οἴχεται δόμων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔπω· κακός γε μάντις ἂν γνοίη τάδε.</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>τί φής; ἔχεις τι τῶν λελεγμένων δίχα;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγγελλ’  ἰοῦσα, πρᾶσσε τἀπεσταλμένα.</l>
 						<l n="780">μέλει  θεοῖσιν ὧνπερ ἂν μέλῃ  πέρι.</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>ἀλλ’ εἶμι καὶ σοῖς ταῦτα πείσομαι λόγοις.</l>
 						<l>γένοιτο δ’ ὡς ἄριστα σὺν θεῶν δόσει.</l>
@@ -1622,7 +1622,7 @@ convert to p3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν παραιτουμένᾳ μοι, πάτερ</l>
 						<l>Ζεῦ θεῶν Ὀλυμπίων,</l>
@@ -1634,7 +1634,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἓ ἕ, πρὸ δὲ δὴ ’χθρῶν</l>
 						<l n="790">τὸν ἔσωθεν μελάθρων, Ζεῦ,</l>
@@ -1645,7 +1645,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴσθι δ’ ἀνδρὸς φίλου πῶλον εὖ‐</l>
 						<l n="795">νιν ζυγέντ’ ἐν ἅρμασιν</l>
@@ -1657,7 +1657,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="800">οἵ τ’ ἔσω  δωμάτων</l>
 						<l>πλουτογαθῆ  μυχὸν νομίζετε,</l>
@@ -1669,7 +1669,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ δὲ  καλῶς κτίμενον  ὦ μέγα ναίων</l>
 						<l>στόμιον, εὖ δὸς ἀνιδεῖν δόμον ἀνδρός,</l>
@@ -1680,7 +1680,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ξυλλάβοι δ’ ἐνδίκως</l>
 						<l>παῖς ὁ Μαίας, ἐπεὶ φορώτατος</l>
@@ -1693,7 +1693,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ τότ’ ἤδη  κλυτὸν</l>
 						<l n="820">δωμάτων λυτήριον,</l>
@@ -1706,7 +1706,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὺ δὲ θαρσῶν, ὅταν ἥκῃ μέρος ἔργων,</l>
 						<l>ἐπαΰσας πατρὸς αὐδὰν</l>
@@ -1716,7 +1716,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Περσέως τ’ ἐν φρεσὶν</l>
 						<l>καρδίαν ἀνασχεθών,</l>
@@ -1743,7 +1743,7 @@ convert to p3
 					<l>πεδάρσιοι θρῴσκουσι, θνῄσκοντες μάτην;</l>
 					<l>τί τῶνδ’ ἂν εἴποις ὥστε δηλῶσαι φρενί;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἠκούσαμεν μέν, πυνθάνου δὲ τῶν ξένων</l>
 					<l>ἔσω παρελθών.  οὐδὲν ἀγγέλων σθένος</l>
@@ -1758,7 +1758,7 @@ convert to p3
 					<milestone ed="p" n="855" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="855">Ζεῦ Ζεῦ, τί λέγω, πόθεν ἄρξωμαι</l>
 						<l>τάδ’ ἐπευχομένη κἀπιθεάζουσ’,</l>
@@ -1780,7 +1780,7 @@ convert to p3
 						<speaker>Αἴγισθος</speaker>
 						<l>ἒ ἔ, ὀτοτοτοῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="870">ἔα ἔα μάλα·</l>
 						<l>πῶς ἔχει; πῶς κέκρανται δόμοις;</l>
@@ -1946,7 +1946,7 @@ convert to p3
 						<l>ἦ κάρτα μάντις οὑξ ὀνειράτων φόβος.</l>
 						<l n="930">ἔκανες  ὃν οὐ χρῆν, καὶ τὸ μὴ χρεὼν πάθε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στένω μὲν οὖν καὶ τῶνδε συμφορὰν διπλῆν.</l>
 						<l>ἐπεὶ δὲ πολλῶν αἱμάτων ἐπήκρισε</l>
@@ -1958,7 +1958,7 @@ convert to p3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="935">ἔμολε μὲν δίκα Πριαμίδαις χρόνῳ,</l>
 						<l>βαρύδικος  ποινά·</l>
@@ -1971,7 +1971,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπολολύξατ’ ὦ δεσποσύνων δόμων</l>
 						<l>ἀναφυγᾶς  κακῶν καὶ κτεάνων τριβᾶς</l>
@@ -1981,7 +1981,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔμολε δ’ ᾧ μέλει κρυπταδίου μάχας</l>
 						<l>δολιόφρων ποινά·</l>
@@ -1993,7 +1993,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="942a">&lt;ἐπολολύξατ’ ὦ δεσποσύνων δόμων</l>
 						<l n="943a">ἀναφυγᾶς κακῶν καὶ κτεάνων τριβᾶς</l>
@@ -2003,7 +2003,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="953">τά περ ὁ Λοξίας ὁ Παρνασσίας</l>
 						<l>μέγαν ἔχων μυχὸν χθονὸς ἐπωρθία‐</l>
@@ -2016,7 +2016,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάρα τε φῶς ἰδεῖν</l>
 						<l>μέγα  τ’ ἀφῃρέθην ψάλιον οἰκέων.</l>
@@ -2026,7 +2026,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="965">τάχα δὲ παντελὴς χρόνος ἀμείψεται</l>
 						<l>πρόθυρα δωμάτων, ὅταν ἀφ’ ἑστίας</l>
@@ -2039,7 +2039,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymn">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="972">πάρα τε φῶς ἰδεῖν</l>
 						<l n="962a">&lt;μέγα τ’ ἀφῃρέθην ψάλιον οἰκέων.</l>
@@ -2101,7 +2101,7 @@ convert to p3
 					<milestone ed="p" n="1007" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ  &lt;αἰαῖ&gt; μελέων ἔργων·</l>
 						<l>στυγερῷ θανάτῳ διεπράχθης.</l>
@@ -2126,7 +2126,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔτις μερόπων ἀσινὴς  βίοτον</l>
 						<l>διὰ παντὸς  ἀπήμον’  ἀμείψει.</l>
@@ -2166,7 +2166,7 @@ convert to p3
 						<l>ἐγὼ δ’ ἀλήτης τῆσδε γῆς ἀπόξενος,</l>
 						<l>ζῶν καὶ τεθνηκὼς τάσδε κληδόνας λιπών.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ εὖ γ’ ἔπραξας, μηδ’ ἐπιζευχθῇς  στόμα</l>
 						<l n="1045">φήμῃ πονηρᾷ  μηδ’ ἐπιγλωσσῶ κακά,</l>
@@ -2183,7 +2183,7 @@ convert to p3
 						<l n="1050">πυκνοῖς δράκουσιν· οὐκέτ’ ἂν μείναιμ’  ἐγώ.</l>
 						<milestone ed="p" n="1051" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίνες σε δόξαι, φίλτατ’ ἀνθρώπων πατρί,</l>
 						<l>στροβοῦσιν; ἴσχε, μὴ φόβου νικῶ  πολύ.</l>
@@ -2193,7 +2193,7 @@ convert to p3
 						<l>οὐκ εἰσὶ δόξαι τῶνδε πημάτων ἐμοί·</l>
 						<l>σαφῶς γὰρ αἵδε μητρὸς ἔγκοτοι κύνες.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1055">ποταίνιον γὰρ αἷμά σοι χεροῖν ἔτι·</l>
 						<l>ἐκ τῶνδέ τοι ταραγμὸς ἐς φρένας πίτνει.</l>
@@ -2203,7 +2203,7 @@ convert to p3
 						<l>ἄναξ Ἄπολλον, αἵδε πληθύουσι  δή,</l>
 						<l>κἀξ ὀμμάτων στάζουσιν αἷμα δυσφιλές.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἷς σοὶ  καθαρμός· Λοξίας  δὲ προσθιγὼν</l>
 						<l n="1060">ἐλεύθερόν σε τῶνδε πημάτων κτίσει.</l>
@@ -2213,7 +2213,7 @@ convert to p3
 						<l>ὑμεῖς μὲν οὐχ ὁρᾶτε τάσδ’, ἐγὼ δ’ ὁρῶ·</l>
 						<l>ἐλαύνομαι δὲ κοὐκέτ’ ἂν μείναιμ’  ἐγὼ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ εὐτυχοίης, καί σ’ ἐποπτεύων πρόφρων</l>
 						<l>θεὸς φυλάσσοι καιρίοισι συμφοραῖς.</l>
@@ -2221,7 +2221,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1065">ὅδε τοι μελάθροις τοῖς βασιλείοις</l>
 						<l>τρίτος αὖ χειμὼν</l>

--- a/tei/aeschylus-persians.xml
+++ b/tei/aeschylus-persians.xml
@@ -54,16 +54,16 @@
 					<person xml:id="atossa" sex="FEMALE">
 						<persName>Ἄτοσσα</persName>
 					</person>
-					<person xml:id="kserkses" sex="MALE">
+					<person xml:id="xerxes" sex="MALE">
 						<persName>Ξέρξης</persName>
 					</person>
-					<person xml:id="eidolondareioy" sex="MALE">
+					<person xml:id="eidolon_dareiou" sex="MALE">
 						<persName>Εἴδωλον  Δαρείου</persName>
 					</person>
-					<person xml:id="aggelos" sex="MALE">
+					<person xml:id="angelos" sex="MALE">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="UNKNOWN">
+					<personGrp xml:id="choros" sex="UNKNOWN">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="dareios" sex="MALE">
@@ -178,7 +178,7 @@ convert to P3
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
 				<div2 type="anapests">
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Τάδε μὲν Περσῶν τῶν οἰχομένων</l>
 						<l>Ἑλλάδ’ ἐς αἶαν πιστὰ καλεῖται,</l>
@@ -251,7 +251,7 @@ convert to P3
 			<milestone ed="p" n="65" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="65">πεπέρακεν μὲν ὁ περσέπτολις ἤδη</l>
 						<l>βασίλειος στρατὸς εἰς ἀν‐</l>
@@ -265,7 +265,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολυάνδρου δ’ Ἀσίας θούριος ἄρχων</l>
 						<l>ἐπὶ πᾶσαν χθόνα ποιμα‐</l>
@@ -279,7 +279,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κυάνεον δ’ ὄμμασι λεύσσων</l>
 						<l>φονίου δέργμα δράκοντος,</l>
@@ -291,7 +291,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δόκιμος δ’ οὔτις ὑποστὰς</l>
 						<l>μεγάλῳ ῥεύματι φωτῶν</l>
@@ -303,7 +303,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θεόθεν γὰρ κατὰ Μοῖρ’</l>
 						<l>ἐκράτησεν τὸ παλαι‐</l>
@@ -316,7 +316,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="100">ἔμαθον δ’  εὐρυπόροι‐</l>
 						<l>ο θαλάσσας πολιαι‐</l>
@@ -329,7 +329,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δολόμητιν δ’ ἀπάταν θεοῦ</l>
 						<l>τίς ἀνὴρ θνατὸς ἀλύξει;</l>
@@ -339,7 +339,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φιλόφρων γὰρ παρασαίνει</l>
 						<l>βροτὸν εἰς ἄρκυας Ἄτα,</l>
@@ -349,7 +349,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="115">ταῦτά μοι μελαγχίτων</l>
 						<l>φρὴν ἀμύσσεται φόβῳ,</l>
@@ -360,7 +360,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="120">καὶ τὸ Κισσίων πόλισμ’</l>
 						<l>ἀντίδουπον ᾄσεται,</l>
@@ -371,7 +371,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="6" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πᾶς γὰρ ἱππηλάτας</l>
 						<l>καὶ πεδοστιβὴς λεὼς</l>
@@ -384,7 +384,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="6" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λέκτρα δ’ ἀνδρῶν πόθῳ</l>
 						<l>πίμπλαται δακρύμασιν·</l>
@@ -397,7 +397,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="140">ἀλλ’ ἄγε, Πέρσαι, τόδ’ ἐνεζόμενοι</l>
 						<l>στέγος ἀρχαῖον,</l>
@@ -418,7 +418,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="155">ὦ βαθυζώνων ἄνασσα Περσίδων ὑπερτάτη,</l>
 						<l>μῆτερ ἡ Ξέρξου γεραιά, χαῖρε, Δαρείου γύναι·</l>
@@ -447,7 +447,7 @@ convert to P3
 						<l>τοῦδέ μοι γένεσθε, Πέρσαι, γηραλέα πιστώματα·</l>
 						<l>πάντα γὰρ τὰ κέδν’ ἐν ὑμῖν ἐστί μοι βουλεύματα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὖ τόδ’ ἴσθι, γῆς ἄνασσα τῆσδε, μή σε δὶς φράσαι</l>
 						<l>μήτ’ ἔπος μήτ’ ἔργον ὧν ἂν δύναμις ἡγεῖσθαι θέλῃ·</l>
@@ -505,7 +505,7 @@ convert to P3
 					<milestone ed="p" n="215" unit="card"/>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="215">οὔ σε βουλόμεσθα, μῆτερ, οὔτ’ ἄγαν φοβεῖν λόγοις</l>
 						<l>οὔτε θαρσύνειν. θεοὺς δὲ προστροπαῖς ἱκνουμένη,</l>
@@ -529,7 +529,7 @@ convert to P3
 						<l>ὦ φίλοι, ποῦ τὰς Ἀθήνας φασὶν ἱδρῦσθαι χθονός.</l>
 						<milestone ed="p" n="232" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τῆλε πρὸς δυσμαῖς ἄνακτος Ἡλίου φθινασμάτων.</l>
 					</sp>
@@ -537,7 +537,7 @@ convert to P3
 						<speaker>Ἄτοσσα</speaker>
 						<l>ἀλλὰ μὴν ἵμειρ’ ἐμὸς παῖς τήνδε θηρᾶσαι πόλιν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πᾶσα γὰρ γένοιτ’ ἂν Ἑλλὰς βασιλέως ὑπήκοος.</l>
 					</sp>
@@ -545,7 +545,7 @@ convert to P3
 						<speaker>Ἄτοσσα</speaker>
 						<l n="235">ὧδέ τις πάρεστιν αὐτοῖς ἀνδροπλήθεια στρατοῦ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ στρατὸς τοιοῦτος, ἔρξας πολλὰ δὴ Μήδους κακά.</l>
 					</sp>
@@ -553,7 +553,7 @@ convert to P3
 						<speaker>Ἄτοσσα</speaker>
 						<l>καὶ τί πρὸς τούτοισιν ἄλλο; πλοῦτος ἐξαρκὴς δόμοις;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀργύρου πηγή τις αὐτοῖς ἐστι, θησαυρὸς χθονός.</l>
 					</sp>
@@ -561,7 +561,7 @@ convert to P3
 						<speaker>Ἄτοσσα</speaker>
 						<l>πότερα γὰρ τοξουλκὸς αἰχμὴ διὰ χεροῖν αὐτοῖς πρέπει;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="240">οὐδαμῶς· ἔγχη σταδαῖα καὶ φεράσπιδες σαγαί.</l>
 					</sp>
@@ -569,7 +569,7 @@ convert to P3
 						<speaker>Ἄτοσσα</speaker>
 						<l>τίς δὲ ποιμάνωρ ἔπεστι κἀπιδεσπόζει στρατῷ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔτινος δοῦλοι κέκληνται φωτὸς οὐδ’ ὑπήκοοι.</l>
 					</sp>
@@ -577,7 +577,7 @@ convert to P3
 						<speaker>Ἄτοσσα</speaker>
 						<l>πῶς ἂν οὖν μένοιεν ἄνδρας πολεμίους ἐπήλυδας;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὥστε Δαρείου πολύν τε καὶ καλὸν φθεῖραι στρατόν.</l>
 					</sp>
@@ -585,14 +585,14 @@ convert to P3
 						<speaker>Ἄτοσσα</speaker>
 						<l n="245">δεινά τοι λέγεις ἰόντων τοῖς τεκοῦσι φροντίσαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἐμοὶ δοκεῖν τάχ’ εἴσῃ πάντα νημερτῆ λόγον.</l>
 						<l>τοῦδε γὰρ δράμημα φωτὸς Περσικὸν πρέπει μαθεῖν,</l>
 						<l>καὶ φέρει σαφές τι πρᾶγος ἐσθλὸν ἢ κακὸν κλύειν.</l>
 						<milestone ed="p" n="249" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ὦ γῆς ἁπάσης Ἀσιάδος πολίσματα,</l>
 						<l n="250">ὦ Περσὶς αἶα καὶ πολὺς πλούτου λιμήν,</l>
@@ -607,7 +607,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄνῑ ἄνια κακὰ</l>
 						<l>νεόκοτα καὶ δάῑ·. αἰαῖ,</l>
@@ -615,7 +615,7 @@ convert to P3
 						<l>τόδ’ ἄχος κλύοντες.</l>
 						<milestone ed="p" n="260" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l n="260">ὡς πάντα γ’ ἔστ’ ἐκεῖνα διαπεπραγμένα·</l>
 						<l>αὐτὸς δ’ ἀέλπτως νόστιμον βλέπω φάος.</l>
@@ -623,7 +623,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ μακροβίοτος</l>
 						<l>ὅδε γέ τις αἰὼν ἐφάνθη</l>
@@ -631,7 +631,7 @@ convert to P3
 						<l n="265">τόδε πῆμ’ ἄελπτον.</l>
 						<milestone ed="p" n="266" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>καὶ μὴν παρών γε κοὐ λόγους ἄλλων κλύων,</l>
 						<l>Πέρσαι, φράσαιμ’ ἂν οἷ’ ἐπορσύνθη κακά.</l>
@@ -639,7 +639,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὀτοτοτοῖ, μάταν</l>
 						<l>τὰ πολλὰ βέλεα παμμιγῆ</l>
@@ -647,7 +647,7 @@ convert to P3
 						<l>αν ἐφ’ Ἑλλάδα χώραν.</l>
 						<milestone ed="p" n="272" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>πλήθουσι νεκρῶν δυσπότμως ἐφθαρμένων</l>
 						<l>Σαλαμῖνος ἀκταὶ πᾶς τε πρόσχωρος τόπος.</l>
@@ -655,7 +655,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὀτοτοτοῖ, φίλων</l>
 						<l n="275">ἁλίδονα μέλεα πολυβαφῆ</l>
@@ -663,7 +663,7 @@ convert to P3
 						<l>σθαι πλάγκτ’ ἐν διπλάκεσσιν.</l>
 						<milestone ed="p" n="278" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>οὐδὲν γὰρ ἤρκει τόξα, πᾶς δ’ ἀπώλλυτο</l>
 						<l>στρατὸς δαμασθεὶς ναΐοισιν ἐμβολαῖς</l>
@@ -671,7 +671,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="280">ἴυζ’ ἄποτμον Πέρσαις</l>
 						<l>δυσαιανῆ βοὰν</l>
@@ -679,7 +679,7 @@ convert to P3
 						<l>ἔφθισαν· αἰαῖ στρατοῦ φθαρέντος.</l>
 						<milestone ed="p" n="284" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ὦ πλεῖστον ἔχθος ὄνομα Σαλαμῖνος κλύειν.</l>
 						<l n="285">φεῦ, τῶν Ἀθηνῶν ὡς στένω μεμνημένος.</l>
@@ -687,7 +687,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στυγναί γ’ Ἀθᾶναι δᾴοις·</l>
 						<l>μεμνῆσθαί τοι πάρα</l>
@@ -710,7 +710,7 @@ convert to P3
 					<l>τῶν ἀρχελείων, ὅστ’ ἐπὶ σκηπτουχίᾳ</l>
 					<l>ταχθεὶς ἄνανδρον τάξιν ἠρήμου θανών;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>Ξέρξης μὲν αὐτὸς ζῇ τε καὶ βλέπει φάος.</l>
 				</sp>
@@ -719,7 +719,7 @@ convert to P3
 					<l n="300">ἐμοῖς μὲν εἶπας δώμασιν φάος μέγα</l>
 					<l>καὶ λευκὸν ἦμαρ νυκτὸς ἐκ μελαγχίμου.</l>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>Ἀρτεμβάρης δὲ μυρίας ἵππου βραβεὺς</l>
 					<l>στύφλους παρ’ ἀκτὰς θείνεται Σιληνιῶν.</l>
@@ -761,7 +761,7 @@ convert to P3
 					<l n="335">ὥστ’ ἀξιῶσαι Περσικῷ στρατεύματι</l>
 					<l>μάχην συνάψαι ναΐοισιν ἐμβολαῖς;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>πλήθους μὲν ἂν σάφ’ ἴσθ’ ἕκατι βάρβαρον</l>
 					<l>ναυσὶν κρατῆσαι.  καὶ γὰρ Ἕλλησιν μὲν ἦν</l>
@@ -779,7 +779,7 @@ convert to P3
 					<speaker>Ἄτοσσα</speaker>
 					<l>ἔτ’ ἆρ’ Ἀθηνῶν ἔστ’ ἀπόρθητος πόλις;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἀνδρῶν γὰρ ὄντων ἕρκος ἐστὶν ἀσφαλές.</l>
 				</sp>
@@ -790,7 +790,7 @@ convert to P3
 					<l>ἢ παῖς ἐμός, πλήθει καταυχήσας νεῶν;</l>
 					<milestone ed="p" n="353" unit="card"/>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἦρξεν μέν, ὦ δέσποινα, τοῦ παντὸς κακοῦ</l>
 					<l>φανεὶς ἀλάστωρ ἢ κακὸς δαίμων ποθέν.</l>
@@ -880,7 +880,7 @@ convert to P3
 					<l>αἰαῖ, κακῶν δὴ πέλαγος ἔρρωγεν μέγα</l>
 					<l>Πέρσαις τε καὶ πρόπαντι βαρβάρων γένει.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="435">εὖ νυν τόδ’ ἴσθι, μηδέπω μεσοῦν κακόν·</l>
 					<l>τοιάδ’ ἐπ’ αὐτοῖς ἦλθε συμφορὰ πάθους</l>
@@ -892,7 +892,7 @@ convert to P3
 					<l>λέξον τίν’ αὖ φὴς τήνδε συμφορὰν στρατῷ</l>
 					<l n="440">ἐλθεῖν κακῶν ῥέπουσαν ἐς τὰ μάσσονα.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>Περσῶν ὅσοιπερ ἦσαν ἀκμαῖοι φύσιν,</l>
 					<l>ψυχήν τ’ ἄριστοι κεὐγένειαν ἐκπρεπεῖς,</l>
@@ -904,7 +904,7 @@ convert to P3
 					<l n="445">οἲ ’γὼ τάλαινα συμφορᾶς κακῆς, φίλοι.</l>
 					<l>ποίῳ μόρῳ δὲ τούσδε φὴς ὀλωλέναι;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>νῆσός τις ἔστι πρόσθε Σαλαμῖνος τόπων,</l>
 					<l>βαιά, δύσορμος ναυσίν, ἣν ὁ φιλόχορος</l>
@@ -945,7 +945,7 @@ convert to P3
 					<l>ποῦ τάσδ’ ἔλειπες· οἶσθα σημῆναι τορῶς;</l>
 					<milestone ed="p" n="480" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="480">ναῶν γε ταγοὶ τῶν λελειμμένων σύδην</l>
 					<l>κατ’ οὖρον οὐκ εὔκοσμον αἴρονται φυγήν·</l>
@@ -984,7 +984,7 @@ convert to P3
 					<l>κακῶν ἃ Πέρσαις ἐγκατέσκηψεν θεός.</l>
 					<milestone ed="p" n="515" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="515">ὦ δυσπόνητε δαῖμον, ὡς ἄγαν βαρὺς</l>
 					<l>ποδοῖν ἐνήλου παντὶ Περσικῷ γένει.</l>
@@ -1009,7 +1009,7 @@ convert to P3
 					<milestone ed="p" n="532" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Ζεῦ βασιλεῦ, νῦν &lt;γὰρ&gt; Περσῶν</l>
 						<l>τῶν  μεγαλαύχων καὶ πολυάνδρων</l>
@@ -1033,7 +1033,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν γὰρ δὴ πρόπασα μὲν στένει  γαῖ’</l>
 						<l>Ἀσιὰς ἐκκενουμένα.</l>
@@ -1049,7 +1049,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πεζούς τε γὰρ καὶ θαλασσίους</l>
 						<l>λινόπτεροι  κυανώπιδες</l>
@@ -1065,7 +1065,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοὶ δ’ ἄρα πρωτόμοιροι, φεῦ,</l>
 						<l>λειφθέντες  πρὸς ἀνάγκας, ἠέ,</l>
@@ -1079,7 +1079,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>γναπτόμενοι δὲ δίνᾳ,  φεῦ,</l>
 						<l>σκύλλονται πρὸς ἀναύδων, ἠέ,</l>
@@ -1093,7 +1093,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοὶ δ’ ἀνὰ  γᾶν Ἀσίαν δὴν</l>
 						<l n="585">οὐκέτι  περσονομοῦνται,</l>
@@ -1106,7 +1106,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδ’ ἔτι γλῶσσα βροτοῖσιν</l>
 						<l>ἐν φυλακαῖς· λέλυται  γὰρ</l>
@@ -1156,7 +1156,7 @@ convert to P3
 					<milestone ed="p" n="623" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βασίλεια γύναι, πρέσβος Πέρσαις,</l>
 						<l>σύ τε πέμπε χοὰς  θαλάμους ὑπὸ γῆς,</l>
@@ -1174,7 +1174,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ ῥ’ ἀίει  μου  μακαρίτας</l>
 						<l>ἰσοδαίμων βασιλεὺς</l>
@@ -1187,7 +1187,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="640">ἀλλὰ σύ μοι Γᾶ τε καὶ  ἄλλοι</l>
 						<l>χθονίων ἁγεμόνες</l>
@@ -1200,7 +1200,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ φίλος ἁνήρ, φίλος ὄχθος·</l>
 						<l>φίλα γὰρ κέκευθεν ἤθη.</l>
@@ -1211,7 +1211,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδὲ γὰρ ἄνδρας ποτ’  ἀπώλλυ</l>
 						<l>πολεμοφθόροισιν ἄταις,</l>
@@ -1222,7 +1222,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βαλήν, ἀρχαῖος  βαλήν,</l>
 						<l>ἴθι, ἱκοῦ·</l>
@@ -1235,7 +1235,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅπως αἰανῆ κλύῃς</l>
 						<l n="665">νέα τ’ ἄχη,</l>
@@ -1248,7 +1248,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ αἰαῖ·</l>
 						<l>ὦ πολύκλαυτε φίλοισι θανών,</l>
@@ -1264,7 +1264,7 @@ convert to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#eidolondareioy">
+					<sp who="#eidolon_dareiou">
 						<speaker>Εἴδωλον  Δαρείου</speaker>
 						<l>ὦ πιστὰ πιστῶν ἥλικές θ’ ἥβης ἐμῆς</l>
 						<l>Πέρσαι γεραιοί, τίνα πόλις πονεῖ πόνον;</l>
@@ -1285,7 +1285,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σέβομαι μὲν προσιδέσθαι,</l>
 						<l n="695">σέβομαι δ’ ἀντία λέξαι</l>
@@ -1301,7 +1301,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="700">δίεμαι μὲν χαρίσασθαι,</l>
 						<l>δίεμαι δ’ ἀντία φάσθαι,</l>
@@ -1489,7 +1489,7 @@ convert to P3
 						<l>οὐκ ἂν  φανεῖμεν πήματ’ ἔρξαντες  τόσα.</l>
 						<milestone ed="p" n="787" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί οὖν, ἄναξ Δαρεῖε, ποῖ καταστρέφεις</l>
 						<l>λόγων  τελευτήν; πῶς ἂν ἐκ τούτων ἔτι</l>
@@ -1501,7 +1501,7 @@ convert to P3
 						<l>μηδ’ εἰ στράτευμα πλεῖον  τὸ Μηδικόν.</l>
 						<l>αὐτὴ γὰρ  ἡ γῆ ξύμμαχος κείνοις  πέλει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς τοῦτ’ ἔλεξας, τίνι τρόπῳ δὲ  συμμαχεῖ;</l>
 					</sp>
@@ -1509,7 +1509,7 @@ convert to P3
 						<speaker>Δαρεῖος</speaker>
 						<l>κτείνουσα λιμῷ τοὺς ὑπερπόλλους  ἄγαν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="795">ἀλλ’ εὐσταλῆ  τοι λεκτὸν ἀροῦμεν στόλον.</l>
 					</sp>
@@ -1518,7 +1518,7 @@ convert to P3
 						<l>ἀλλ’ οὐδ’ ὁ μείνας νῦν ἐν Ἑλλάδος τόποις</l>
 						<l>στρατὸς  κυρήσει νοστίμου σωτηρίας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς εἶπας; οὐ γὰρ πᾶν στράτευμα βαρβάρων</l>
 						<l>περᾷ τὸν  Ἕλλης πορθμὸν Εὐρώπης  ἄπο;</l>
@@ -1574,7 +1574,7 @@ convert to P3
 						<l>ὡς τοῖς θανοῦσι πλοῦτος οὐδὲν  ὠφελεῖ.</l>
 						<milestone ed="p" n="843" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ πολλὰ καὶ παρόντα καὶ μέλλοντ’ ἔτι</l>
 						<l>ἤλγησ’  ἀκούσας βαρβάροισι πήματα.</l>
@@ -1594,7 +1594,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πόποι ἦ μεγάλας ἀγαθᾶς τε πο‐</l>
 						<l>λισσονόμου βιοτᾶς ἐπεκύρσαμεν,</l>
@@ -1606,7 +1606,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρῶτα μὲν  εὐδοκίμους στρατιὰς ἀπε‐</l>
 						<l>φαινόμεθ’, ἠδὲ  νομίσματα πύργινα</l>
@@ -1618,7 +1618,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅσσας δ’ εἷλε πόλεις πόρον</l>
 						<l n="865">οὐ διαβὰς Ἅλυος ποταμοῖο,</l>
@@ -1630,7 +1630,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λίμνας τ’  ἔκτοθεν αἳ κατὰ</l>
 						<l>χέρσον ἐληλαμέναι πέρι  πύργον</l>
@@ -1642,7 +1642,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νᾶσοί θ’ αἳ κατὰ πρῶν’</l>
 						<l n="880">ἅλιον περίκλυστοι</l>
@@ -1656,7 +1656,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ τὰς ἀγχιάλους</l>
 						<l>ἐκράτυνε μεσάκτους,</l>
@@ -1670,7 +1670,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ τὰς εὐκτεάνους  κατὰ</l>
 						<l>κλῆρον Ἰαόνιον  πολυάνδρους</l>
@@ -1689,7 +1689,7 @@ convert to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἰώ,</l>
 						<l>δύστηνος ἐγὼ στυγερᾶς μοίρας</l>
@@ -1704,7 +1704,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὀτοτοῖ, βασιλεῦ, στρατιᾶς ἀγαθῆς</l>
 						<l>καὶ περσονόμου  τιμῆς μεγάλης,</l>
@@ -1726,13 +1726,13 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ὅδ’ ἐγώ, οἰοῖ,  αἰακτὸς</l>
 						<l>μέλεος γέννᾳ γᾷ τε πατρῴᾳ</l>
 						<l>κακὸν ἄρ’  ἐγενόμαν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="935">πρόσφθογγόν σοι νόστου  τὰν</l>
 						<l>κακοφάτιδα βοάν,</l>
@@ -1744,13 +1744,13 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἵετ’  αἰανῆ [καὶ]   πάνδυρτον</l>
 						<l>δύσθροον αὐδάν.    δαίμων γὰρ ὅδ’ αὖ</l>
 						<l>μετάτροπος ἐπ’  ἐμοί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἥσω τοι τὰν πάνδυρτον,</l>
 						<l n="945">σὰ  πάθη τε σέβων</l>
@@ -1762,7 +1762,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l n="950">Ἰάνων γὰρ  ἀπηύρα,</l>
 						<l>Ἰάνων ναύφρακτος</l>
@@ -1770,7 +1770,7 @@ convert to P3
 						<l>νυχίαν πλάκα  κερσάμενος</l>
 						<l>δυσδαίμονά τ’ ἀκτάν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="955">οἰοιοῖ βόα καὶ πάντ’ ἐκπεύθου.—</l>
 						<l>ποῦ δὲ φίλων ἄλλος ὄχλος,</l>
@@ -1783,7 +1783,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ὀλοοὺς ἀπέλειπον</l>
 						<l>Τυρίας ἐκ ναὸς</l>
@@ -1791,7 +1791,7 @@ convert to P3
 						<l n="965">Σαλαμινιάσι στυφελοῦ</l>
 						<l>θείνοντας ἐπ’ ἀκτᾶς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἰοιοῖ, &lt;βόα&gt;· ποῦ σοι  Φαρνοῦχος</l>
 						<l>Ἀριόμαρδός τ’ ἀγαθός,</l>
@@ -1804,14 +1804,14 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἰὼ ἰώ μοί μοι</l>
 						<l n="975">τὰς ὠγυγίους κατιδόντες</l>
 						<l>στυγνὰς  Ἀθάνας πάντες ἑνὶ πιτύλῳ,</l>
 						<l>ἐὴ ἐή, τλάμονες ἀσπαίρουσι  χέρσῳ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ καὶ τὸν Περσᾶν  αὐτοῦ</l>
 						<l>τὸν σὸν πιστὸν πάντ’ ὀφθαλμὸν</l>
@@ -1829,14 +1829,14 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>&lt;ἰὼ ἰὼ&gt; δῆτα</l>
 						<l>ἴυγγ’  ἀγαθῶν ἑτάρων μοι [ὑπομιμνήσκεις]</l>
 						<l n="990">&lt;κινεῖς&gt; ἄλαστα στυγνὰ πρόκακα λέγων.</l>
 						<l>βοᾷ βοᾷ  &lt;μοι&gt; μελέων  ἔντοσθεν  ἦτορ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ἄλλους γε  ποθοῦμεν,</l>
 						<l>Μάρδων ἀνδρῶν μυριοταγὸν</l>
@@ -1852,19 +1852,19 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>βεβᾶσι γὰρ τοίπερ ἀγρέται  στρατοῦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βεβᾶσιν, οἴ,  νώνυμοι.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἰὴ ἰή, ἰὼ  ἰώ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1005">ἰὼ ἰώ,  δαίμονες,</l>
 						<l>ἔθεθ’ ἄελπτον κακὸν</l>
@@ -1873,19 +1873,19 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>πεπλήγμεθ’ οἵᾳ δῑ αἰῶνος  τύχᾳ·</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πεπλήγμεθ’· εὔδηλα  γάρ·</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l n="1010">νέᾳ νέᾳ δύᾳ  δύᾳ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1012">κύρσαντες οὐκ  εὐτυχῶς</l>
 						<l n="1011">Ἰάνων ναυβατᾶν.</l>
@@ -1894,115 +1894,115 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>πῶς δ’  οὔ;  στρατὸν μὲν τοσοῦ‐</l>
 						<l n="1015">τον τάλας  πέπληγμαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί δ’ οὔκ; ὄλωλεν μεγάλως τὰ  Περσᾶν.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ὁρᾷς τὸ λοιπὸν τόδε τᾶς ἐμᾶς  στολᾶς;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρῶ ὁρῶ.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l n="1020">τόνδε  τ’  ὀιστοδέγμονα—</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί τόδε λέγεις  σεσωσμένον;</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>θησαυρὸν βελέεσσιν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βαιά γ’ ὡς ἀπὸ  πολλῶν.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἐσπανίσμεθ’ ἀρωγῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1025">Ἰάνων λαὸς οὐ  φυγαίχμας.</l>
 						<milestone ed="p" n="1026" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="5" type="antistrophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἀγανόρειος·  κατεῖ‐</l>
 						<l>δον δὲ  πῆμ’  ἄελπτον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τραπέντα ναύφρακτον ἐρεῖς  ὅμιλον;</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l n="1030">πέπλον δ’ ἐπέρρηξ’ ἐπὶ  συμφορᾷ  κακοῦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παπαῖ  παπαῖ.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>καὶ πλέον ἢ παπαῖ μὲν  οὖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δίδυμα γάρ ἐστι καὶ  τριπλᾶ—</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>λυπρά, χάρματα δ’  ἐχθροῖς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1035">καὶ σθένος γ’  ἐκολούσθη—</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>γυμνός εἰμι  προπομπῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φίλων ἄταισι  ποντίαισιν·</l>
 						<milestone ed="p" n="1038" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="6" type="strophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>δίαινε δίαινε πῆμα·   πρὸς δόμους δ’  ἴθι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ αἰαῖ, δύα  δύα.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l n="1040">βόα νυν  ἀντίδουπά  μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δόσιν κακὰν κακῶν  κακοῖς.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἴυζε μέλος ὁμοῦ  τιθείς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὀτοτοτοτοῖ.</l>
 						<l>βαρεῖά γ’ ἅδε  συμφορά.</l>
@@ -2011,27 +2011,27 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="6" type="antistrophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἔρεσσ’ ἔρεσσε καὶ   στέναζ’ ἐμὴν  χάριν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>διαίνομαι γοεδνὸς  ὤν.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>βόα νυν ἀντίδουπά  μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μέλειν πάρεστι,  δέσποτα.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l n="1050">ἐπορθίαζέ νυν  γόοις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὀτοτοτοτοῖ.</l>
 						<l>μέλαινα δ’  ἀμμεμείξεται,</l>
@@ -2040,98 +2040,98 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="7" type="strophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>καὶ στέρν’ ἄρασσε κἀπιβόα τὸ  Μύσιον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1055">ἄνῑ  ἄνια.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>καί μοι γενείου πέρθε λευκήρη  τρίχα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄπριγδ’ ἄπριγδα μάλα  γοεδνά.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἀύτει δ’  ὀξύ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ τάδ’  ἔρξω.</l>
 						<milestone ed="p" n="1060" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="7" type="antistrophe">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l n="1060">πέπλον δ’ ἔρεικε κολπίαν  ἀκμῇ χερῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄνῑ ἄνια.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>καὶ ψάλλ’ ἔθειραν καὶ κατοίκτισαι  στρατόν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄπριγδ’ ἄπριγδα μάλα  γοεδνά.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>διαίνου δ’ ὄσσε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1065">τέγγομαί τοι.</l>
 						<milestone ed="p" n="1066" unit="card"/>
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>βόα νυν ἀντίδουπά μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἰοῖ  οἰοῖ.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>αἰακτὸς ἐς δόμους  κίε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1070">ἰὼ ἰώ,  [Περσὶς αἶα δύσβατος].</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἰωὰ δὴ κατ’  ἄστυ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰωὰ δῆτα, ναὶ  ναί.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>γοᾶσθ’ ἁβροβάται.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰώ, Περσὶς αἶα  δύσβατος.</l>
 					</sp>
-					<sp who="#kserkses">
+					<sp who="#xerxes">
 						<speaker>Ξέρξης</speaker>
 						<l>ἰὴ ἰὴ τρισκάλμοισιν,</l>
 						<l n="1075">ἰὴ ἰή, βάρισιν  ὀλόμενοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πέμψω τοί σε δυσθρόοις  γόοις.</l>
 					</sp>

--- a/tei/aeschylus-prometheus-bound.xml
+++ b/tei/aeschylus-prometheus-bound.xml
@@ -57,19 +57,19 @@
 					<person xml:id="io" sex="FEMALE">
 						<persName>Ἰώ</persName>
 					</person>
-					<person xml:id="efaistos" sex="MALE">
+					<person xml:id="hephaistos" sex="MALE">
 						<persName>Ἥφαιστος</persName>
 					</person>
-					<person xml:id="prometheys" sex="MALE">
+					<person xml:id="prometheus" sex="MALE">
 						<persName>Προμηθεύς</persName>
 					</person>
 					<person xml:id="okeanos" sex="MALE">
 						<persName>Ὠκεανός</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="UNKNOWN">
+					<personGrp xml:id="choros" sex="UNKNOWN">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="ermes" sex="MALE">
+					<person xml:id="hermes" sex="MALE">
 						<persName>Ἑρμῆς</persName>
 					</person>
 				</listPerson>
@@ -191,7 +191,7 @@ convert to P3
 					<l n="10">ὡς ἂν διδαχθῇ τὴν Διὸς τυραννίδα</l>
 					<l>στέργειν, φιλανθρώπου δὲ παύεσθαι τρόπου.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>Κράτος Βία τε, σφῷν μὲν ἐντολὴ Διὸς</l>
 					<l>ἔχει τέλος δὴ κοὐδὲν ἐμποδὼν ἔτι·</l>
@@ -231,7 +231,7 @@ convert to P3
 					<l>τί τὸν θεοῖς ἔχθιστον οὐ στυγεῖς θεόν,</l>
 					<l>ὅστις τὸ σὸν θνητοῖσι προὔδωκεν γέρας;</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>τὸ συγγενές τοι δεινὸν ἥ θ’ ὁμιλία.</l>
 				</sp>
@@ -240,7 +240,7 @@ convert to P3
 					<l n="40">σύμφημ’· ἀνηκουστεῖν δὲ τῶν πατρὸς λόγων</l>
 					<l>οἷόν τε πῶς; οὐ τοῦτο δειμαίνεις πλέον;</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>αἰεί γε  δὴ νηλὴς σὺ καὶ θράσους πλέως.</l>
 				</sp>
@@ -249,7 +249,7 @@ convert to P3
 					<l>ἄκος γὰρ οὐδὲν τόνδε θρηνεῖσθαι. σὺ δὲ</l>
 					<l>τὰ μηδὲν ὠφελοῦντα μὴ πόνει μάτην.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l n="45">ὦ πολλὰ μισηθεῖσα χειρωναξία.</l>
 				</sp>
@@ -258,7 +258,7 @@ convert to P3
 					<l>τί νιν στυγεῖς; πόνων γὰρ ὡς ἁπλῷ λόγῳ</l>
 					<l>τῶν νῦν παρόντων οὐδὲν αἰτία τέχνη.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>ἔμπας τις αὐτὴν ἄλλος ὤφελεν λαχεῖν.</l>
 				</sp>
@@ -267,7 +267,7 @@ convert to P3
 					<l>ἅπαντ’ ἐπαχθῆ  πλὴν θεοῖσι κοιρανεῖν·</l>
 					<l n="50">ἐλεύθερος γὰρ οὔτις ἐστὶ πλὴν Διός.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>ἔγνωκα τοῖσδε κοὐδὲν ἀντειπεῖν ἔχω.</l>
 				</sp>
@@ -276,7 +276,7 @@ convert to P3
 					<l>οὔκουν ἐπείξῃ τῷδε δεσμὰ  περιβαλεῖν,</l>
 					<l>ὡς μή σ’ ἐλινύοντα προσδερχθῇ πατήρ;</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>καὶ δὴ πρόχειρα ψάλια  δέρκεσθαι πάρα.</l>
 				</sp>
@@ -285,7 +285,7 @@ convert to P3
 					<l n="55">βαλών  νιν ἀμφὶ χερσὶν ἐγκρατεῖ σθένει</l>
 					<l>ῥαιστῆρι θεῖνε, πασσάλευε πρὸς πέτραις.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>περαίνεται δὴ κοὐ ματᾷ τοὔργον τόδε.</l>
 				</sp>
@@ -294,7 +294,7 @@ convert to P3
 					<l>ἄρασσε μᾶλλον, σφίγγε, μηδαμῇ χάλα.</l>
 					<l>δεινὸς γὰρ εὑρεῖν κἀξ ἀμηχάνων πόρον.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l n="60">ἄραρεν ἥδε γ’ ὠλένη δυσεκλύτως.</l>
 					<milestone ed="p" n="61" unit="card"/>
@@ -304,7 +304,7 @@ convert to P3
 					<l>καὶ τήνδε νῦν πόρπασον ἀσφαλῶς, ἵνα</l>
 					<l>μάθῃ σοφιστὴς ὢν Διὸς νωθέστερος.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>πλὴν τοῦδ’ ἂν οὐδεὶς ἐνδίκως μέμψαιτό μοι.</l>
 				</sp>
@@ -313,7 +313,7 @@ convert to P3
 					<l>ἀδαμαντίνου νῦν σφηνὸς αὐθάδη γνάθον</l>
 					<l n="65">στέρνων διαμπὰξ πασσάλεῡ ἐρρωμένως.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>αἰαῖ, Προμηθεῦ, σῶν ὑπερστένω  πόνων.</l>
 				</sp>
@@ -322,7 +322,7 @@ convert to P3
 					<l>σὺ δ’ αὖ κατοκνεῖς τῶν Διός τ’ ἐχθρῶν ὕπερ</l>
 					<l>στένεις; ὅπως μὴ σαυτὸν οἰκτιεῖς ποτε.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>ὁρᾷς θέαμα δυσθέατον ὄμμασιν.</l>
 				</sp>
@@ -331,7 +331,7 @@ convert to P3
 					<l n="70">ὁρῶ κυροῦντα τόνδε  τῶν ἐπαξίων.</l>
 					<l>ἀλλ’ ἀμφὶ πλευραῖς μασχαλιστῆρας βάλε.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>δρᾶν ταῦτ’ ἀνάγκη, μηδὲν ἐγκέλεῡ ἄγαν.</l>
 				</sp>
@@ -340,7 +340,7 @@ convert to P3
 					<l>ἦ μὴν κελεύσω κἀπιθωύξω γε πρός.</l>
 					<l>χώρει κάτω, σκέλη δὲ κίρκωσον βίᾳ.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l n="75">καὶ δὴ πέπρακται τοὔργον οὐ μακρῷ  πόνῳ.</l>
 				</sp>
@@ -349,7 +349,7 @@ convert to P3
 					<l>ἐρρωμένως νῦν θεῖνε διατόρους πέδας·</l>
 					<l>ὡς οὑπιτιμητής γε  τῶν ἔργων βαρύς.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>ὅμοια μορφῇ γλῶσσά σου γηρύεται.</l>
 				</sp>
@@ -358,7 +358,7 @@ convert to P3
 					<l>σὺ μαλθακίζου, τὴν δ’ ἐμὴν αὐθαδίαν</l>
 					<l n="80">ὀργῆς τε τραχύτητα  μὴ ’πίπλησσέ μοι.</l>
 				</sp>
-				<sp who="#efaistos">
+				<sp who="#hephaistos">
 					<speaker>Ἥφαιστος</speaker>
 					<l>στείχωμεν, ὡς κώλοισιν ἀμφίβληστρ’ ἔχει.</l>
 				</sp>
@@ -372,7 +372,7 @@ convert to P3
 					<l>ὅτῳ τρόπῳ τῆσδ’ ἐκκυλισθήσῃ τέχνης.</l>
 					<milestone ed="p" n="88" unit="card"/>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ὦ δῖος  αἰθὴρ καὶ ταχύπτεροι πνοαί,</l>
 					<l>ποταμῶν τε πηγαί, ποντίων τε κυμάτων</l>
@@ -384,7 +384,7 @@ convert to P3
 				</sp>
 				<milestone ed="p" n="95" unit="card"/>
 				<div2 type="anapests">
-					<sp n="Προμηθεύς" who="#prometheys">
+					<sp n="Προμηθεύς" who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="95">χρόνον ἀθλεύσω.</l>
 						<l>τοιόνδ’ ὁ νέος ταγὸς μακάρων</l>
@@ -410,7 +410,7 @@ convert to P3
 					<milestone ed="p" n="114" unit="card"/>
 				</div2>
 				<div2 type="lyric">
-					<sp n="Προμηθεύς" who="#prometheys">
+					<sp n="Προμηθεύς" who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἆ ἆ ἔα ἔα.</l>
 						<l n="115">τίς ἀχώ, τίς ὀδμὰ προσέπτα μ’ ἀφεγγής,</l>
@@ -423,7 +423,7 @@ convert to P3
 					<milestone ed="p" n="121" unit="card"/>
 				</div2>
 				<div2 type="anapests">
-					<sp n="Προμηθεύς" who="#prometheys">
+					<sp n="Προμηθεύς" who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>δῑ ἀπεχθείας ἐλθόνθ’ ὁπόσοι</l>
 						<l>τὴν Διὸς αὐλὴν εἰσοιχνεῦσιν,</l>
@@ -438,7 +438,7 @@ convert to P3
 			<milestone ed="p" n="128" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδὲν φοβηθῇς· φιλία</l>
 						<l n="128b">γὰρ ἅδε  τάξις πτερύγων</l>
@@ -454,7 +454,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>αἰαῖ αἰαῖ,</l>
 						<l>τῆς πολυτέκνου Τηθύος ἔκγονα,</l>
@@ -469,7 +469,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λεύσσω, Προμηθεῦ· φοβερὰ</l>
 						<l n="145">δ’ ἐμοῖσιν ὄσσοις ὀμίχλα</l>
@@ -485,7 +485,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>εἰ γάρ μ’ ὑπὸ γῆν νέρθεν θ’  Ἅιδου</l>
 						<l>τοῦ νεκροδέγμονος εἰς ἀπέρατον</l>
@@ -499,7 +499,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="160">τίς ὧδε τλησικάρδιος</l>
 						<l>θεῶν, ὅτῳ τάδ’ ἐπιχαρῆ;</l>
@@ -513,7 +513,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἦ μὴν ἔτ’ ἐμοῦ, καίπερ κρατεραῖς</l>
 						<l>ἐν γυιοπέδαις  αἰκιζομένου,</l>
@@ -531,7 +531,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="180">σὺ μὲν θρασύς τε καὶ πικραῖς</l>
 						<l>δύαισιν οὐδὲν ἐπιχαλᾷς,</l>
@@ -546,7 +546,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>οἶδ’ ὅτι τραχὺς καὶ  παρ’ ἑαυτῷ</l>
 						<l n="190">τὸ δίκαιον ἔχων Ζεύς. ἀλλ’ ἔμπας  [ὀίω]</l>
@@ -560,14 +560,14 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πάντ’ ἐκκάλυψον καὶ γέγων’ ἡμῖν λόγον,</l>
 					<l>ποίῳ λαβών σε Ζεὺς ἐπ’ αἰτιάματι,</l>
 					<l>οὕτως ἀτίμως καὶ πικρῶς αἰκίζεται·</l>
 					<l>δίδαξον ἡμᾶς, εἴ τι μὴ βλάπτει λόγῳ.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ἀλγεινὰ μέν μοι καὶ λέγειν ἐστὶν τάδε,</l>
 					<l n="200">ἄλγος δὲ σιγᾶν, πανταχῇ δὲ δύσποτμα.</l>
@@ -622,66 +622,66 @@ convert to P3
 					<l>ὧδ’ ἐρρύθμισμαι,  Ζηνὶ δυσκλεὴς θέα.</l>
 					<milestone ed="p" n="244" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σιδηρόφρων τε κἀκ πέτρας εἰργασμένος</l>
 					<l n="245">ὅστις, Προμηθεῦ, σοῖσιν οὐ συνασχαλᾷ</l>
 					<l>μόχθοις· ἐγὼ γὰρ οὔτ’ ἂν εἰσιδεῖν τάδε</l>
 					<l>ἔχρῃζον εἰσιδοῦσά τ’ ἠλγύνθην  κέαρ.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>καὶ μὴν φίλοις &lt;γ’ &gt; ἐλεινὸς  εἰσορᾶν ἐγώ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μή πού τι προύβης τῶνδε καὶ περαιτέρω;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="250">θνητούς γ’  ἔπαυσα μὴ προδέρκεσθαι  μόρον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τὸ ποῖον εὑρὼν τῆσδε φάρμακον νόσου;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>τυφλὰς ἐν αὐτοῖς ἐλπίδας κατῴκισα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μέγ’ ὠφέλημα  τοῦτ’ ἐδωρήσω βροτοῖς.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>πρὸς τοῖσδε μέντοι πῦρ ἐγώ σφιν ὤπασα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="255">καὶ νῦν φλογωπὸν πῦρ ἔχουσ’ ἐφήμεροι;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ἀφ’ οὗ γε πολλὰς ἐκμαθήσονται τέχνας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τοιοῖσδε δή σε Ζεὺς ἐπ’ αἰτιάμασιν—</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>αἰκίζεταί τε κοὐδαμῇ χαλᾷ κακῶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐδ’ ἔστιν ἄθλου τέρμα σοι προκείμενον;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="260">οὐκ ἄλλο γ’ οὐδέν, πλὴν ὅταν κείνῳ δοκῇ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δόξει δὲ πῶς; τίς ἐλπίς; οὐχ ὁρᾷς ὅτι</l>
 					<l>ἥμαρτες; ὡς δ’ ἥμαρτες οὔτ’ ἐμοὶ λέγειν</l>
@@ -689,7 +689,7 @@ convert to P3
 					<l>μεθῶμεν, ἄθλου δ’ ἔκλυσιν ζήτει τινά.</l>
 					<milestone ed="p" n="265" unit="card"/>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="265">ἐλαφρὸν ὅστις πημάτων ἔξω πόδα</l>
 					<l>ἔχει παραινεῖν νουθετεῖν τε τὸν κακῶς</l>
@@ -708,7 +708,7 @@ convert to P3
 					<milestone ed="p" n="279" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἀκούσαις ἐπεθώυξας</l>
 						<l n="280">τοῦτο, Προμηθεῦ.</l>
@@ -738,7 +738,7 @@ convert to P3
 						<l>φίλος ἐστὶ βεβαιότερός σοι.</l>
 						<milestone ed="p" n="300" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="300">ἔα· τί χρῆμα λεύσσω;  καὶ σὺ δὴ πόνων ἐμῶν</l>
 						<l>ἥκεις ἐπόπτης; πῶς ἐτόλμησας, λιπὼν</l>
@@ -777,7 +777,7 @@ convert to P3
 						<l>γλώσσῃ ματαίᾳ ζημία προστρίβεται;</l>
 						<milestone ed="p" n="332" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ζηλῶ σ’ ὁθούνεκ’ ἐκτὸς αἰτίας κυρεῖς</l>
 						<l>τούτων  μετασχεῖν  καὶ τετολμηκὼς ἐμοί.</l>
@@ -794,7 +794,7 @@ convert to P3
 						<l>δώσειν Δί’, ὥστε τῶνδέ σ’ ἐκλῦσαι πόνων.</l>
 						<milestone ed="p" n="343" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>τὰ μὲν σ’ ἐπαινῶ κοὐδαμῇ  λήξω ποτέ·</l>
 						<l n="343b">προθυμίας γὰρ οὐδὲν ἐλλείπεις.  ἀτὰρ</l>
@@ -843,7 +843,7 @@ convert to P3
 						<l>οὔκουν, Προμηθεῦ, τοῦτο γιγνώσκεις, ὅτι</l>
 						<l n="380">ὀργῆς  νοσούσης εἰσὶν ἰατροὶ λόγοι;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἐάν τις ἐν καιρῷ γε μαλθάσσῃ κέαρ</l>
 						<l>καὶ μὴ σφριγῶντα θυμὸν ἰσχναίνῃ βίᾳ.</l>
@@ -853,7 +853,7 @@ convert to P3
 						<l>ἐν τῷ προθυμεῖσθαι δὲ καὶ τολμᾶν τίνα</l>
 						<l>ὁρᾷς ἐνοῦσαν ζημίαν; δίδασκέ με.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="385">μόχθον περισσὸν κουφόνουν τ’  εὐηθίαν.</l>
 					</sp>
@@ -862,7 +862,7 @@ convert to P3
 						<l>ἔα με τῇδε τῇ νόσῳ νοσεῖν, ἐπεὶ</l>
 						<l>κέρδιστον εὖ φρονοῦντα μὴ φρονεῖν δοκεῖν.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἐμὸν δοκήσει τἀμπλάκημ’ εἶναι τόδε.</l>
 					</sp>
@@ -870,7 +870,7 @@ convert to P3
 						<speaker>Ὠκεανός</speaker>
 						<l>σαφῶς μ’ ἐς οἶκον σὸς λόγος στέλλει πάλιν.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="390">μὴ γάρ σε θρῆνος οὑμὸς εἰς ἔχθραν βάλῃ.</l>
 					</sp>
@@ -878,7 +878,7 @@ convert to P3
 						<speaker>Ὠκεανός</speaker>
 						<l>ἦ τῷ νέον θακοῦντι παγκρατεῖς ἕδρας;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>τούτου φυλάσσου μή ποτ’ ἀχθεσθῇ κέαρ.</l>
 					</sp>
@@ -886,7 +886,7 @@ convert to P3
 						<speaker>Ὠκεανός</speaker>
 						<l>ἡ σή, Προμηθεῦ, συμφορὰ διδάσκαλος.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>στέλλου, κομίζου, σῷζε τὸν παρόντα νοῦν.</l>
 					</sp>
@@ -902,7 +902,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στένω σε τᾶς οὐλομένας  τύχας, Προμηθεῦ·</l>
 						<l n="400">δακρυσίστακτα  δ’ ἀπ’ ὄσσων</l>
@@ -916,7 +916,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρόπασα δ’ ἤδη στονόεν λέλακε χώρα,</l>
 						<l>μεγαλοσχήμονά ἀρχαι‐</l>
@@ -930,7 +930,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="415">Κολχίδος τε γᾶς ἔνοικοι</l>
 						<l>παρθένοι, μάχας ἄτρεστοι,</l>
@@ -941,7 +941,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="420">†Ἀραβίας τ’  ἄρειον ἄνθος,</l>
 						<l>ὑψίκρημνον  οἳ πόλισμα</l>
@@ -952,7 +952,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="425">[†μόνον δὴ  πρόσθεν ἄλλον ἐν πόνοις</l>
 						<l>δαμέντ’ ἀδαμαντοδέτοις</l>
@@ -963,7 +963,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βοᾷ δὲ πόντιος κλύδων</l>
 						<l>ξυμπίτνων, στένει βυθός,</l>
@@ -975,7 +975,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>μή τοι χλιδῇ δοκεῖτε μηδ’ αὐθαδίᾳ</l>
 					<l>σιγᾶν με· συννοίᾳ δὲ δάπτομαι κέαρ,</l>
@@ -1024,14 +1024,14 @@ convert to P3
 					<l>τῆς νῦν παρούσης πημονῆς ἀπαλλαγῶ.</l>
 					<milestone ed="p" n="472" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πέπονθας αἰκὲς  πῆμ’· ἀποσφαλεὶς φρενῶν</l>
 					<l>πλανᾷ, κακὸς δ’ ἰατρὸς ὥς τις ἐς νόσον</l>
 					<l>πεσὼν ἀθυμεῖς καὶ σεαυτὸν οὐκ ἔχεις</l>
 					<l n="475">εὑρεῖν ὁποίοις φαρμάκοις ἰάσιμος.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>τὰ λοιπά μου κλύουσα θαυμάσῃ πλέον,</l>
 					<l>οἵας τέχνας τε καὶ πόρους ἐμησάμην.</l>
@@ -1066,49 +1066,49 @@ convert to P3
 					<l>πᾶσαι τέχναι βροτοῖσιν ἐκ Προμηθέως.</l>
 					<milestone ed="p" n="507" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μή νυν βροτοὺς μὲν ὠφέλει καιροῦ πέρα,</l>
 					<l>σαυτοῦ δ’ ἀκήδει δυστυχοῦντος. ὡς ἐγὼ</l>
 					<l>εὔελπίς εἰμι τῶνδέ σ’ ἐκ δεσμῶν ἔτι</l>
 					<l n="510">λυθέντα μηδὲν μεῖον ἰσχύσειν Διός.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>οὐ ταῦτα ταύτῃ Μοῖρά πω τελεσφόρος</l>
 					<l>κρᾶναι πέπρωται, μυρίαις δὲ πημοναῖς</l>
 					<l>δύαις τε καμφθεὶς ὧδε δεσμὰ φυγγάνω·</l>
 					<l>τέχνη δ’ ἀνάγκης ἀσθενεστέρα μακρῷ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="515">τίς οὖν ἀνάγκης ἐστὶν οἰακοστρόφος;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>Μοῖραι τρίμορφοι μνήμονές τ’  Ἐρινύες</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τούτων ἄρα Ζεύς ἐστιν ἀσθενέστερος;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>οὔκουν ἂν ἐκφύγοι γε τὴν πεπρωμένην.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί γὰρ πέπρωται Ζηνὶ πλὴν  ἀεὶ κρατεῖν;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="520">τοῦτ’ οὐκέτ’ ἂν  πύθοιο μηδὲ λιπάρει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἦ πού τι σεμνόν ἐστιν ὃ ξυναμπέχεις.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ἄλλου λόγου μέμνησθε, τόνδε δ’ οὐδαμῶς</l>
 					<l>καιρὸς γεγωνεῖν, ἀλλὰ συγκαλυπτέος</l>
@@ -1119,7 +1119,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδάμ’  ὁ πάντα νέμων</l>
 						<l>θεῖτ’ ἐμᾷ γνώμᾳ κράτος ἀντίπαλον Ζεύς,</l>
@@ -1131,7 +1131,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἁδύ  τι θαρσαλέαις</l>
 						<l>τὸν μακρὸν τείνειν βίον ἐλπίσι, φαναῖς</l>
@@ -1144,7 +1144,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="545">φέρ’, ὅπως ἄχαρις χάρις,  ὦ φίλος·</l>
 						<l>εἰπὲ ποῦ τίς  ἀλκά;</l>
@@ -1157,7 +1157,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔμαθον τάδε σὰς προσιδοῦσ’  ὀλο‐</l>
 						<l>ὰς τύχας, Προμηθεῦ.</l>
@@ -1221,7 +1221,7 @@ convert to P3
 						<l>κλύεις φθέγμα τᾶς βούκερω παρθένου;</l>
 						<milestone ed="p" n="589" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>πῶς δ’ οὐ κλύω τῆς οἰστροδινήτου κόρης,</l>
 						<l n="590">τῆς  Ἰναχείας;  ἣ Διὸς θάλπει κέαρ</l>
@@ -1255,7 +1255,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>λέξω τορῶς σοι πᾶν ὅπερ χρῄζεις μαθεῖν,</l>
 					<l n="610">οὐκ ἐμπλέκων αἰνίγματ’, ἀλλ’  ἁπλῷ λόγῳ,</l>
@@ -1267,7 +1267,7 @@ convert to P3
 					<l>ὦ κοινὸν ὠφέλημα θνητοῖσιν φανείς,</l>
 					<l>τλῆμον Προμηθεῦ, τοῦ δίκην πάσχεις τάδε;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="615">ἁρμοῖ πέπαυμαι τοὺς ἐμοὺς θρηνῶν πόνους.</l>
 				</sp>
@@ -1275,7 +1275,7 @@ convert to P3
 					<speaker>Ἰώ</speaker>
 					<l>οὔκουν πόροις ἂν τήνδε δωρεὰν ἐμοί;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>λέγ’ ἥντιν’ αἰτῇ·  πᾶν γὰρ ἂν  πύθοιό μου.</l>
 				</sp>
@@ -1283,7 +1283,7 @@ convert to P3
 					<speaker>Ἰώ</speaker>
 					<l>σήμηνον ὅστις ἐν φάραγγί σ’ ὤχμασεν.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>βούλευμα μὲν τὸ Δῖον, Ἡφαίστου δὲ χείρ.</l>
 				</sp>
@@ -1291,7 +1291,7 @@ convert to P3
 					<speaker>Ἰώ</speaker>
 					<l n="620">ποινὰς δὲ ποίων ἀμπλακημάτων τίνεις;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>τοσοῦτον ἀρκῶ σοι σαφηνίσας  μόνον.</l>
 				</sp>
@@ -1300,7 +1300,7 @@ convert to P3
 					<l>καὶ πρός γε τούτοις τέρμα τῆς ἐμῆς πλάνης</l>
 					<l>δεῖξον, τίς ἔσται τῇ ταλαιπώρῳ χρόνος.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>τὸ μὴ μαθεῖν σοι κρεῖσσον ἢ μαθεῖν τάδε.</l>
 				</sp>
@@ -1308,7 +1308,7 @@ convert to P3
 					<speaker>Ἰώ</speaker>
 					<l n="625">μήτοι με κρύψῃς τοῦθ’  ὅπερ μέλλω παθεῖν.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ἀλλ’ οὐ μεγαίρω τοῦδέ σοι  δωρήματος.</l>
 				</sp>
@@ -1316,7 +1316,7 @@ convert to P3
 					<speaker>Ἰώ</speaker>
 					<l>τί δῆτα μέλλεις μὴ οὐ  γεγωνίσκειν τὸ πᾶν;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>φθόνος μὲν οὐδείς, σὰς δ’ ὀκνῶ θράξαι φρένας.</l>
 				</sp>
@@ -1324,18 +1324,18 @@ convert to P3
 					<speaker>Ἰώ</speaker>
 					<l>μή μου προκήδου μᾶσσον ὡς ἐμοὶ γλυκύ.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="630">ἐπεὶ προθυμῇ, χρὴ λέγειν. ἄκουε δή.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μήπω γε· μοῖραν δ’ ἡδονῆς κἀμοὶ πόρε.</l>
 					<l>τὴν τῆσδε πρῶτον ἱστορήσωμεν νόσον,</l>
 					<l>αὐτῆς λεγούσης τὰς πολυφθόρους τύχας·</l>
 					<l>τὰ λοιπὰ δ’ ἄθλων σοῦ διδαχθήτω πάρα.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="635">σὸν ἔργον,  Ἰοῖ, ταῖσδ’ ὑπουργῆσαι χάριν,</l>
 					<l>ἄλλως τε πάντως καὶ κασιγνήταις πατρός.</l>
@@ -1408,7 +1408,7 @@ convert to P3
 					<milestone ed="p" n="687" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔα ἔα, ἄπεχε, φεῦ·</l>
 						<l>οὔποτ’ οὔποτ’ ηὔχουν  &lt;ὧδε &gt;  ξένους</l>
@@ -1420,17 +1420,17 @@ convert to P3
 						<l n="695">πέφρικ’ εἰσιδοῦσα  πρᾶξιν Ἰοῦς.</l>
 						<milestone ed="p" n="696" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>πρῴ γε στενάζεις καὶ φόβου πλέα τις εἶ·</l>
 						<l>ἐπίσχες ἔστ’ ἂν καὶ τὰ λοιπὰ προσμάθῃς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λέγ’, ἐκδίδασκε· τοῖς νοσοῦσί τοι γλυκὺ</l>
 						<l>τὸ λοιπὸν ἄλγος προυξεπίστασθαι τορῶς.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="700">τὴν πρίν γε χρείαν  ἠνύσασθ’  ἐμοῦ πάρα</l>
 						<l>κούφως· μαθεῖν γὰρ τῆσδε πρῶτ’ ἐχρῄζετε</l>
@@ -1483,16 +1483,16 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>ἰώ μοί μοι, ἒ ἔ.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>σὺ δ’ αὖ κέκραγας κἀναμυχθίζῃ; τί που</l>
 						<l>δράσεις, ὅταν τὰ λοιπὰ πυνθάνῃ κακά;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="745">ἦ γάρ τι λοιπὸν τῇδε πημάτων ἐρεῖς;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>δυσχείμερόν γε πέλαγος ἀτηρᾶς δύης.</l>
 					</sp>
@@ -1504,7 +1504,7 @@ convert to P3
 						<l n="750">ἀπηλλάγην;  κρεῖσσον γὰρ εἰσάπαξ θανεῖν</l>
 						<l>ἢ τὰς ἁπάσας ἡμέρας πάσχειν κακῶς.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἦ δυσπετῶς  ἂν τοὺς ἐμοὺς ἄθλους φέροις,</l>
 						<l>ὅτῳ θανεῖν μέν ἐστιν οὐ πεπρωμένον·</l>
@@ -1516,7 +1516,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>ἦ γάρ ποτ’ ἔστιν ἐκπεσεῖν ἀρχῆς Δία;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἥδοῑ ἄν,  οἶμαι, τήνδ’ ἰδοῦσα συμφοράν.</l>
 					</sp>
@@ -1524,7 +1524,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>πῶς δ’ οὐκ ἄν, ἥτις ἐκ Διὸς πάσχω κακῶς;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="760">ὡς τοίνυν ὄντων τῶνδέ σοι μαθεῖν  πάρα.</l>
 					</sp>
@@ -1532,7 +1532,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>πρὸς τοῦ τύραννα σκῆπτρα συληθήσεται;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>πρὸς αὐτὸς αὑτοῦ κενοφρόνων βουλευμάτων.</l>
 					</sp>
@@ -1540,7 +1540,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>ποίῳ τρόπῳ; σήμηνον, εἰ μή τις βλάβη.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>γαμεῖ γάμον τοιοῦτον ᾧ ποτ’ ἀσχαλᾷ.</l>
 					</sp>
@@ -1548,7 +1548,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l n="765">θέορτον, ἢ βρότειον;  εἰ ῥητόν, φράσον.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>τί δ’ ὅντιν’·; οὐ γὰρ ῥητὸν αὐδᾶσθαι τόδε.</l>
 					</sp>
@@ -1556,7 +1556,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>ἦ πρὸς δάμαρτος ἐξανίσταται θρόνων;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἣ τέξεταί γε παῖδα φέρτερον πατρός.</l>
 					</sp>
@@ -1564,7 +1564,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>οὐδ’ ἔστιν αὐτῷ τῆσδ’ ἀποστροφὴ τύχης;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="770">οὐ δῆτα, πλὴν ἔγωγ’ ἂν ἐκ δεσμῶν λυθείς.</l>
 					</sp>
@@ -1572,7 +1572,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>τίς οὖν ὁ λύσων ἐστὶν ἄκοντος Διός;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>τῶν σῶν τιν’ αὐτὸν  ἐγγόνων εἶναι χρεών.</l>
 					</sp>
@@ -1580,7 +1580,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>πῶς εἶπας; ἦ ’μὸς παῖς σ’ ἀπαλλάξει κακῶν;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>τρίτος γε γένναν πρὸς δέκ’ ἄλλαισιν γοναῖς.</l>
 					</sp>
@@ -1588,7 +1588,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l n="775">ἥδ’ οὐκέτ’ εὐξύμβλητος ἡ χρησμῳδία.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>καὶ μηδὲ σαυτῆς  ἐκμαθεῖν ζήτει πόνους.</l>
 					</sp>
@@ -1596,7 +1596,7 @@ convert to P3
 						<speaker>Ἰώ</speaker>
 						<l>μή μοι προτείνων κέρδος εἶτ’ ἀποστέρει.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>δυοῖν λόγοιν σε θατέρῳ δωρήσομαι.</l>
 					</sp>
@@ -1605,19 +1605,19 @@ convert to P3
 						<l>ποίοιν; πρόδειξον, αἵρεσίν τ’ ἐμοὶ δίδου.</l>
 						<milestone ed="p" n="780" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="780">δίδωμ’· ἑλοῦ γάρ, ἢ πόνων τὰ λοιπά σοι</l>
 						<l>φράσω σαφηνῶς, ἢ τὸν ἐκλύσοντ’ ἐμέ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τούτων σὺ τὴν μὲν τῇδε, τὴν δ’ ἐμοὶ χάριν</l>
 						<l>θέσθαι θέλησον, μηδ’ ἀτιμάσῃς λόγου·</l>
 						<l>καὶ τῇδε μὲν γέγωνε τὴν λοιπὴν πλάνην,</l>
 						<l n="785">ἐμοὶ δὲ τὸν λύσοντα· τοῦτο γὰρ ποθῶ.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἐπεὶ προθυμεῖσθ’, οὐκ ἐναντιώσομαι</l>
 						<l>τὸ μὴ οὐ  γεγωνεῖν πᾶν ὅσον προσχρῄζετε.</l>
@@ -1663,14 +1663,14 @@ convert to P3
 						<l>σχολὴ δὲ πλείων ἢ θέλω πάρεστί μοι.</l>
 						<milestone ed="p" n="819" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ μέν τι τῇδε λοιπὸν ἢ παρειμένον</l>
 						<l n="820">ἔχεις γεγωνεῖν τῆς πολυφθόρου πλάνης,</l>
 						<l>λέγ’· εἰ δὲ πάντ’ εἴρηκας, ἡμῖν αὖ χάριν</l>
 						<l>δὸς ἥνπερ  αἰτούμεσθα, μέμνησαι δέ που.</l>
 					</sp>
-					<sp n="Προμηθεύς" who="#prometheys">
+					<sp n="Προμηθεύς" who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>τὸ πᾶν πορείας ἥδε τέρμ’ ἀκήκοεν.</l>
 						<l>ὅπως δ’ ἂν εἰδῇ μὴ μάτην κλύουσά μου,</l>
@@ -1761,7 +1761,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ σοφὸς ἦ σοφὸς [ἦν]  ὃς</l>
 						<l>πρῶτος ἐν γνώμᾳ τόδ’ ἐβάστασε καὶ γλώς‐</l>
@@ -1774,7 +1774,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μήποτε μήποτέ μ’, ὦ</l>
 						<l n="895">&lt;πότνιαι&gt;   Μοῖραι, λεχέων Διὸς εὐνά‐</l>
@@ -1787,7 +1787,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐμοὶ δ’  ὅτε   μὲν ὁμαλὸς ὁ γάμος,</l>
 						<l>ἄφοβος· [οὐ δέδια·]  μηδὲ κρεισσόνων θεῶν</l>
@@ -1801,7 +1801,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ἦ μὴν ἔτι Ζεύς, καίπερ αὐθάδης φρενῶν,</l>
 					<l>ἔσται ταπεινός, οἷον ἐξαρτύεται</l>
@@ -1825,43 +1825,43 @@ convert to P3
 					<l>πταίσας δὲ τῷδε πρὸς κακῷ  μαθήσεται</l>
 					<l>ὅσον τό τ’ ἄρχειν καὶ τὸ δουλεύειν δίχα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σύ θην ἃ χρῄζεις, ταῦτ’ ἐπιγλωσσᾷ Διός.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ἅπερ τελεῖται, πρὸς δ’ ἃ βούλομαι λέγω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="930">καὶ προσδοκᾶν χρὴ δεσπόσειν Ζηνός τινα;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>καὶ τῶνδέ γ’, ἕξει δυσλοφωτέρους πόνους.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς δ’  οὐχὶ ταρβεῖς τοιάδ’ ἐκρίπτων ἔπη;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>τί δ’ ἂν  φοβοίμην ᾧ θανεῖν οὐ μόρσιμον;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἆθλον ἄν σοι τοῦδ’ ἔτ’  ἀλγίω πόροι.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="935">ὁ δ’ οὖν ποιείτω· πάντα προσδοκητά μοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οἱ προσκυνοῦντες τὴν Ἀδράστειαν σοφοί.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>σέβου, προσεύχου, θῶπτε  τὸν κρατοῦντ’ ἀεί.</l>
 					<l>ἐμοὶ δ’ ἔλασσον Ζηνὸς ἢ μηδὲν μέλει.</l>
@@ -1872,7 +1872,7 @@ convert to P3
 					<l>πάντως τι καινὸν ἀγγελῶν ἐλήλυθεν.</l>
 					<milestone ed="p" n="944" unit="card"/>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>σὲ τὸν σοφιστήν, τὸν πικρῶς ὑπέρπικρον,</l>
 					<l n="945">τὸν ἐξαμαρτόντ’  εἰς θεοὺς ἐφημέροις</l>
@@ -1884,7 +1884,7 @@ convert to P3
 					<l>ὁδούς, Προμηθεῦ, προσβάλῃς· ὁρᾷς δ’ ὅτι</l>
 					<l>Ζεὺς τοῖς τοιούτοις οὐχὶ μαλθακίζεται.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>σεμνόστομός γε καὶ φρονήματος πλέως</l>
 					<l>ὁ μῦθός ἐστιν, ὡς θεῶν ὑπηρέτου.</l>
@@ -1899,88 +1899,88 @@ convert to P3
 					<l>πεύσῃ γὰρ οὐδὲν ὧν ἀνιστορεῖς ἐμέ.</l>
 					<milestone ed="p" n="964" unit="card"/>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>τοιοῖσδε μέντοι καὶ πρὶν αὐθαδίσμασιν</l>
 					<l n="965">ἐς τάσδε σαυτὸν πημονὰς καθώρμισας.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>τῆς σῆς λατρείας τὴν ἐμὴν δυσπραξίαν,</l>
 					<l>σαφῶς ἐπίστασ’, οὐκ ἂν ἀλλάξαιμ’ ἐγώ.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>κρεῖσσον γὰρ οἶμαι τῇδε λατρεύειν πέτρᾳ</l>
 					<l>ἢ πατρὶ φῦναι  Ζηνὶ πιστὸν  ἄγγελον.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="970">οὕτως ὑβρίζειν τοὺς ὑβρίζοντας χρεών.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>χλιδᾶν ἔοικας τοῖς παροῦσι πράγμασι.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>χλιδῶ; χλιδῶντας ὧδε τοὺς ἐμοὺς ἐγὼ</l>
 					<l>ἐχθροὺς ἴδοιμι· καὶ σὲ δ’ ἐν τούτοις λέγω.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἦ κἀμὲ γάρ τι συμφοραῖς ἐπαιτιᾷ;</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="975">ἁπλῷ λόγῳ τοὺς πάντας ἐχθαίρω θεούς,</l>
 					<l>ὅσοι παθόντες εὖ κακοῦσί μ’ ἐκδίκως.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>κλύω σ’ ἐγὼ μεμηνότ’ οὐ σμικρὰν  νόσον.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>νοσοῖμ’ ἄν, εἰ νόσημα τοὺς ἐχθροὺς στυγεῖν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>εἴης φορητὸς οὐκ ἄν, εἰ πράσσοις καλῶς.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l part="Y">&lt;ὤμοι.&gt;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l n="980">ὤμοι; τόδε Ζεὺς τοὔπος οὐκ ἐπίσταται.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ἀλλ’ ἐκδιδάσκει πάνθ’ ὁ γηράσκων χρόνος.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>καὶ μὴν σύ γ’ οὔπω σωφρονεῖν ἐπίστασαι.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>σὲ γὰρ προσηύδων οὐκ ἂν ὄνθ’ ὑπηρέτην.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἐρεῖν ἔοικας οὐδὲν ὧν χρῄζει πατήρ.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l n="985">καὶ μὴν ὀφείλων γ’ ἂν τίνοιμ’  αὐτῷ χάριν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἐκερτόμησας δῆθεν ὡς παῖδ’ ὄντα με.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>οὐ γὰρ σὺ παῖς τε κἄτι τοῦδ’ ἀνούστερος</l>
 					<l>εἰ προσδοκᾷς ἐμοῦ τι πεύσεσθαι  πάρα;</l>
@@ -1993,20 +1993,20 @@ convert to P3
 					<l n="995">γνάμψει  γὰρ οὐδὲν τῶνδέ μ’ ὥστε καὶ φράσαι</l>
 					<l>πρὸς οὗ χρεών νιν ἐκπεσεῖν τυραννίδος.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ὅρα νυν  εἴ σοι ταῦτ’ ἀρωγὰ φαίνεται.</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ὦπται  πάλαι δὴ καὶ βεβούλευται τάδε.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>τόλμησον, ὦ μάταιε, τόλμησόν ποτε</l>
 					<l n="1000">πρὸς τὰς παρούσας πημονὰς ὀρθῶς φρονεῖν,</l>
 				</sp>
-				<sp who="#prometheys">
+				<sp who="#prometheus">
 					<speaker>Προμηθεύς</speaker>
 					<l>ὀχλεῖς μάτην με κῦμ’ ὅπως παρηγορῶν.</l>
 					<l>εἰσελθέτω σε μήποθ’  ὡς ἐγὼ Διὸς</l>
@@ -2016,7 +2016,7 @@ convert to P3
 					<l>λῦσαί με δεσμῶν τῶνδε· τοῦ παντὸς δέω.</l>
 					<milestone ed="p" n="1007" unit="card"/>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>λέγων ἔοικα πολλὰ καὶ μάτην ἐρεῖν·</l>
 					<l>τέγγῃ γὰρ οὐδὲν οὐδὲ μαλθάσσῃ λιταῖς</l>
@@ -2054,7 +2054,7 @@ convert to P3
 					<l>πάπταινε καὶ φρόντιζε, μηδ’ αὐθαδίαν</l>
 					<l n="1035">εὐβουλίας ἀμείνον’  ἡγήσῃ ποτέ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμῖν μὲν Ἑρμῆς οὐκ ἄκαιρα φαίνεται</l>
 					<l>λέγειν. ἄνωγε γάρ σε τὴν αὐθαδίαν</l>
@@ -2063,7 +2063,7 @@ convert to P3
 					<milestone ed="p" n="1040" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="1040">εἰδότι τοί μοι τάσδ’ ἀγγελίας</l>
 						<l>ὅδ’ ἐθώυξεν· πάσχειν δὲ κακῶς</l>
@@ -2082,7 +2082,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>τοιάδε μέντοι τῶν φρενοπλήκτων</l>
 						<l n="1055">βουλεύματ’  ἔπη τ’  ἔστιν ἀκοῦσαι.</l>
@@ -2096,7 +2096,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄλλο τι φώνει καὶ παραμυθοῦ μ’</l>
 						<l>ὅ τι καὶ πείσεις· οὐ γὰρ δή που</l>
@@ -2109,7 +2109,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ἀλλ’ οὖν μέμνησθ’ ἁγὼ  προλέγω</l>
 						<l>μηδὲ πρὸς ἄτης θηραθεῖσαι</l>
@@ -2122,7 +2122,7 @@ convert to P3
 						<l>ἐμπλεχθήσεσθ’ ὑπ’ ἀνοίας.</l>
 						<milestone ed="p" n="1080" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="1080">καὶ μὴν ἔργῳ κοὐκέτι μύθῳ</l>
 						<l>χθὼν σεσάλευται·</l>

--- a/tei/aeschylus-seven-against-thebes.xml
+++ b/tei/aeschylus-seven-against-thebes.xml
@@ -57,19 +57,19 @@
 					<person xml:id="ismene" sex="FEMALE">
 						<persName>Ἰσμήνη</persName>
 					</person>
-					<person xml:id="aggelos" sex="MALE">
+					<person xml:id="angelos" sex="MALE">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<person xml:id="keryks" sex="UNKNOWN">
+					<person xml:id="keryx" sex="UNKNOWN">
 						<persName>Κῆρυξ</persName>
 					</person>
-					<person xml:id="emixorionb" sex="UNKNOWN">
-						<persName>Ἡμιχόριον Β</persName>
-					</person>
-					<person xml:id="emixoriona" sex="UNKNOWN">
-						<persName>Ἡμιχόριον Α</persName>
-					</person>
-					<personGrp xml:id="xoros" sex="UNKNOWN">
+					<personGrp xml:id="hemichorion_a" sex="UNKNOWN">
+						<name>Ἡμιχόριον Α</name>
+					</personGrp>
+					<personGrp xml:id="hemichorion_b" sex="UNKNOWN">
+						<name>Ἡμιχόριον Β</name>
+					</personGrp>
+					<personGrp xml:id="choros" sex="UNKNOWN">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="antigone" sex="FEMALE">
@@ -225,7 +225,7 @@ convert to P3
 					<l>καὶ τῶνδ’ ἀκούσας οὔ τι μὴ ληφθῶ δόλῳ.</l>
 					<milestone ed="p" n="39" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>Ἐτεόκλεες, φέριστε Καδμείων ἄναξ,</l>
 					<l n="40">ἥκω σαφῆ τἀκεῖθεν ἐκ στρατοῦ φέρων,</l>
@@ -272,7 +272,7 @@ convert to P3
 					<milestone ed="p" n="78" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θρέομαι φοβερὰ μεγάλ’ ἄχη·</l>
 						<l>μεθεῖται στρατός· στρατόπεδον λιπὼν</l>
@@ -308,7 +308,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θεοὶ πολιάοχοι πάντες ἴτε χθονὸς·</l>
 						<l n="110">ἴδετε παρθένων</l>
@@ -331,7 +331,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σύ τ’, ὦ Διογενὲς φιλόμαχον κράτος,</l>
 						<l>ῥυσίπολις  γενοῦ,</l>
@@ -352,7 +352,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἒ ἒ ἒ ἔ,</l>
 						<l n="150">ὄτοβον ἁρμάτων ἀμφὶ πόλιν κλύω·</l>
@@ -366,7 +366,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἒ ἒ ἒ ἔ,</l>
 						<l n="158b">ἀκροβόλων δ’ ἐπάλξεων λιθὰς ἔρχεται·</l>
@@ -380,7 +380,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ παναρκεῖς  θεοί,</l>
 						<l>ἰὼ τέλειοι τέλειαί τε γᾶς</l>
@@ -393,7 +393,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ φίλοι δαίμονες,</l>
 						<l n="175">λυτήριοί  &lt;τ’&gt;  ἀμφιβάντες πόλιν,</l>
@@ -435,7 +435,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ φίλον Οἰδίπου τέκος, ἔδεισ’ ἀκού‐</l>
 						<l>σασα τὸν ἁρματόκτυπον ὄτοβον ὄτοβον,</l>
@@ -452,7 +452,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἐπὶ δαιμόνων πρόδρομος ἦλθον ἀρ‐</l>
 						<l>χαῖα βρέτη, θεοῖσι πίσυνος,  νιφάδος</l>
@@ -469,7 +469,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μήποτ’ ἐμὸν κατ’ αἰῶνα λίποι  θεῶν</l>
 						<l n="220">ἅδε πανάγυρις, μηδ’ ἐπίδοιμι τάνδ’</l>
@@ -485,7 +485,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔστι· θεοῦ  δ’ ἔτ’ ἰσχὺς καθυπερτέρα·</l>
 						<l>πολλάκι δ’ ἐν κακοῖσι τὸν  ἀμάχανον</l>
@@ -501,7 +501,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>διὰ θεῶν πόλιν νεμόμεθ’  ἀδάματον,</l>
 						<l>δυσμενέων δ’ ὄχλον πύργος ἀποστέγει.</l>
@@ -516,7 +516,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποτίφατον  κλύουσα πάταγον ἀνάμιγα</l>
 						<l n="240">ταρβοσύνῳ φόβῳ τάνδ’ ἐς ἀκρόπτολιν,</l>
@@ -532,7 +532,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="245">καὶ μὴν ἀκούω γ’ ἱππικῶν φρυαγμάτων.</l>
 				</sp>
@@ -540,7 +540,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>μή νυν  ἀκούουσ’ ἐμφανῶς ἄκοῡ ἄγαν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>στένει πόλισμα γῆθεν, ὡς κυκλουμένων.</l>
 				</sp>
@@ -548,7 +548,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>οὐκοῦν ἔμ’ ἀρκεῖ τῶνδε βουλεύειν πέρι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δέδοικ’, ἀραγμὸς δ’ ἐν πύλαις ὀφέλλεται.</l>
 				</sp>
@@ -556,7 +556,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l n="250">οὐ σῖγα μηδὲν τῶνδ’ ἐρεῖς κατὰ πτόλιν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ ξυντέλεια, μὴ προδῷς πυργώματα.</l>
 				</sp>
@@ -564,7 +564,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>οὐκ ἐς φθόρον  σιγῶσ’ ἀνασχήσῃ τάδε;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θεοὶ πολῖται, μή με δουλείας τυχεῖν.</l>
 				</sp>
@@ -572,7 +572,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>αὐτὴ σὺ δουλοῖς κἀμὲ καὶ πᾶσαν πόλιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="255">ὦ παγκρατὲς Ζεῦ, τρέψον εἰς ἐχθροὺς βέλος.</l>
 				</sp>
@@ -580,7 +580,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>ὦ Ζεῦ, γυναικῶν οἷον ὤπασας γένος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μοχθηρόν, ὥσπερ ἄνδρας ὧν ἁλῷ πόλις.</l>
 				</sp>
@@ -588,7 +588,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>παλινστομεῖς αὖ θιγγάνουσ’ ἀγαλμάτων;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀψυχίᾳ γὰρ γλῶσσαν ἁρπάζει φόβος.</l>
 				</sp>
@@ -596,7 +596,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l n="260">αἰτουμένῳ μοι κοῦφον εἰ δοίης τέλος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>λέγοις ἂν ὡς τάχιστα, καὶ τάχ’ εἴσομαι.</l>
 				</sp>
@@ -604,7 +604,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>σίγησον, ὦ τάλαινα, μὴ φίλους φόβει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σιγῶ· σὺν ἄλλοις πείσομαι τὸ μόρσιμον.</l>
 				</sp>
@@ -645,7 +645,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μέλει, φόβῳ δ’ οὐχ ὑπνώσσει κέαρ·</l>
 						<l>γείτονες δὲ καρδίας</l>
@@ -667,7 +667,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποῖον δ’ ἀμείψεσθε  γαίας πέδον</l>
 						<l n="305">τᾶσδ’ ἄρειον, ἐχθροῖς</l>
@@ -690,7 +690,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἰκτρὸν γὰρ πόλιν ὧδ’ ὠγυγίαν</l>
 						<l>Ἀίδᾳ προϊάψαι, δορὸς ἄγραν</l>
@@ -708,7 +708,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κλαυτὸν δ’ ἀρτιτρόποις  ὠμοδρόποις</l>
 						<l>νομίμων προπάροιθεν διαμεῖψαι</l>
@@ -726,7 +726,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="345">κορκορυγαὶ  δ’ ἀν’ ἄστυ, προτὶ [πτόλιν]</l>
 						<l>δ’ ὁρκάνα</l>
@@ -745,7 +745,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παντοδαπὸς δὲ καρπὸς χαμάδις πεσὼν</l>
 						<l>ἀλγύνει κυρήσας· πικρὸν δ’</l>
@@ -764,19 +764,19 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#emixoriona">
+				<sp who="#hemichorion_a">
 					<speaker>Ἡμιχόριον Α</speaker>
 					<l>ὅ τοι κατόπτης, ὡς ἐμοὶ δοκεῖ, στρατοῦ</l>
 					<l n="370">πευθώ τιν’ ἡμῖν, ὦ φίλαι, νέαν φέρει,</l>
 					<l>σπουδῇ διώκων πομπίμους χνόας ποδῶν.</l>
 				</sp>
-				<sp who="#emixorionb">
+				<sp who="#hemichorion_b">
 					<speaker>Ἡμιχόριον Β</speaker>
 					<l>καὶ μὴν ἄναξ ὅδ’ αὐτὸς Οἰδίπου τόκος</l>
 					<l>εἰς  ἀρτίκολλον ἀγγέλου λόγον μαθεῖν·</l>
 					<l>σπουδὴ δὲ καὶ τοῦδ’ οὐκ ἀπαρτίζει πόδα.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="375">λέγοιμ’ ἂν εἰδὼς εὖ τὰ τῶν ἐναντίων,</l>
 					<l>ὥς τ’  ἐν πύλαις ἕκαστος εἴληχεν πάλον.</l>
@@ -828,7 +828,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν ἁμόν  νυν  ἀντίπαλον εὐτυχεῖν</l>
 						<l>θεοὶ δοῖεν, ὡς δικαίως πόλεως</l>
@@ -837,7 +837,7 @@ convert to P3
 						<l>ὀλομένων ἰδέσθαι.</l>
 						<milestone ed="p" n="422" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>τούτῳ μὲν οὕτως εὐτυχεῖν δοῖεν θεοί·</l>
 						<l>Καπανεὺς δ’ ἐπ’ Ἠλέκτραισιν εἴληχεν πύλαις,</l>
@@ -876,7 +876,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὄλοιθ’ ὃς πόλει μεγάλ’ ἐπεύχεται,</l>
 						<l>κεραυνοῦ δέ νιν  βέλος ἐπισχέθοι,</l>
@@ -885,7 +885,7 @@ convert to P3
 						<l>δορί ποτ’ ἐκλαπάξαι.</l>
 						<milestone ed="p" n="457" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>καὶ μὴν τὸν ἐντεῦθεν λαχόντα πρὸς πύλαις</l>
 						<l>λέξω· τρίτῳ γὰρ Ἐτεόκλῳ τρίτος πάλος</l>
@@ -919,7 +919,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεύχομαι τῷδε  μὲν εὐτυχεῖν, ἰὼ</l>
 						<l>πρόμαχ’ ἐμῶν δόμων, τοῖσι δὲ δυστυχεῖν.</l>
@@ -928,7 +928,7 @@ convert to P3
 						<l n="485">Ζεὺς νεμέτωρ ἐπίδοι κοταίνων.</l>
 						<milestone ed="p" n="486" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>τέταρτος ἄλλος, γείτονας πύλας ἔχων</l>
 						<l>Ὄγκας Ἀθάνας, ξὺν βοῇ παρίσταται,</l>
@@ -972,7 +972,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πέποιθα &lt;δὴ&gt;  τὸν Διὸς ἀντίτυπον ἔχοντ’</l>
 						<l>ἄφιλον ἐν σάκει τοῦ χθονίου δέμας</l>
@@ -981,7 +981,7 @@ convert to P3
 						<l n="525">πρόσθε πυλᾶν κεφαλὰν ἰάψειν.</l>
 						<milestone ed="p" n="526" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>οὕτως γένοιτο.  τὸν δὲ πέμπτον αὖ λέγω,</l>
 						<l>πέμπταισι προσταχθέντα Βορραίαις  πύλαις,</l>
@@ -1027,7 +1027,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἱκνεῖται λόγος διὰ στηθέων,</l>
 						<l>τριχὸς δ’ ὀρθίας πλόκαμος ἵσταται,</l>
@@ -1036,7 +1036,7 @@ convert to P3
 						<l>θεοὶ  τοῦδ’ ὀλέσειαν ἐν γᾷ.</l>
 						<milestone ed="p" n="568" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ἕκτον λέγοιμ’ ἂν ἄνδρα σωφρονέστατον,</l>
 						<l>ἀλκήν τ’ ἄριστον μάντιν, Ἀμφιάρεω βίαν·</l>
@@ -1109,7 +1109,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κλύοντες θεοὶ δικαίας λιτὰς</l>
 						<l>ἁμετέρας  τελεῖθ’, ὡς πόλις εὐτυχῇ,</l>
@@ -1121,7 +1121,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τὸν ἕβδομον δὴ τόνδ’ ἐφ’ ἑβδόμαις πύλαις</l>
 					<l>λέξω, τὸν αὐτοῦ σοῦ κασίγνητον, πόλει</l>
@@ -1176,7 +1176,7 @@ convert to P3
 					<l n="675">ἐχθρὸς σὺν ἐχθρῷ στήσομαι. φέρ’ ὡς τάχος</l>
 					<l>κνημῖδας, αἰχμῆς καὶ πέτρων  προβλήματα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μή, φίλτατ’ ἀνδρῶν, Οἰδίπου τέκος, γένῃ</l>
 					<l>ὀργὴν ὁμοῖος τῷ κάκιστ’ αὐδωμένῳ·</l>
@@ -1195,7 +1195,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί μέμονας,  τέκνον; μή τί σε  θυμοπλη‐</l>
 						<l>θὴς δορίμαργος  ἄτα φερέτω· κακοῦ δ’</l>
@@ -1210,7 +1210,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὠμοδακής σ’ ἄγαν ἵμερος ἐξοτρύ‐</l>
 						<l>νει πικρόκαρπον ἀνδροκτασίαν  τελεῖν</l>
@@ -1225,7 +1225,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ σὺ μὴ ’ποτρύνου· κακὸς οὐ κεκλή‐</l>
 						<l>σῃ βίον εὖ κυρήσας· μελάναιγις [δ’·] οὐκ</l>
@@ -1241,7 +1241,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="705">νῦν ὅτε σοι παρέστακεν· ἐπεὶ δαίμων</l>
 						<l>λήματος ἐν τροπαίᾳ χρονίᾳ  μεταλ‐</l>
@@ -1258,7 +1258,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πιθοῦ  γυναιξί, καίπερ οὐ στέργων ὅμως.</l>
 				</sp>
@@ -1266,7 +1266,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>λέγοιτ’ ἂν ὧν ἄνη τις·  οὐδὲ χρὴ μακράν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μὴ ’λθῃς ὁδοὺς σὺ τάσδ’ ἐφ’ ἑβδόμαις πύλαις.</l>
 				</sp>
@@ -1274,7 +1274,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l n="715">τεθηγμένον τοί μ’ οὐκ ἀπαμβλυνεῖς λόγῳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>νίκην γε μέντοι καὶ κακὴν τιμᾷ θεός.</l>
 				</sp>
@@ -1282,7 +1282,7 @@ convert to P3
 					<speaker>Ἐτεοκλής</speaker>
 					<l>οὐκ ἄνδρ’ ὁπλίτην τοῦτο χρὴ στέργειν ἔπος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ αὐτάδελφον αἷμα δρέψασθαι θέλεις;</l>
 				</sp>
@@ -1294,7 +1294,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="720">πέφρικα τὰν ὠλεσίοικον</l>
 						<l>θεόν, οὐ θεοῖς ὁμοίαν,</l>
@@ -1307,7 +1307,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ξένος δὲ κλήρους  ἐπινωμᾷ,</l>
 						<l>Χάλυβος Σκυθᾶν  ἄποικος,</l>
@@ -1320,7 +1320,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεὶ δ’ ἂν  αὐτοκτόνως</l>
 						<l n="735">αὐτοδάικτοι θάνωσι,</l>
@@ -1334,7 +1334,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παλαιγενῆ γὰρ λέγω</l>
 						<l>παρβασίαν  ὠκύποινον·</l>
@@ -1348,7 +1348,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="750">κρατηθεὶς δ’ ἐκ φίλων ἀβουλιᾶν</l>
 						<l>ἐγείνατο  μὲν μόρον αὑτῷ,</l>
@@ -1362,7 +1362,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κακῶν δ’ ὥσπερ θάλασσα κῦμ’ ἄγει·</l>
 						<l>τὸ μὲν πίτνον, ἄλλο δ’ ἀείρει</l>
@@ -1376,7 +1376,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τελειᾶν  γὰρ παλαιφάτων ἀρᾶν</l>
 						<l>βαρεῖαι καταλλαγαί· τὰ δ’ ὀλοὰ</l>
@@ -1388,7 +1388,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίν’ ἀνδρῶν γὰρ τοσόνδ’ ἐθαύμασαν</l>
 						<l>θεοὶ καὶ ξυνέστιοι πόλεος ὁ</l>
@@ -1400,7 +1400,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεὶ δ’ ἀρτίφρων</l>
 						<l>ἐγένετο μέλεος ἀθλίων</l>
@@ -1413,7 +1413,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="785">τέκνοις δ’ ἀγρίας</l>
 						<l>ἐφῆκεν ἐπικότους τροφᾶς,</l>
@@ -1427,7 +1427,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>θαρσεῖτε, παῖδες μητέρων τεθραμμέναι.</l>
 					<l>πόλις πέφευγεν ἥδε δούλιον  ζυγόν·</l>
@@ -1441,43 +1441,43 @@ convert to P3
 					<l>ἄναξ Ἀπόλλων εἵλετ’, Οἰδίπου γένει</l>
 					<l>κραίνων παλαιὰς Λαΐου δυσβουλίας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἔστι πρᾶγμα νεόκοτον πόλει πλέον;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>πόλις σέσωσται· βασιλέες  δ’ ὁμόσποροι—</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="805">τίνες;  τί δ’ εἶπας;  παραφρονῶ φόβῳ λόγου.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>φρονοῦσα νῦν ἄκουσον· Οἰδίπου τόκοι —</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οἲ ’γὼ  τάλαινα, μάντις εἰμὶ τῶν κακῶν.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐδ’ ἀμφιλέκτως μὴν κατεσποδημένοι—</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐκεῖθι κεῖσθον ; βαρέα δ’ οὖν ὅμως φράσον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="810">ἅνδρες  τεθνᾶσιν ἐκ χερῶν  αὐτοκτόνων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὕτως ἀδελφαῖς χερσὶν ἠναίρονθ’ ἅμα ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὕτως ὁ δαίμων κοινὸς ἦν ἀμφοῖν ἄγαν.</l>
 					<l>αὐτὸς δ’ ἀναλοῖ δῆτα δύσποτμον γένος.</l>
@@ -1494,7 +1494,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ μεγάλε Ζεῦ καὶ πολιοῦχοι</l>
 						<l>δαίμονες, οἳ δὴ Κάδμου πύργους</l>
@@ -1510,7 +1510,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ μέλαινα καὶ τελεία</l>
 						<l n="833b">γένεος Οἰδίπου τ’ ἀρά,</l>
@@ -1524,7 +1524,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="840">ἐξέπραξεν, οὐδ’ ἀπεῖπεν</l>
 						<l>πατρόθεν εὐκταία φάτις·</l>
@@ -1538,7 +1538,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάδ’ αὐτόδηλα, προῦπτος  ἀγγέλου λόγος·</l>
 						<l>διπλαῖ μέριμναι,  †διδυμάνορα</l>
@@ -1569,7 +1569,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="875">ἰὼ ἰὼ δύσφρονες,</l>
 						<l>φίλων ἄπιστοι καὶ κακῶν ἀτρύμονες,</l>
@@ -1581,7 +1581,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰὼ δωμάτων</l>
 						<l>ἐρειψίτοιχοι  καὶ πικρὰς μοναρχίας</l>
@@ -1593,7 +1593,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δῑ εὐωνύμων τετυμμένοι,</l>
 						<l>τετυμμένοι δῆθ’,</l>
@@ -1613,7 +1613,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="900">διήκει δὲ καὶ πόλιν στόνος,</l>
 						<l>στένουσι πύργοι,</l>
@@ -1631,7 +1631,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σιδαρόπλακτοι  μὲν ὧδ’ ἔχουσιν,</l>
 						<l>σιδαρόπλακτοι  δὲ τοὺς μένουσι,</l>
@@ -1648,7 +1648,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάρεστι δ’ εἰπεῖν ἐπ’ ἀθλίοισιν</l>
 						<l>ὡς ἐρξάτην πολλὰ μὲν πολίτας,</l>
@@ -1665,7 +1665,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁμόσποροι δῆτα καὶ πανώλεθροι,</l>
 						<l>διατομαῖς οὐ φίλοις,</l>
@@ -1683,7 +1683,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="945">ἔχουσι μοῖραν λαχόντες οἱ  μέλεοι</l>
 						<l>διοδότων  ἀχθέων·</l>
@@ -1794,7 +1794,7 @@ convert to P3
 						<speaker>Ἰσμήνη</speaker>
 						<l>πέλας ἀδελφέ’ ἀδελφεῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ Μοῖρα βαρυδότειρα μογερά,</l>
 						<l>πότνιά τ’ Οἰδίπου σκιά,</l>
@@ -1851,7 +1851,7 @@ convert to P3
 						<speaker>Ἰσμήνη</speaker>
 						<l n="990">†δίυγρα τριπάλτων πημάτων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ  Μοῖρα βαρυδότειρα μογερά,</l>
 						<l>πότνιά τ’ Οἰδίπου σκιά,</l>
@@ -1932,7 +1932,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>δοκοῦντα καὶ δόξαντ’ ἀπαγγέλλειν με χρὴ</l>
 					<l>δήμου προβούλοις τῆσδε Καδμείας πόλεως·</l>
@@ -1977,7 +1977,7 @@ convert to P3
 					<l>θάρσει, παρέσται μηχανὴ δραστήριος.</l>
 					<milestone ed="p" n="1048" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>αὐδῶ πόλιν σε μὴ βιάζεσθαι τάδε.</l>
 				</sp>
@@ -1985,7 +1985,7 @@ convert to P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>αὐδῶ σὲ  μὴ περισσὰ κηρύσσειν ἐμοί.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="1050">τραχύς γε μέντοι  δῆμος ἐκφυγὼν κακά.</l>
 				</sp>
@@ -1993,7 +1993,7 @@ convert to P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>τράχυν’· ἄθαπτος δ’ οὗτος οὐ γενήσεται.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἀλλ’ ὃν πόλις στυγεῖ, σὺ τιμήσεις τάφῳ,;</l>
 				</sp>
@@ -2001,7 +2001,7 @@ convert to P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>ἤδη τὰ τοῦδε  διατετίμηται θεοῖς.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>οὔ, πρίν γε χώραν τήνδε κινδύνῳ βαλεῖν.</l>
 				</sp>
@@ -2009,7 +2009,7 @@ convert to P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l n="1055">παθὼν κακῶς κακοῖσιν ἀντημείβετο.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἀλλ’ εἰς ἅπαντας ἀνθ’ ἑνὸς τόδ’ ἔργον ἦν.</l>
 				</sp>
@@ -2018,12 +2018,12 @@ convert to P3
 					<l>ἔρις περαίνει μῦθον ὑστάτη θεῶν.</l>
 					<l>ἐγὼ δὲ θάψω τόνδε· μὴ μακρηγόρει.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἀλλ’ αὐτόβουλος ἴσθ’, ἀπεννέπω δ’ ἐγώ.</l>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">φεῦ φεῦ.</l>
 						<l n="1060">ὦ μεγάλαυχοι καὶ φθερσιγενεῖς</l>
@@ -2039,7 +2039,7 @@ convert to P3
 						<l n="1070">μονόκλαυτον ἔχων θρῆνον  ἀδελφῆς</l>
 						<l>εἶσιν· τίς ἂν οὖν τὰ πίθοιτο ;</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>δράτω &lt;τι&gt;  πόλις καὶ μὴ δράτω</l>
 						<l>τοὺς κλαίοντας Πολυνείκη.</l>
@@ -2048,7 +2048,7 @@ convert to P3
 						<l>κοινὸν τόδ’ ἄχος, καὶ πόλις ἄλλως</l>
 						<l>ἄλλοτ’ ἐπαινεῖ τὰ δίκαια.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>ἡμεῖς δ’ ἅμα τῷδ’, ὥσπερ τε πόλις</l>
 						<l>καὶ τὸ δίκαιον ξυνεπαινεῖ.</l>

--- a/tei/aeschylus-suppliant-women.xml
+++ b/tei/aeschylus-suppliant-women.xml
@@ -60,19 +60,19 @@
 					<person xml:id="keryx">
 						<persName>Κῆρυχ</persName>
 					</person>
-					<person xml:id="basileys">
+					<person xml:id="basileus">
 						<persName>βασιλεύς</persName>
 					</person>
 					<personGrp xml:id="xorostherapainon">
 						<name>Χορός Θεραπαινῶν</name>
 					</personGrp>
-					<person xml:id="keryks">
+					<person xml:id="keryx">
 						<persName>Κῆρυξ</persName>
 					</person>
 					<person xml:id="danaos">
 						<persName>Δαναός</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="therapaina">
@@ -189,7 +189,7 @@ convert to P3
 			<div1 type="episode">
 				<div2 type="lyric">
 					<milestone ed="p" n="1" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ζεὺς μὲν ἀφίκτωρ ἐπίδοι προφρόνως</l>
 						<l>στόλον ἡμέτερον νάιον ἀρθέντ’</l>
@@ -236,7 +236,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="40">νῦν δ’ ἐπικεκλομένα</l>
 						<l>Δῖον πόρτιν ὑπερ‐</l>
@@ -251,7 +251,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅντ’   ἐπιλεξαμένα,</l>
 						<l n="50">νῦν ἐν ποιονόμοις</l>
@@ -266,7 +266,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δὲ κυρεῖ τις πέλας οἰωνοπόλων</l>
 						<l>ἔγγαιος οἶκτον [οἰκτρὸν] ἀίων,</l>
@@ -277,7 +277,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἅτ’ ἀπὸ χλωρῶν πετάλων ἐργομένα</l>
 						<l>πενθεῖ μὲν οἶκτον ἠθέων·</l>
@@ -288,7 +288,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὼς καὶ ἐγὼ φιλόδυρ‐</l>
 						<l>τος Ἰαονίοισι νόμοισι</l>
@@ -303,7 +303,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλά, θεοὶ γενέται</l>
 						<l>κλύετ’ εὖ τὸ δίκαιον ἰδόντες·</l>
@@ -318,7 +318,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὖ δ’ εἴη Διόθεν παναληθῶς.</l>
 						<l>Διὸς ἵμερος οὐκ εὐθήρατος ἐτύχθη.</l>
@@ -329,7 +329,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πίπτει δ’ ἀσφαλὲς οὐδ’ ἐπὶ νώτῳ,</l>
 						<l>κορυφᾷ  Διὸς εἰ κρανθῇ , πρᾶγμα τέλειον.</l>
@@ -340,7 +340,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰάπτει δ’ ἐλπίδων</l>
 						<l>ἀφ’ ὑψιπύργων πανώλεις</l>
@@ -354,7 +354,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰδέσθω δ’ εἰς ὕβριν</l>
 						<l n="105">βρότειον, οἵα  νεάζει</l>
@@ -368,7 +368,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="6" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοιαῦτα πάθεα μέλεα θρεομένα λέγω</l>
 						<l>λιγέα βαρέα δακρυοπετῆ,</l>
@@ -379,7 +379,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἱλεοῦμαι μὲν Ἀπίαν βοῦνιν,</l>
 						<l>καρβᾶνα δ’ αὐδὰν</l>
@@ -391,7 +391,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="6" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θεοῖς δ’ ἐναγέα τέλεα πελομένων καλῶς</l>
 						<l>ἐπίδρομ’, ὁπόθι θάνατος ἀπῇ.</l>
@@ -402,7 +402,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἱλεοῦμαι μὲν Ἀπίαν βοῦνιν,</l>
 						<l>καρβᾶνα δ’ αὐδὰν</l>
@@ -414,7 +414,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="7" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πλάτα μὲν οὖν  λινορραφής τε</l>
 						<l n="135">δόμος ἅλα στέγων δορὸς</l>
@@ -427,7 +427,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σπέρμα  σεμνᾶς μέγα ματρὸς</l>
 						<l>εὐνὰς ἀνδρῶν, ἒ ἔ,</l>
@@ -436,7 +436,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="7" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θέλουσα δ’   αὖ  θέλουσαν ἁγνά  μ’</l>
 						<l n="145">ἐπιδέτω Διὸς κόρα,</l>
@@ -449,7 +449,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σπέρμα σεμνᾶς μέγα ματρὸς</l>
 						<l>εὐνὰς ἀνδρῶν, ἒ ἔ,</l>
@@ -458,7 +458,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="8" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δὲ μή, μελανθὲς</l>
 						<l>ἡλιόκτυπον γένος</l>
@@ -472,7 +472,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆ Ζήν, Ἰοῦς ἰῷ</l>
 						<l>μῆνις μάστειρ’ ἐκ θεῶν·</l>
@@ -484,7 +484,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="8" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ τότ’  οὐ δικαίοις</l>
 						<l>Ζεὺς ἐνέξεται λόγοις,</l>
@@ -498,7 +498,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="162a">&lt;ἆ Ζήν, Ἰοῦς ἰῶ ,</l>
 						<l n="163a">μῆνις μάστειρ’ ἐκ θεῶν·</l>
@@ -545,7 +545,7 @@ convert to P3
 					<l>μέμνησο δ’ εἴκειν· χρεῖος εἶ ξένη φυγάς.</l>
 					<l>θρασυστομεῖν γὰρ οὐ πρέπει τοὺς ἥσσονας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πάτερ, φρονούντως πρὸς φρονοῦντας ἐννέπεις.</l>
 					<l n="205">φυλάξομαι δὲ τάσδε μεμνῆσθαι σέθεν</l>
@@ -556,7 +556,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l>ἴδοιτο δῆτα πρευμενοῦς ἀπ’ ὄμματος·</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θέλοιμ’ ἂν ἤδη σοὶ πέλας θρόνους ἔχειν.</l>
 				</sp>
@@ -564,7 +564,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l>μή νυν σχόλαζε, μηχανῆς δ’ ἔστω κράτος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="210">ὦ Ζεῦ, κόπων οἴκτιρε μὴ ἀπολωλότας.</l>
 				</sp>
@@ -572,7 +572,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l>κείνου θέλοντος εὖ τελευτήσει τάδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>
 						<gap desc="*"/>
@@ -582,7 +582,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l>καὶ Ζηνὸς ὄρνιν τόνδε νῦν κικλῄσκετε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καλοῦμεν αὐγὰς ἡλίου σωτηρίους,—</l>
 				</sp>
@@ -590,7 +590,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l>ἁγνόν τ’ Ἀπόλλω, φυγάδ’ ἀπ’ οὐρανοῦ θεόν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="215">εἰδὼς ἂν αἶσαν τήνδε συγγνοίη βροτοῖς.</l>
 				</sp>
@@ -598,7 +598,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l>συγγνοῖτο δῆτα καὶ παρασταίη πρόφρων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τίν’ οὖν κικλῄσκω τῶνδε δαιμόνων ἔτι;</l>
 				</sp>
@@ -606,7 +606,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l>ὁρῶ τρίαιναν τήνδε σημεῖον θεοῦ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εὖ τ’ ἔπεμψεν εὖ τε δεξάσθω χθονί.</l>
 				</sp>
@@ -614,7 +614,7 @@ convert to P3
 					<speaker>Δαναός</speaker>
 					<l n="220">Ἑρμῆς ὅδ’ ἄλλος τοῖσιν Ἑλλήνων νόμοις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐλευθέροις νυν ἐσθλὰ κηρυκευέτω.</l>
 				</sp>
@@ -634,7 +634,7 @@ convert to P3
 					<l>ὅπως ἂν ὑμῖν πρᾶγος εὖ νικᾷ τόδε.</l>
 					<milestone ed="p" n="234" unit="card"/>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ποδαπὸν ὅμιλον τόνδ’ ἀνελληνόστολον</l>
 					<l n="235">πέπλοισι βαρβάροισι καὶ πυκνώμασι</l>
@@ -649,13 +649,13 @@ convert to P3
 					<l>καὶ τἄλλα πόλλ’ ἔτ’ εἰκάσαι δίκαιον ἦν,</l>
 					<l n="245">εἰ μὴ παρόντι φθόγγος ἦν ὁ σημανῶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἴρηκας ἀμφὶ κόσμον ἀψευδῆ λόγον.</l>
 					<l>ἐγὼ δὲ πρὸς σὲ πότερον ὡς ἔτην λέγω,</l>
 					<l>ἢ ῥήτορ’ ἱεροράβδον, ἢ πόλεως ἀγόν;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>πρὸς ταῦτ’ ἀμείβου καὶ λέγ’ εὐθαρσὴς ἐμοί.</l>
 					<l n="250">τοῦ γηγενοῦς γάρ εἰμ’ ἐγὼ Παλαίχθονος</l>
@@ -690,13 +690,13 @@ convert to P3
 					<l>μακράν γε μὲν δὴ ῥῆσιν οὐ στέργει πόλις.</l>
 					<milestone ed="p" n="274" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>βραχὺς τορός θ’ ὁ μῦθος· Ἀργεῖαι γένος</l>
 					<l n="275">ἐξευχόμεσθα, σπέρματ’ εὐτέκνου βοός·</l>
 					<l>καὶ ταῦτ’ ἀληθῆ πάντα προσφύσω λόγῳ.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ἄπιστα μυθεῖσθ’, ὦ ξέναι, κλύειν ἐμοί,</l>
 					<l>ὅπως τόδ’ ὑμῖν ἐστιν Ἀργεῖον γένος.</l>
@@ -714,146 +714,146 @@ convert to P3
 					<l n="290">ὅπως γένεθλον σπέρμα τ’ Ἀργεῖον τὸ σόν.</l>
 					<milestone ed="p" n="291" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>κλῃδοῦχον Ἥρας φασὶ δωμάτων ποτὲ</l>
 					<l>Ἰὼ γενέσθαι τῇ δ’ ἐν Ἀργείᾳ χθονί;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ἦν ὡς μάλιστα, καὶ φάτις πολλὴ κρατεῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="295">μὴ καὶ λόγος τις Ζῆνα μειχθῆναι βροτῷ;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>κἄκρυπτά γ’ Ἥρας ταῦτα τἀμπαλάγματα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς οὖν τελευτᾷ βασιλέων νείκη τάδε;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>βοῦν τὴν γυναῖκ’ ἔθηκεν Ἀργεία θεός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="300">οὔκουν πελάζει Ζεὺς ἐπ’  εὐκραίρῳ βοΐ;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>φασίν, πρέποντα βουθόρῳ ταύρῳ δέμας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δῆτα πρὸς ταῦτ’ ἄλοχος ἰσχυρὰ Διός;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>τὸν πάνθ’ ὁρῶντα φύλακ’ ἐπέστησεν βοΐ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ποῖον πανόπτην οἰοβουκόλον λέγεις;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="305">Ἄργον, τὸν Ἑρμῆς παῖδα γῆς κατέκτανεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί οὖν ἔτευξεν ἄλλο δυσπότμῳ βοΐ;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>βοηλάτην μύωπα κινητήριον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οἶστρον καλοῦσιν αὐτὸν οἱ Νείλου πέλας.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>τοιγάρ νιν ἐκ γῆς ἤλασεν μακρῷ  δρόμῳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="310">καὶ ταῦτ’ ἔλεξας πάντα συγκόλλως ἐμοί.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>καὶ μὴν Κάνωβον κἀπὶ Μέμφιν ἵκετο.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ Ζεύς γ’ ἐφάπτωρ χειρὶ φιτύει γόνον.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>τίς οὖν ὁ Δῖος πόρτις εὔχεται βοός;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="315">Ἔπαφος ἀληθῶς ῥυσίων ἐπώνυμος.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>
 						<gap desc="*"/>
 					</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Λιβύη, μέγιστον γῆς &lt;πέδον&gt; καρπουμένη.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>
 						<gap desc="*"/>
 					</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>
 						<gap desc="*"/>
 					</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>τίν’ οὖν ἔτ’ ἄλλον τῆσδε βλαστημὸν λέγεις;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Βῆλον δίπαιδα πατέρα τοῦδ’ ἐμοῦ πατρός.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="320">τὸ πάνσοφον νῦν ὄνομα τοῦτό μοι φράσον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Δαναός, ἀδελφὸς δ’ ἐστὶ πεντηκοντάπαις.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>καὶ τοῦδ’ ἄνοιγε τοὔνομ’ ἀφθόνῳ λόγῳ.</l>
 					<milestone ed="p" n="323" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Αἴγυπτος.  εἰδὼς δ’ ἁμὸν ἀρχαῖον γένος</l>
 					<l>πράσσοις ἂν ὡς Ἀργεῖον ἀνστήσῃς στόλον.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="325">δοκεῖτε &lt;δή&gt; μοι τῆσδε κοινωνεῖν χθονὸς</l>
 					<l>τἀρχαῖον.  ἀλλὰ πῶς πατρῷα δώματα</l>
 					<l>λιπεῖν ἔτλητε; τίς κατέσκηψεν τύχη;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄναξ Πελασγῶν, αἰόλ’ ἀνθρώπων κακά.</l>
 					<l>πόνου δ’ ἴδοις ἂν οὐδαμοῦ ταὐτὸν πτερόν·</l>
@@ -861,60 +861,60 @@ convert to P3
 					<l>κέλσειν ἐς Ἄργος κῆδος ἐγγενὲς τὸ πρίν,</l>
 					<l>ἔχθει μεταπτοιοῦσαν εὐναίων γάμων;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>τί φὴς ἱκνεῖσθαι τῶνδ’ ἀγωνίων θεῶν,</l>
 					<l>λευκοστεφεῖς ἔχουσα νεοδρέπτους κλάδους;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="335">ὡς μὴ γένωμαι δμωὶς Αἰγύπτου γένει.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>πότερα κατ’ ἔχθραν, ἢ τὸ μὴ θέμις λέγεις;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τίς δ’ ἂν φίλους ὠνοῖτο τοὺς κεκτημένους;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>σθένος μὲν οὕτως μεῖζον αὔξεται βροτοῖς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ δυστυχούντων γ’ εὐμαρὴς ἀπαλλαγή.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="340">πῶς οὖν πρὸς ὑμᾶς εὐσεβὴς ἐγὼ πέλω;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>αἰτοῦσι μὴ ’κδοὺς παισὶν Αἰγύπτου πάλιν.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>βαρέα σύ γ’ εἶπας, πόλεμον ἄρασθαι νέον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἡ δίκη γε ξυμμάχων ὑπερστατεῖ.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>βασιλεύς</speaker>
 					<l>εἴπερ γ’ ἀπ’ ἀρχῆς πραγμάτων κοινωνὸς ἦν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="345">αἰδοῦ σὺ πρύμναν πόλεος ὧδ’ ἐστεμμένην.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>πέφρικα λεύσσων τάσδ’ ἕδρας κατασκίους.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>βαρύς γε μέντοι Ζηνὸς ἱκεσίου κότος.</l>
 					<milestone ed="p" n="348" unit="card"/>
@@ -922,7 +922,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Παλαίχθονος τέκος, κλῦθί μου</l>
 						<l>πρόφρονι καρδίᾳ,   Πελασγῶν ἄναξ.</l>
@@ -932,7 +932,7 @@ convert to P3
 						<l>κε φράζουσα βοτῆρι μόχθους.</l>
 						<milestone ed="p" n="354" unit="card"/>
 					</sp>
-					<sp who="#basileys">
+					<sp who="#basileus">
 						<speaker>Βασιλεύς</speaker>
 						<l>ὁρῶ κλάδοισι νεοδρόποις κατάσκιον</l>
 						<l n="355">νεύονθ’ ὅμιλον τόνδ’ ἀγωνίων θεῶν.</l>
@@ -943,7 +943,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴδοιτο δῆτ’ ἄνατον φυγὰν</l>
 						<l n="360">ἱκεσία Θέμις Διὸς κλαρίου.</l>
@@ -953,7 +953,7 @@ convert to P3
 						<l>θεῶν λήματ’ ἀπ’  ἀνδρὸς ἁγνοῦ.</l>
 						<milestone ed="p" n="365" unit="card"/>
 					</sp>
-					<sp who="#basileys">
+					<sp who="#basileus">
 						<speaker>Βασιλεύς</speaker>
 						<l n="365">οὔτοι κάθησθε δωμάτων ἐφέστιοι</l>
 						<l>ἐμῶν.  τὸ κοινὸν δ’ εἰ μιαίνεται πόλις,</l>
@@ -964,7 +964,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="370">σύ τοι πόλις, σὺ δὲ τὸ δάμιον.</l>
 						<l>πρύτανις ἄκριτος ὤν,</l>
@@ -974,7 +974,7 @@ convert to P3
 						<l n="375">πᾶν ἐπικραίνεις· ἄγος φυλάσσου.</l>
 						<milestone ed="p" n="376" unit="card"/>
 					</sp>
-					<sp who="#basileys">
+					<sp who="#basileus">
 						<speaker>Βασιλεύς</speaker>
 						<l>ἄγος μὲν εἴη τοῖς ἐμοῖς παλιγκότοις,</l>
 						<l>ὑμῖν δ’ ἀρήγειν οὐκ ἔχω βλάβης ἄτερ.</l>
@@ -985,7 +985,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν ὑψόθεν σκοπὸν ἐπισκόπει,</l>
 						<l>φύλακα πολυπόνων</l>
@@ -995,7 +995,7 @@ convert to P3
 						<l>δυσπαραθέλκτους παθόντος οἴκτοις.</l>
 						<milestone ed="p" n="387" unit="card"/>
 					</sp>
-					<sp who="#basileys">
+					<sp who="#basileus">
 						<speaker>Βασιλεύς</speaker>
 						<l>εἴ τοι κρατοῦσι παῖδες Αἰγύπτου σέθεν</l>
 						<l>νόμῳ πόλεως, φάσκοντες ἐγγύτατα γένους</l>
@@ -1006,7 +1006,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μή τί ποτ’ οὖν γενοίμαν ὑποχείριος</l>
 						<l>κράτεσιν ἀρσένων.  ὕπαστρον δέ τοι</l>
@@ -1015,7 +1015,7 @@ convert to P3
 						<l>κρῖνε σέβας τὸ πρὸς θεῶν.</l>
 						<milestone ed="p" n="397" unit="card"/>
 					</sp>
-					<sp who="#basileys">
+					<sp who="#basileus">
 						<speaker>Βασιλεύς</speaker>
 						<l>οὐκ εὔκριτον τὸ κρῖμα. μή μ’ αἱροῦ κριτήν.</l>
 						<l>εἶπον δὲ καὶ πρίν, οὐκ ἄνευ δήμου τάδε</l>
@@ -1026,7 +1026,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀμφοτέρους ὁμαίμων τάδ’ ἐπισκοπεῖ</l>
 						<l>Ζεὺς ἑτερορρεπής, νέμων εἰκότως</l>
@@ -1035,7 +1035,7 @@ convert to P3
 						<l>γεῖς τὸ δίκαιον ἔρξας;</l>
 						<milestone ed="p" n="407" unit="card"/>
 					</sp>
-					<sp who="#basileys">
+					<sp who="#basileus">
 						<speaker>Βασιλεύς</speaker>
 						<l>δεῖ τοι βαθείας φροντίδος σωτηρίου,</l>
 						<l>δίκην κολυμβητῆρος, ἐς βυθὸν μολεῖν</l>
@@ -1052,7 +1052,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φρόντισον καὶ γενοῦ</l>
 						<l>πανδίκως εὐσεβὴς</l>
@@ -1063,7 +1063,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδ’ ἴδῃς μ’ ἐξ ἑδρᾶν</l>
 						<l>πολυθέων ῥυσια‐</l>
@@ -1074,7 +1074,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μή τι τλῇς τὰν ἱκέτιν εἰσιδεῖν</l>
 						<l>ἀπὸ βρετέων βίᾳ</l>
@@ -1085,7 +1085,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴσθι γάρ· παισὶ τάδε καὶ δόμοις,</l>
 						<l>ὁπότερ’ ἂν κτίσῃς,</l>
@@ -1097,7 +1097,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>καὶ δὴ πέφρασμαι. δεῦρο δ’ ἐξοκέλλεται.</l>
 					<l>ἢ τοῖσιν ἢ τοῖς πόλεμον αἴρεσθαι μέγαν</l>
@@ -1117,59 +1117,59 @@ convert to P3
 					<l>θέλω δ’ ἄιδρις μᾶλλον ἢ σοφὸς κακῶν</l>
 					<l>εἶναι. γένοιτο δ’ εὖ παρὰ γνώμην ἐμήν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="455">πολλῶν ἄκουσον τέρματ’ αἰδοίων λόγων.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ἤκουσα, καὶ λέγοις ἄν. οὔ με φεύξεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔχω στρόφους ζώνας τε, συλλαβὰς πέπλων</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>τάχ’ ἂν γυναιξὶ ταῦτα συμπρεπῆ πέλοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐκ τῶνδε τοίνυν, ἴσθι, μηχανὴ καλή—</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="460">λέξον τίν’ αὐδὴν τήνδε γηρυθεῖσ’ ἔσῃ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἰ μή τι πιστὸν τῷδ’ ὑποστήσεις στόλῳ—</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>τί σοι περαίνει μηχανὴ συζωμάτων;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>νέοις πίναξι βρέτεα κοσμῆσαι τάδε.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>αἰνιγματῶδες τοὔπος· ἀλλ’ ἁπλῶς φράσον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="465">ἐκ τῶνδ’ ὅπως τάχιστ’ ἀπάγξασθαι θεῶν.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ἤκουσα μαστικτῆρα καρδίας λόγον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ξυνῆκας· ὠμμάτωσα γὰρ σαφέστερον.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>καὶ πολλαχῇ γε δυσπάλαιστα πράγματα,</l>
 					<l>κακῶν δὲ πλῆθος ποταμὸς ὣς ἐπέρχεται·</l>
@@ -1211,59 +1211,59 @@ convert to P3
 					<l>τρέφει.  φύλαξαι μὴ θράσος τέκῃ φόβον·</l>
 					<l>καὶ δὴ φίλον τις ἔκταν’ ἀγνοίας ὕπο.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="500">στείχοιτ’ ἄν, ἄνδρες· εὖ γὰρ ὁ ξένος λέγει.</l>
 					<l>ἡγεῖσθε βωμοὺς ἀστικούς, θεῶν ἕδρας·</l>
 					<l>καὶ ξυμβολοῦσιν οὐ πολυστομεῖν χρεὼν</l>
 					<l>ναύτην ἄγοντας τόνδ’ ἐφέστιον θεῶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τούτῳ μὲν εἶπας, καὶ τεταγμένος κίοι·</l>
 					<l n="505">ἐγὼ δὲ πῶς δρῶ; ποῦ θράσος νέμεις ἐμοί;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>κλάδους μὲν αὐτοῦ λεῖπε, σημεῖον πόνου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ δή σφε λείπω χειρὶ καὶ λόγοις σέθεν.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>λευρὸν κατ’ ἄλσος νῦν ἐπιστρέφου τόδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ πῶς βέβηλον ἄλσος ἂν ῥύοιτό με;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="510">οὔτοι πτερωτῶν ἁρπαγαῖς &lt;σ’&gt; ἐκδώσομεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εἰ δρακόντων δυσφρόνων ἐχθίοσιν;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>εὔφημον εἴη τοὔπος εὐφημουμένῃ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὔτοι τι θαῦμα δυσφορεῖν φόβῳ φρενός.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ἀεί γ’ ἄναρκτόν ἐστι δεῖμ’ ἐξαίσιον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="515">σὺ καὶ λέγων εὔφραινε καὶ πράσσων φρένα.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ἀλλ’ οὔτι δαρὸν χρόνον ἐρημώσει πατήρ.</l>
 					<l>ἐγὼ δὲ λαοὺς συγκαλῶν ἐγχωρίους</l>
@@ -1278,7 +1278,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄναξ ἀνάκτων, μακάρων</l>
 						<l n="525">μακάρτατε καὶ τελέων</l>
@@ -1291,7 +1291,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ πρὸς γυναικῶν &lt;δ’&gt; ἐπιδὼν</l>
 						<l>παλαίφατον ἁμέτερον</l>
@@ -1304,7 +1304,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παλαιὸν, δ’  εἰς ἴχνος μετέσταν</l>
 						<l>ματέρος ἀνθονόμους ἐπωπάς,</l>
@@ -1319,7 +1319,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰάπτει δ’ Ἀσίδος δῑ  αἴας</l>
 						<l>μηλοβότου Φρυγίας διαμπάξ.</l>
@@ -1334,7 +1334,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἱκνεῖται δὴ σινουμένα βέλει</l>
 						<l>βουκόλου πτερόεντος</l>
@@ -1349,7 +1349,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="565">βροτοὶ δ’, οἳ γᾶς τότ’ ἦσαν ἔννομοι</l>
 						<l>χλωρῷ δείματι θυμὸν</l>
@@ -1364,7 +1364,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δῑ  αἰῶνος κρέων ἀπαύστου</l>
 						<l n="575">Ζεὺς...</l>
@@ -1378,7 +1378,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δῑ αἰῶνος μακροῦ πάνολβον·</l>
 						<l>ἔνθεν πᾶσα βοᾷ χθών,</l>
@@ -1392,7 +1392,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="590">τίν’ ἂν θεῶν ἐνδικωτέροισιν</l>
 						<l>κεκλοίμαν εὐλόγως ἐπ’ ἔργοις;</l>
@@ -1403,7 +1403,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="5" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="595">ὑπ’ ἀρχᾶς δ’ οὔ τινος θοάζων</l>
 						<l>τὸ μεῖον κρεισσόνων κρατύνει.</l>
@@ -1420,7 +1420,7 @@ convert to P3
 					<l n="600">θαρσεῖτε παῖδες. εὖ τὰ τῶν ἐγχωρίων·</l>
 					<l>δήμου δέδοκται παντελῆ ψηφίσματα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ χαῖρε πρέσβυ, φίλτατ’ ἀγγέλλων ἐμοί</l>
 					<l>ἔνισπε δ’ ἡμῖν ποῖ κεκύρωται τέλος,</l>
@@ -1451,7 +1451,7 @@ convert to P3
 					<milestone ed="p" n="625" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="625">ἄγε δή, λέξωμεν ἐπ’ Ἀργείοις</l>
 						<l>εὐχὰς ἀγαθάς, ἀγαθῶν ποινάς.</l>
@@ -1464,7 +1464,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="630">νῦν ὅτε καί, θεοὶ</l>
 						<l>διογενεῖς, κλύοιτ’ εὐ‐</l>
@@ -1483,7 +1483,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδὲ μετ’ ἀρσένων</l>
 						<l>ψῆφον ἔθεντ’ ἀτιμώ‐</l>
@@ -1502,7 +1502,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοιγὰρ ὑποσκίων</l>
 						<l>ἐκ στομάτων ποτά‐</l>
@@ -1519,7 +1519,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>†καὶ γεραροῖσι πρε‐</l>
 						<l>σβυτοδόκοι γεμόν‐</l>
@@ -1536,7 +1536,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδέ τις ἀνδροκμὴς</l>
 						<l>λοιγὸς ἐπελθέτω</l>
@@ -1552,7 +1552,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καρποτελῆ  δέ τοι</l>
 						<l>Ζεὺς ἐπικραινέτω</l>
@@ -1568,7 +1568,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φυλάσσοι τ’ ἀτρεμαῖα τιμὰς</l>
 						<l>τὸ δάμιον, τὸ πτόλιν κρατύνει,</l>
@@ -1580,7 +1580,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θεοὺς δ’, οἳ γᾶν ἔχουσιν  ἀεὶ</l>
 						<l n="705">τίοιεν ἐγχωρίοις πατρῴαις</l>
@@ -1620,7 +1620,7 @@ convert to P3
 					<l>θάρσει· χρόνῳ τοι κυρίῳ τ’ ἐν ἡμέρᾳ</l>
 					<l>θεοὺς ἀτίζων τις βροτῶν δώσει δίκην.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πάτερ, φοβοῦμαι, νῆες ὡς ὠκύπτεροι</l>
 					<l n="735">ἥκουσι· μῆκος δ’ οὐδὲν ἐν μέσῳ χρόνου.</l>
@@ -1638,7 +1638,7 @@ convert to P3
 						<l>ἐπεὶ τελεία ψῆφος Ἀργείων, τέκνα,</l>
 						<l n="740">θάρσει, μαχοῦνται περὶ σέθεν, σάφ’ οἶδ’ ἐγώ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>[Χορός]</speaker>
 						<l>ἐξῶλές ἐστι μάργον Αἰγύπτου γένος</l>
 						<l>μάχης τ’ ἄπληστον·  καὶ λέγω πρὸς εἰδότα.</l>
@@ -1655,7 +1655,7 @@ convert to P3
 						<l>πολλοὺς δέ γ’ εὑρήσουσιν ἐν μεσημβρίας</l>
 						<l>θάλπει βραχίον’ εὖ κατερρινημένους.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>[Χορός]</speaker>
 						<l>μόνην δὲ μὴ πρόλειπε· λίσσομαι, πάτερ.</l>
 						<l>γυνὴ μονωθεῖσ’ οὐδέν· οὐκ ἔνεστ’ Ἄρης.</l>
@@ -1672,7 +1672,7 @@ convert to P3
 						<l>καλῶς ἂν ἡμῖν ξυμφέροι ταῦτ’ ὦ τέκνα,</l>
 						<l>εἰ σοί τε καὶ θεοῖσιν ἐχθαιροίατο.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>[Χορός]</speaker>
 						<l n="755">οὐ μὴ τριαίνας τάσδε καὶ θεῶν σέβη</l>
 						<l>δείσαντες ἡμῶν χεῖρ’ ἀπόσχωνται, πάτερ.</l>
@@ -1692,7 +1692,7 @@ convert to P3
 					<l n="760">ἀλλ’ ἔστι φήμη τοὺς λύκους κρείσσους κυνῶν</l>
 					<l>εἶναι· βύβλου δὲ καρπὸς οὐ κρατεῖ στάχυν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>[Χορός]</speaker>
 					<l>ὡς καὶ ματαίων ἀνοσίων τε κνωδάλων</l>
 					<l>ἔχοντας ὀργάς, χρὴ φυλάσσεσθαι τάχος.</l>
@@ -1719,7 +1719,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ γᾶ βοῦνι, πάνδικον σέβας,</l>
 						<l>τί πεισόμεσθα; ποῖ φύγωμεν Ἀπίας</l>
@@ -1733,7 +1733,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄφυκτον δ’ οὐκέτ’ ἂν πέλοι κακόν·</l>
 						<l n="785">κελαινόχρως δὲ πάλλεταί μου καρδία.</l>
@@ -1747,7 +1747,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πόθεν δέ μοι γένοιτ’ ἂν αἰθέρος θρόνος,</l>
 						<l>πρὸς ὃν νέφη μυδηλὰ γίγνεται χιών,</l>
@@ -1761,7 +1761,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="800">κυσὶν δ’ ἔπειθ’ ἕλωρα κἀπιχωρίοις</l>
 						<l>ὄρνισι δεῖπνον οὐκ ἀναίνομαι πέλειν·</l>
@@ -1775,7 +1775,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴυζε δ’ ὀμφὰν οὐρανίαν</l>
 						<l>&lt;μέλεα&gt; μέλη λιτανὰ θεοῖς·</l>
@@ -1789,7 +1789,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>γένος γὰρ Αἰγύπτειον ὕβριν</l>
 						<l>δύσφορον ἀρσενογενὲς</l>
@@ -1805,7 +1805,7 @@ convert to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<!-- The cries were marked "noparse," as were the obelized words. -->
 						<l n="825">ό ό ό, ά ά ά·</l>
@@ -1821,7 +1821,7 @@ convert to P3
 						<l>γαϊάναξ προτάσσου.†</l>
 						<milestone ed="p" n="836" unit="card"/>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>&lt;Κῆρυξ&gt;</speaker>
 						<l>σοῦσθε σοῦσθ’ ἐπὶ βᾶ‐</l>
 						<l>ριν ὅπως ποδῶν &lt;ἔχετε&gt;</l>
@@ -1836,7 +1836,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>&lt;Χορός &gt;</speaker>
 						<l>εἴθ’  ἀνὰ  πολύρυτον</l>
 						<l>ἁλμήεντα πόρον</l>
@@ -1846,7 +1846,7 @@ convert to P3
 						<l>ησυδουπιάπιτα†</l>
 						<milestone ed="p" n="849" unit="card"/>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>&lt;Κῆρυξ&gt;</speaker>
 						<l>†κελεύω βοᾶν μεθέσθαι</l>
 						<l n="850">ἴχαρ φρενί τ’ ἄταν.†</l>
@@ -1857,7 +1857,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>&lt;Χορός &gt;</speaker>
 						<l>μήποτε πάλιν ἴδοιμ’</l>
 						<l n="855">ἀλφεσίβοιον ὕδωρ,</l>
@@ -1867,7 +1867,7 @@ convert to P3
 						<l n="860">†βαθρείας βαθρείας, γέρον.†</l>
 						<milestone ed="p" n="861" unit="card"/>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>&lt;Κῆρυξ&gt;</speaker>
 						<l>σὺ δ’ ἐν ναῒ ναῒ βάσῃ</l>
 						<l>τάχα θέλεος ἀθέλεος,</l>
@@ -1878,7 +1878,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>&lt;Χορός&gt;</speaker>
 						<l>αἰαῖ αἰαῖ.</l>
 						<l>αἲ γὰρ δυσπαλάμως ὄλοιο</l>
@@ -1898,7 +1898,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>&lt;Χορός&gt;</speaker>
 						<l>οἰοῖ οἰοῖ,</l>
 						<l>λύμας, ᾇ σὺ πρὸ γᾶς ὑλάσκων</l>
@@ -1908,7 +1908,7 @@ convert to P3
 						<l>ψειεν ἄιστον ὕβριν.</l>
 						<milestone ed="p" n="882" unit="card"/>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>Κῆρυξ</speaker>
 						<l>βαίνειν κελεύω βᾶριν εἰς ἀμφίστροφον</l>
 						<l>ὅσον τάχιστα· μηδέ τις σχολαζέτω.</l>
@@ -1917,7 +1917,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="885">οἰοῖ, πάτερ, βρέτεος ἄρος</l>
 						<l>ἀτᾷ μ’·· ἅλαδ’ ἄγει</l>
@@ -1929,7 +1929,7 @@ convert to P3
 						<l>ὦ πᾶ, Γᾶς παῖ, Ζεῦ.</l>
 						<milestone ed="p" n="893" unit="card"/>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>Κῆρυξ</speaker>
 						<l>οὔτοι φοβοῦμαι δαίμονας τοὺς ἐνθάδε·</l>
 						<l>οὐ γάρ μ’ ἔθρεψαν, οὐδ’ ἐγήρασαν τροφῇ.</l>
@@ -1937,7 +1937,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="895">μαιμᾷ πέλας  δίπους ὄφις·</l>
 						<l>
@@ -1954,21 +1954,21 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>εἰ μή τις ἐς ναῦν εἶσιν αἰνέσας τάδε,</l>
 					<l>λακὶς χιτῶνος ἔργον οὐ κατοικτιεῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>διωλόμεσθ’· ἄσεπτ’, ἄναξ, πάσχομεν—</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="905">πολλοὺς ἄνακτας, παῖδας Αἰγύπτου τάχα</l>
 					<l>ὄψεσθε· θαρσεῖτ’, οὐκ ἐρεῖτ’ ἀναρχίαν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>&lt;Χορός&gt;</speaker>
 					<l>ἰὼ πόλεως ἀγοὶ πρόμοι, δάμναμαι.</l>
 				</sp>
@@ -1977,7 +1977,7 @@ convert to P3
 					<l>ἕλξειν ἔοιχ’ ὑμᾶς ἀποσπάσας κόμης,</l>
 					<l n="910">ἐπεὶ οὐκ ἀκούετ’ ὀξὺ τῶν ἐμῶν λόγων.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>οὗτος, τί ποιεῖς; ἐκ ποίου φρονήματος</l>
 					<l>ἀνδρῶν Πελασγῶν τήνδ’ ἀτιμάζεις χθόνα;</l>
@@ -1985,64 +1985,64 @@ convert to P3
 					<l>κάρβανος ὢν δ’ Ἕλλησιν ἐγχλίεις ἄγαν·</l>
 					<l n="915">καὶ πόλλ’ ἁμαρτὼν οὐδὲν ὤρθωσας φρενί.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>τί δ’ ἠμπλάκηται τῶνδ’ ἐμοὶ δίκης ἄτερ;</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ξένος μὲν εἶναι πρῶτον οὐκ ἐπίστασαι.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>πῶς δ’ οὐχί; τἄμ’ ὀλωλόθ’ εὑρίσκων ἄγω.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ποίοισιν εἰπὼν προξένοις ἐγχωρίοις;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="920">Ἑρμῇ μεγίστῳ προξένῳ μαστηρίῳ.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>θεοῖσιν εἰπὼν τοὺς θεοὺς οὐδὲν σέβῃ.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>τοὺς ἀμφὶ Νεῖλον δαίμονας σεβίζομαι.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>οἱ δ’ ἐνθάδ’ οὐδέν, ὡς ἐγὼ σέθεν κλύω;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἄγοιμ’ ἄν, εἴ τις τάσδε μὴ ’ξαιρήσεται.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l n="925">κλάοις ἄν, εἰ ψαύσειας, οὐ μάλ’ ἐς μακράν.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἤκουσα τοὔπος &lt;δ’&gt; οὐδαμῶς φιλόξενον.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>οὐ γὰρ ξενοῦμαι τοὺς θεῶν συλήτορας.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>λέγοιμ’ ἂν ἐλθὼν παισὶν Αἰγύπτου τάδε.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>Βασιλεύς</speaker>
 					<l>ἀβουκόλητον τοῦτ’ ἐμῷ, φρονήματι.</l>
 					<milestone ed="p" n="930" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="930">ἀλλ’ ὡς ἂν εἰδὼς ἐννέπω σαφέστερον,—</l>
 					<l>καὶ γὰρ πρέπει κήρυκ’ ἀπαγγέλλειν τορῶς</l>
@@ -2053,7 +2053,7 @@ convert to P3
 					<l>ἔλυσεν· ἀλλὰ πολλὰ γίγνεται πάρος</l>
 					<l>πεσήματ’ ἀνδρῶν κἀπολακτισμοὶ βίου.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>&lt;Βασιλεύς&gt;</speaker>
 					<l>τί σοι λέγειν χρὴ τοὔνομ’; ἐν χρόνῳ μαθὼν</l>
 					<l>εἴσῃ σύ τ’ αὐτὸς χοἰ ξυνέμποροι σέθεν.</l>
@@ -2068,12 +2068,12 @@ convert to P3
 					<l>σαφῆ δ’ ἀκούεις ἐξ ἐλευθεροστόμου</l>
 					<l>γλώσσης.  κομίζου δ’ ὡς τάχιστ’ ἐξ ὀμμάτων.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>&lt;Κῆρυξ&gt;</speaker>
 					<l n="950">ἔοιγμεν ἤδη πόλεμον ἀρεῖσθαι νέον.</l>
 					<l>εἴη δὲ νίκη καὶ κράτη τοῖς ἄρσεσιν.</l>
 				</sp>
-				<sp who="#basileys">
+				<sp who="#basileus">
 					<speaker>&lt;Βασιλεύς&gt;</speaker>
 					<l>ἀλλ’ ἄρσενάς τοι τῆσδε γῆς οἰκήτορας</l>
 					<l>εὑρήσετ’ οὐ πίνοντας ἐκ κριθῶν μέθυ.</l>
@@ -2092,7 +2092,7 @@ convert to P3
 					<milestone ed="p" n="966" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἀντ’ ἀγαθῶν ἀγαθοῖσι βρύοις,</l>
 						<l>δῖε Πελασγῶν.</l>
@@ -2152,7 +2152,7 @@ convert to P3
 						<l>μόνον φύλαξαι τάσδ’ ἐπιστολὰς πατρός,</l>
 						<l>τὸ σωφρονεῖν τιμῶσα τοῦ βίου πλέον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τἄλλ’ εὐτυχοῖμεν πρὸς θεῶν Ὀλυμπίων.</l>
 						<l n="1015">ἐμῆς δ’ ὀπώρας οὕνεκ’ εὖ θάρσει, πάτερ.</l>
@@ -2262,7 +2262,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>&lt;Χορός&gt;</speaker>
 						<l>Ζεὺς ἄναξ ἀποστεροί‐</l>
 						<l>η γάμον δυσάνορα</l>
@@ -2274,7 +2274,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>&lt;Χορός&gt;</speaker>
 						<l>καὶ κράτος νέμοι γυναι‐</l>
 						<l>ξίν· τὸ βέλτερον κακοῦ</l>

--- a/tei/aeschylus-suppliant-women.xml
+++ b/tei/aeschylus-suppliant-women.xml
@@ -58,7 +58,7 @@
 						<name>Χορός Δαναΐδων</name>
 					</personGrp>
 					<person xml:id="keryx">
-						<persName>Κῆρυχ</persName>
+						<persName>Κῆρυξ</persName>
 					</person>
 					<person xml:id="basileus">
 						<persName>βασιλεύς</persName>
@@ -66,9 +66,6 @@
 					<personGrp xml:id="xorostherapainon">
 						<name>Χορός Θεραπαινῶν</name>
 					</personGrp>
-					<person xml:id="keryx">
-						<persName>Κῆρυξ</persName>
-					</person>
 					<person xml:id="danaos">
 						<persName>Δαναός</persName>
 					</person>
@@ -1889,7 +1886,7 @@ convert to P3
 						<milestone ed="p" n="872" unit="card"/>
 					</sp>
 					<sp who="#keryx">
-						<speaker>Κῆρυχ</speaker>
+						<speaker>Κῆρυξ</speaker>
 						<l>ἴυζε καὶ λάκαζε καὶ κάλει θεούς.</l>
 						<l>Αἰγυπτίαν γὰρ βᾶριν οὐχ ὑπερθορῇ.</l>
 						<l>[ἴυζε καὶ]</l>
@@ -1973,7 +1970,7 @@ convert to P3
 					<l>ἰὼ πόλεως ἀγοὶ πρόμοι, δάμναμαι.</l>
 				</sp>
 				<sp who="#keryx">
-					<speaker>&lt;Κῆρυχ&gt;</speaker>
+					<speaker>&lt;Κῆρυξ&gt;</speaker>
 					<l>ἕλξειν ἔοιχ’ ὑμᾶς ἀποσπάσας κόμης,</l>
 					<l n="910">ἐπεὶ οὐκ ἀκούετ’ ὀξὺ τῶν ἐμῶν λόγων.</l>
 				</sp>

--- a/tei/aristophanes-acharnians.xml
+++ b/tei/aristophanes-acharnians.xml
@@ -52,19 +52,19 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="nikarxos">
+					<person xml:id="nikarchos">
 						<persName>Νίκαρχος</persName>
 					</person>
-					<person xml:id="aggelosa">
+					<person xml:id="angelos_a">
 						<persName>Ἄγγελος Α</persName>
 					</person>
 					<person xml:id="dr">
 						<persName>Δρ.</persName>
 					</person>
-					<person xml:id="eyripides">
+					<person xml:id="euripides">
 						<persName>Εὐριπίδης</persName>
 					</person>
-					<person xml:id="amfitheos">
+					<person xml:id="amphitheos">
 						<persName>Ἀμφίθεος</persName>
 					</person>
 					<person xml:id="thygater">
@@ -73,43 +73,43 @@
 					<person xml:id="georgos">
 						<persName>Γεωργός</persName>
 					</person>
-					<person xml:id="keryks">
+					<person xml:id="keryx">
 						<persName>Κῆρυξ</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="sykofantes">
+					<person xml:id="sykophantes">
 						<persName>Συκοφάντης</persName>
 					</person>
-					<person xml:id="pseydartabas">
+					<person xml:id="pseudartabas">
 						<persName>Ψευδαρτάβας</persName>
 					</person>
-					<person xml:id="paranymfos">
+					<person xml:id="paranymphos">
 						<persName>Παράνυμφος</persName>
 					</person>
 					<person xml:id="dikaiopolis">
 						<persName>Δικαιόπολις</persName>
 					</person>
-					<person xml:id="theraponlamaxoy">
+					<person xml:id="therapon_lamachou">
 						<persName>Θεράπων Λαμάχου</persName>
 					</person>
 					<person xml:id="presbys">
 						<persName>Πρέσβυς</persName>
 					</person>
-					<person xml:id="megareys">
+					<person xml:id="megareus">
 						<persName>Μεγαρεύς</persName>
 					</person>
-					<person xml:id="emixorionb">
-						<persName>Ἡμιχόριον Β</persName>
-					</person>
-					<person xml:id="emixoriona">
-						<persName>Ἡμιχόριον Α</persName>
-					</person>
+					<personGrp xml:id="hemichorion_a">
+						<name>Ἡμιχόριον Α</name>
+					</personGrp>
+					<personGrp xml:id="hemichorion_b">
+						<name>Ἡμιχόριον Β</name>
+					</personGrp>
 					<person xml:id="boiotos">
 						<persName>Βοιωτός</persName>
 					</person>
-					<person xml:id="lamaxos">
+					<person xml:id="lamachos">
 						<persName>Λάμαχος</persName>
 					</person>
 					<person xml:id="kora">
@@ -121,13 +121,13 @@
 					<person xml:id="theoros">
 						<persName>Θέωρος</persName>
 					</person>
-					<person xml:id="aggelosb">
+					<person xml:id="angelos_b">
 						<persName>Ἄγγελος Β</persName>
 					</person>
 					<person xml:id="dikaiopolos">
 						<persName>Δικαιόπολος</persName>
 					</person>
-					<person xml:id="kefisofon">
+					<person xml:id="kephisophon">
 						<persName>Κηφισόφων</persName>
 					</person>
 				</listPerson>
@@ -253,36 +253,36 @@ convert to P3
 					<l>ἐς τὴν προεδρίαν πᾶς ἀνὴρ ὠστίζεται.</l>
 					<milestone ed="p" n="43" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>πάριτ’ ἐς τὸ πρόσθεν,</l>
 					<l>πάριθ’, ὡς ἂν ἐντὸς ἦτε τοῦ καθάρματος.</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l n="45">ἤδη τις εἶπε;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l part="Y">τίς ἀγορεύειν βούλεται;</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l>ἐγώ.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l part="Y">τίς ὤν;</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l part="Y">Ἀμφίθεος.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l part="Y">οὐκ ἄνθρωπος;</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l part="Y">οὔ,</l>
 					<l>ἀλλ’ ἀθάνατος. ὁ γὰρ Ἀμφίθεος Δήμητρος ἦν</l>
@@ -294,11 +294,11 @@ convert to P3
 					<l>ἀλλ’ ἀθάνατος ὢν ὦνδρες ἐφόδῑ οὐκ ἔχω·</l>
 					<l>οὐ γὰρ διδόασιν οἱ πρυτάνεις.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l part="Y">οἱ τοξόται.</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l n="55">ὦ Τριπτόλεμε καὶ Κελεὲ περιόψεσθέ με;</l>
 				</sp>
@@ -308,7 +308,7 @@ convert to P3
 					<l>τὸν ἄνδρ’ ἀπάγοντες, ὅστις ἡμῖν ἤθελε</l>
 					<l>σπονδὰς ποιεῖσθαι καὶ κρεμάσαι τὰς ἀσπίδας.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>κάθησο, σῖγα.</l>
 				</sp>
@@ -317,7 +317,7 @@ convert to P3
 					<l part="Y">μὰ τὸν Ἀπόλλω ’γὼ μὲν οὔ,</l>
 					<l n="60">ἢν μὴ περὶ εἰρήνης γε πρυτανεύσητέ μοι.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>οἱ πρέσβεις οἱ παρὰ βασιλέως.</l>
 				</sp>
@@ -326,7 +326,7 @@ convert to P3
 					<l>ποίου βασιλέως; ἄχθομαι ’γὼ πρέσβεσιν</l>
 					<l>καὶ τοῖς ταὧσι τοῖς τ’ ἀλαζονεύμασιν.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>σίγα.</l>
 				</sp>
@@ -417,7 +417,7 @@ convert to P3
 					<l part="Y">ἐκκόψειέ γε</l>
 					<l>κόραξ πατάξας, τόν τε σὸν τοῦ πρέσβεως.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ὁ βασιλέως ὀφθαλμός.</l>
 				</sp>
@@ -434,7 +434,7 @@ convert to P3
 					<l>λέξοντ’ Ἀθηναίοισιν ὦ Ψευδαρτάβα.</l>
 					<milestone ed="p" n="100" unit="card"/>
 				</sp>
-				<sp who="#pseydartabas">
+				<sp who="#pseudartabas">
 					<speaker>Ψευδαρτάβας</speaker>
 					<l n="100">ἰαρταμὰν ἐξάρξαν ἀπισσόνα σάτρα.</l>
 				</sp>
@@ -451,7 +451,7 @@ convert to P3
 					<l>πέμψειν βασιλέα φησὶν ὑμῖν χρυσίον.</l>
 					<l>λέγε δὴ σὺ μεῖζον καὶ σαφῶς τὸ χρυσίον.</l>
 				</sp>
-				<sp who="#pseydartabas">
+				<sp who="#pseudartabas">
 					<speaker>Ψευδαρτάβας</speaker>
 					<l n="104">οὐ λῆψι χρῦσο χαυνόπρωκτ’ Ἰαοναῦ.</l>
 				</sp>
@@ -489,7 +489,7 @@ convert to P3
 					<l>εὐνοῦχος ἡμῖν ἦλθες ἐσκευασμένος;</l>
 					<l>ὁδὶ δὲ τίς ποτ’ ἐστίν; οὐ δήπου Στράτων;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>σίγα, κάθιζε.</l>
 					<l n="124">τὸν βασιλέως ὀφθαλμὸν ἡ βουλὴ καλεῖ</l>
@@ -503,7 +503,7 @@ convert to P3
 					<l>ἀλλ’ ἐργάσομαί τι δεινὸν ἔργον καὶ μέγα.</l>
 					<l>ἀλλ’ Ἀμφίθεός μοι ποῦ ’στιν;</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l part="Y">οὑτοσὶ πάρα.</l>
 				</sp>
@@ -515,7 +515,7 @@ convert to P3
 					<l>ὑμεῖς δὲ πρεσβεύεσθε καὶ κεχήνετε.</l>
 					<milestone ed="p" n="134" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>προσίτω Θέωρος ὁ παρὰ Σιτάλκους.</l>
 				</sp>
@@ -566,7 +566,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l part="Y">τοῦτο μέν γ’ ἤδη σαφές.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="155">οἱ Θρᾷκες ἴτε δεῦρ’, οὓς Θέωρος ἤγαγεν.</l>
 				</sp>
@@ -610,7 +610,7 @@ convert to P3
 					<l>διοσημία ’στὶ καὶ ῥανὶς βέβληκέ με.</l>
 					<milestone ed="p" n="172" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>τοὺς Θρᾷκας ἀπιέναι, παρεῖναι δ’ εἰς ἔνην.</l>
 					<l>οἱ γὰρ πρυτάνεις λύουσι τὴν ἐκκλησίαν.</l>
@@ -621,7 +621,7 @@ convert to P3
 					<l n="175">ἀλλ’ ἐκ Λακεδαίμονος γὰρ Ἀμφίθεος ὁδί.</l>
 					<l>χαῖρ’ Ἀμφίθεε.</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l part="Y">μήπω γε πρίν γ’ ἂν στῶ τρέχων·</l>
 					<l>δεῖ γάρ με φεύγοντ’ ἐκφυγεῖν Ἀχαρνέας.</l>
@@ -630,7 +630,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>τί δ’ ἔστ’;</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l part="Y">ἐγὼ μὲν δεῦρό σοι σπονδὰς φέρων</l>
 					<l>ἔσπευδον· οἱ δ’ ὤσφροντο πρεσβῦταί τινες</l>
@@ -645,7 +645,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>οἱ δ’ οὖν βοώντων· ἀλλὰ τὰς σπονδὰς φέρεις;</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l>ἔγωγέ φημι, τρία γε ταυτὶ γεύματα.</l>
 					<l>αὗται μέν εἰσι πεντέτεις. γεῦσαι λαβών.</l>
@@ -654,7 +654,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>αἰβοῖ.</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l part="Y">τί ἔστιν;</l>
 				</sp>
@@ -663,7 +663,7 @@ convert to P3
 					<l part="Y">οὐκ ἀρέσκουσίν μ’ ὅτι</l>
 					<l n="190">ὄζουσι πίττης καὶ παρασκευῆς νεῶν.</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l>σὺ δ’ ἀλλὰ τασδὶ τὰς δεκέτεις γεῦσαι λαβών.</l>
 				</sp>
@@ -672,7 +672,7 @@ convert to P3
 					<l>ὄζουσι χαὖται πρέσβεων ἐς τὰς πόλεις</l>
 					<l>ὀξύτατον ὥσπερ διατριβῆς τῶν ξυμμάχων.</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l>ἀλλ’ αὑταιὶ σπονδαὶ τριακοντούτιδες</l>
 					<l n="195">κατὰ γῆν τε καὶ θάλατταν.</l>
@@ -688,7 +688,7 @@ convert to P3
 					<l>ἐγὼ δὲ πολέμου καὶ κακῶν ἀπαλλαγεὶς</l>
 					<l>ἄξω τὰ κατ’ ἀγροὺς εἰσιὼν Διονύσια.</l>
 				</sp>
-				<sp who="#amfitheos">
+				<sp who="#amphitheos">
 					<speaker>Ἀμφίθεος</speaker>
 					<l>ἐγὼ δὲ φευξοῦμαί γε τοὺς Ἀχαρνέας.</l>
 					<milestone ed="p" n="204" unit="card"/>
@@ -696,7 +696,7 @@ convert to P3
 			</div1>
 			<div1 type="Parodos">
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τῇδε πᾶς ἕπου δίωκε καὶ τὸν ἄνδρα πυνθάνου</l>
 						<l n="205">τῶν ὁδοιπόρων ἁπάντων· τῇ πόλει γὰρ ἄξιον</l>
@@ -706,7 +706,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐκπέφευγ’, οἴχεται φροῦδος. οἴμοι τάλας</l>
 						<l n="210">τῶν ἐτῶν τῶν ἐμῶν·</l>
@@ -718,7 +718,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν δ’ ἐπειδὴ στερρὸν ἤδη τοὐμὸν ἀντικνήμιον,</l>
 						<l n="220">καὶ παλαιῷ Λακρατείδῃ τὸ σκέλος βαρύνεται,</l>
@@ -728,7 +728,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="225">ὅστις ὦ Ζεῦ πάτερ καὶ θεοὶ τοῖσιν ἐχθροῖσιν ἐσπείσατο,</l>
 						<l>οἷσι παρ’ ἐμοῦ πόλεμος ἐχθοδοπὸς αὔξεται τῶν ἐμῶν χωρίων·</l>
@@ -740,7 +740,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ δεῖ ζητεῖν τὸν ἄνδρα καὶ βλέπειν βαλληνάδε</l>
 						<l n="235">καὶ διώκειν γῆν πρὸ γῆς, ἕως ἂν εὑρεθῇ ποτέ·</l>
@@ -750,7 +750,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>εὐφημεῖτε, εὐφημεῖτε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σῖγα πᾶς. ἠκούσατ’ ἄνδρες ἆρα τῆς εὐφημίας;</l>
 						<l>οὗτος αὐτός ἐστιν ὃν ζητοῦμεν. ἀλλὰ δεῦρο πᾶς</l>
@@ -818,7 +818,7 @@ convert to P3
 			</div1>
 			<div1 type="Parodos">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="280">οὗτος αὐτός ἐστιν, οὗτος.</l>
 						<l>βάλλε βάλλε βάλλε βάλλε,</l>
@@ -832,7 +832,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>Ἡράκλεις τουτὶ τί ἐστι; τὴν χύτραν συντρίψετε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="285">σὲ μὲν οὖν καταλεύσομεν ὦ μιαρὰ κεφαλή.</l>
 					</sp>
@@ -840,7 +840,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀντὶ ποίας αἰτίας ὦχαρνέων γεραίτατοι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοῦτ’ ἐρωτᾷς; ἀναίσχυντος εἶ καὶ βδελυρὸς</l>
 						<l n="290">ὦ προδότα τῆς πατρίδος, ὅστις ἡμῶν μόνος</l>
@@ -850,7 +850,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀντὶ δ’ ὧν ἐσπεισάμην οὐκ ἴστε. μἀλλᾱ ἀκούσατε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="295">σοῦ γ’ ἀκούσωμεν; ἀπολεῖ· κατά σε χώσομεν τοῖς λίθοις.</l>
 					</sp>
@@ -858,7 +858,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>μηδαμῶς πρὶν ἄν γ’ ἀκούσητ’· ἀλλ’ ἀνάσχεσθ’ ὦγαθοί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἀνασχήσομαι· μηδὲ λέγε μοι σὺ λόγον·</l>
 						<l n="300">ὡς μεμίσηκά σε Κλέωνος ἔτι μᾶλλον, ὃν ἐγὼ</l>
@@ -867,7 +867,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σοῦ δ’ ἐγὼ λόγους λέγοντος οὐκ ἀκούσομαι μακρούς,</l>
 						<l>ὅστις ἐσπείσω Λάκωσιν, ἀλλὰ τιμωρήσομαι.</l>
@@ -877,7 +877,7 @@ convert to P3
 						<l n="305">ὦγαθοὶ τοὺς μὲν Λάκωνας ἐκποδὼν ἐάσατε,</l>
 						<l>τῶν δ’ ἐμῶν σπονδῶν ἀκούσατ’, εἰ καλῶς ἐσπεισάμην.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς δέ γ’ ἂν καλῶς λέγοις ἄν, εἴπερ ἐσπείσω γ’ ἅπαξ</l>
 						<l>οἷσιν οὔτε βωμὸς οὔτε πίστις οὔθ’ ὅρκος μένει;</l>
@@ -887,7 +887,7 @@ convert to P3
 						<l>οἶδ’ ἐγὼ καὶ τοὺς Λάκωνας, οἷς ἄγαν ἐγκείμεθα,</l>
 						<l n="310">οὐχ ἁπάντων ὄντας ἡμῖν αἰτίους τῶν πραγμάτων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐχ ἁπάντων ὦ πανοῦργε; ταῦτα δὴ τολμᾷς λέγειν</l>
 						<l>ἐμφανῶς ἤδη πρὸς ἡμᾶς; εἶτ’ ἐγώ σου φείσομαι;</l>
@@ -897,7 +897,7 @@ convert to P3
 						<l>οὐχ ἁπάντων, οὐχ ἁπάντων· ἀλλ’ ἐγὼ λέγων ὁδὶ</l>
 						<l>πόλλ’ ἂν ἀποφήναιμ’ ἐκείνους ἔσθ’ ἃ κἀδικουμένους.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="315">τοῦτο τοὔπος δεινὸν ἤδη καὶ ταραξικάρδιον,</l>
 						<l>εἰ σὺ τολμήσεις ὑπὲρ τῶν πολεμίων ἡμῖν λέγειν.</l>
@@ -907,7 +907,7 @@ convert to P3
 						<l>κἄν γε μὴ λέγω δίκαια μηδὲ τῷ πλήθει δοκῶ,</l>
 						<l>ὑπὲρ ἐπιξήνου ’θελήσω τὴν κεφαλὴν ἔχων λέγειν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰπέ μοι τί φειδόμεσθα τῶν λίθων ὦ δημόται</l>
 						<l n="320">μὴ οὐ καταξαίνειν τὸν ἄνδρα τοῦτον ἐς φοινικίδα;</l>
@@ -917,7 +917,7 @@ convert to P3
 						<l>οἷον αὖ μέλας τις ὑμῖν θυμάλωψ ἐπέζεσεν.</l>
 						<l>οὐκ ἀκούσεσθ’; οὐκ ἀκούσεσθ’ ἐτεὸν ὦχαρνηίδαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἀκουσόμεσθα δῆτα.</l>
 					</sp>
@@ -925,7 +925,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">δεινά τἄρα πείσομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐξολοίμην, ἢν ἀκούσω.</l>
 					</sp>
@@ -933,7 +933,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">μηδαμῶς ὦχαρνικοί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς τεθνήξων ἴσθι νυνί.</l>
 					</sp>
@@ -943,7 +943,7 @@ convert to P3
 						<l n="326">ἀνταποκτενῶ γὰρ ὑμῶν τῶν φίλων τοὺς φιλτάτους·</l>
 						<l>ὡς ἔχω γ’ ὑμῶν ὁμήρους, οὓς ἀποσφάξω λαβών.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰπέ μοι, τί τοῦτ’ ἀπειλεῖ τοὔπος ἄνδρες δημόται</l>
 						<l>τοῖς Ἀχαρνικοῖσιν ἡμῖν; μῶν ἔχει του παιδίον</l>
@@ -954,7 +954,7 @@ convert to P3
 						<l>βάλλετ’ εἰ βούλεσθ’. ἐγὼ γὰρ τουτονὶ διαφθερῶ.</l>
 						<l>εἴσομαι δ’ ὑμῶν τάχ’ ὅστις ἀνθράκων τι κήδεται.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς ἀπωλόμεσθ’. ὁ λάρκος δημότης ὅδ’ ἔστ’ ἐμός.</l>
 						<l>ἀλλὰ μὴ δράσῃς ὃ μέλλεις· μηδαμῶς ὦ μηδαμῶς.</l>
@@ -966,7 +966,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ὡς ἀποκτενῶ, κέκραχθ’· ἐγὼ γὰρ οὐκ ἀκούσομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="336">ἀπολεῖς ἄρ’ ὁμήλικα τόνδε φιλανθρακέα;</l>
 					</sp>
@@ -974,7 +974,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>οὐδ’ ἐμοῦ λέγοντος ὑμεῖς ἀρτίως ἠκούσατε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ γὰρ νῦν λέγ’, εἴ σοι δοκεῖ, τόν τε Λακεδαιμόνιον</l>
 						<l>† αὐτὸν ὅτι τῷ † τρόπῳ σοὐστὶ φίλος·</l>
@@ -984,7 +984,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τοὺς λίθους νύν μοι χαμᾶζε πρῶτον ἐξεράσατε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὑτοιί σοι χαμαί, καὶ σὺ κατάθου πάλιν τὸ ξίφος.</l>
 					</sp>
@@ -992,7 +992,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀλλ’ ὅπως μὴ ν’ τοῖς τρίβωσιν ἐγκάθηνταί που λίθοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐκσέσεισται χαμᾶζ’· οὐχ ὁρᾷς σειόμενον;</l>
 						<l n="345">ἀλλὰ μή μοι πρόφασιν, ἀλλὰ κατάθου τὸ βέλος.</l>
@@ -1018,7 +1018,7 @@ convert to P3
 					<milestone ed="p" n="358" unit="card"/>
 				</sp>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί οὖν οὐ λέγεις, ἐπίξηνον ἐξενεγκὼν θύραζ’,</l>
 						<l n="360">ὅ τι ποτ’ ὦ σχέτλιε τὸ μέγα τοῦτ’ ἔχεις;</l>
@@ -1054,7 +1054,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί ταῦτα στρέφει τεχνάζεις τε καὶ πορίζεις τριβάς;</l>
 						<l n="386">λαβὲ δ’ ἐμοῦ γ’ ἓνεκα παρ’ Ἱερωνύμου</l>
@@ -1071,7 +1071,7 @@ convert to P3
 						<l>καί μοι βαδιστέ’ ἐστὶν ὡς Εὐριπίδην.</l>
 						<l n="395">παῖ παῖ.</l>
 					</sp>
-					<sp who="#kefisofon">
+					<sp who="#kephisophon">
 						<speaker>Κηφισόφων</speaker>
 						<l part="Y">τίς οὗτος,</l>
 					</sp>
@@ -1079,7 +1079,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">ἔνδον ἔστ’ Εὐριπίδης;</l>
 					</sp>
-					<sp who="#kefisofon">
+					<sp who="#kephisophon">
 						<speaker>Κηφισόφων</speaker>
 						<l>οὐκ ἔνδον ἔνδον ἐστίν, εἰ γνώμην ἔχεις.</l>
 					</sp>
@@ -1087,7 +1087,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>πῶς ἔνδον εἶτ’ οὐκ ἔνδον;</l>
 					</sp>
-					<sp who="#kefisofon">
+					<sp who="#kephisophon">
 						<speaker>Κηφισόφων</speaker>
 						<l part="Y">ὀρθῶς ὦ γέρον.</l>
 						<l>ὁ νοῦς μὲν ἔξω ξυλλέγων ἐπύλλια</l>
@@ -1100,7 +1100,7 @@ convert to P3
 						<l>ὅθ’ ὁ δοῦλος οὑτωσὶ σαφῶς ἀπεκρίνατο.</l>
 						<l>ἐκκάλεσον αὐτόν.</l>
 					</sp>
-					<sp who="#kefisofon">
+					<sp who="#kephisophon">
 						<speaker>Κηφισόφων</speaker>
 						<l part="Y">ἀλλ’ ἀδύνατον.</l>
 					</sp>
@@ -1113,7 +1113,7 @@ convert to P3
 						<l>Δικαιόπολις καλεῖ σε Χολλῄδης, ἐγώ.</l>
 						<milestone ed="p" n="407" unit="card"/>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀλλ’ οὐ σχολή.</l>
 					</sp>
@@ -1121,7 +1121,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀλλ’ ἐκκυκλήθητ’.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ἀλλ’ ἀδύνατον.</l>
 					</sp>
@@ -1129,7 +1129,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">ἀλλ’ ὅμως.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀλλ’ ἐκκυκλήσομαι· καταβαίνειν δ’ οὐ σχολή.</l>
 					</sp>
@@ -1137,7 +1137,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>Εὐριπίδη,</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τί λέλακας;</l>
 					</sp>
@@ -1152,7 +1152,7 @@ convert to P3
 						<l>δεῖ γάρ με λέξαι τῷ χορῷ ῥῆσιν μακράν·</l>
 						<l>αὕτη δὲ θάνατον, ἢν κακῶς λέξω, φέρει.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τὰ ποῖα τρύχη; μῶν ἐν οἷς Οἰνεὺς ὁδὶ</l>
 						<l>ὁ δύσποτμος γεραιὸς ἠγωνίζετο;</l>
@@ -1161,7 +1161,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l n="420">οὐκ Οἰνέως ἦν, ἀλλ’ ἔτ’ ἀθλιωτέρου.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τὰ τοῦ τυφλοῦ Φοίνικος;</l>
 					</sp>
@@ -1170,7 +1170,7 @@ convert to P3
 						<l part="Y">οὐ Φοίνικος, οὔ·</l>
 						<l>ἀλλ’ ἕτερος ἦν Φοίνικος ἀθλιώτερος.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ποίας ποθ’ ἁνὴρ λακίδας αἰτεῖται πέπλων;</l>
 						<l>ἀλλ’ ἦ Φιλοκτήτου τὰ τοῦ πτωχοῦ λέγεις;</l>
@@ -1179,7 +1179,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l n="425">οὐκ ἀλλὰ τούτου πολὺ πολὺ πτωχιστέρου.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀλλ’ ἦ τὰ δυσπινῆ ’θέλεις πεπλώματα,</l>
 						<l>ἃ Βελλεροφόντης εἶχ’ ὁ χωλὸς οὑτοσί;</l>
@@ -1189,7 +1189,7 @@ convert to P3
 						<l>οὐ Βελλεροφόντης· ἀλλὰ κἀκεῖνος μὲν ἦν</l>
 						<l>χωλὸς προσαιτῶν στωμύλος δεινὸς λέγειν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="430">οἶδ’ ἄνδρα Μυσὸν Τήλεφον.</l>
 					</sp>
@@ -1198,13 +1198,13 @@ convert to P3
 						<l part="Y">ναὶ Τήλεφον·</l>
 						<l>τούτου δὸς ἀντιβολῶ σέ μοι τὰ σπάργανα.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὦ παῖ δὸς αὐτῷ Τηλέφου ῥακώματα.</l>
 						<l>κεῖται δ’ ἄνωθεν τῶν Θυεστείων ῥακῶν</l>
 						<l>μεταξὺ τῶν Ἰνοῦς.</l>
 					</sp>
-					<sp who="#kefisofon">
+					<sp who="#kephisophon">
 						<speaker>Κηφισόφων</speaker>
 						<l part="Y">ἰδοὺ ταυτὶ λαβέ.</l>
 					</sp>
@@ -1221,7 +1221,7 @@ convert to P3
 						<l>τοὺς δ’ αὖ χορευτὰς ἠλιθίους παρεστάναι,</l>
 						<l>ὅπως ἂν αὐτοὺς ῥηματίοις σκιμαλίσω.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="445">δώσω· πυκνῇ γὰρ λεπτὰ μηχανᾷ φρενί.</l>
 					</sp>
@@ -1231,7 +1231,7 @@ convert to P3
 						<l>εὖ γ’ οἷον ἤδη ῥηματίων ἐμπίμπλαμαι.</l>
 						<l>ἀτὰρ δέομαί γε πτωχικοῦ βακτηρίου.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τουτὶ λαβὼν ἄπελθε λαΐνων σταθμῶν.</l>
 					</sp>
@@ -1243,7 +1243,7 @@ convert to P3
 						<l>δός μοι σπυρίδιον διακεκαυμένον λύχνῳ.</l>
 						<milestone ed="p" n="454" unit="card"/>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τί δ’ ὦ τάλας σε τοῦδ’ ἔχει πλέκους χρέος;</l>
 					</sp>
@@ -1251,7 +1251,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l n="455">χρέος μὲν οὐδέν, βούλομαι δ’ ὅμως λαβεῖν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>λυπηρὸς ἴσθ’ ὢν κἀποχώρησον δόμων.</l>
 					</sp>
@@ -1260,7 +1260,7 @@ convert to P3
 						<l>φεῦ·</l>
 						<l>εὐδαιμονοίης, ὥσπερ ἡ μήτηρ ποτέ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἄπελθε νῦν μοι.</l>
 					</sp>
@@ -1269,7 +1269,7 @@ convert to P3
 						<l part="Y">μἀλλά μοι δὸς ἓν μόνον</l>
 						<l>κοτυλίσκιον τὸ χεῖλος ἀποκεκρουσμένον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="460">φθείρου λαβὼν τόδ’· ἴσθ’ ὀχληρὸς ὢν δόμοις.</l>
 					</sp>
@@ -1279,7 +1279,7 @@ convert to P3
 						<l>ἀλλ’ ὦ γλυκύτατ’ Εὐριπίδη τουτὶ μόνον</l>
 						<l>δός μοι χυτρίδιον σφογγίῳ βεβυσμένον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὦνθρωπ’ ἀφαιρήσει με τὴν τραγῳδίαν·</l>
 						<l n="465">ἄπελθε ταυτηνὶ λαβών.</l>
@@ -1292,7 +1292,7 @@ convert to P3
 						<l>τουτὶ λαβὼν ἄπειμι κοὐ πρόσειμ’ ἔτι·</l>
 						<l>ἐς τὸ σπυρίδιον ἰσχνά μοι φυλλεῖα δός.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="470">ἀπολεῖς μ’. ἰδού σοι. φροῦδά μοι τὰ δράματα.</l>
 					</sp>
@@ -1307,7 +1307,7 @@ convert to P3
 						<l>πλὴν ἓν μόνον, τουτὶ μόνον τουτὶ μόνον,</l>
 						<l>σκάνδικά μοι δὸς μητρόθεν δεδεγμένος.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἁνὴρ ὑβρίζει· κλῇε πηκτὰ δωμάτων.</l>
 					</sp>
@@ -1328,7 +1328,7 @@ convert to P3
 			</div1>
 			<div1 type="Lyric-Scene">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="490">τί δράσεις; τί φήσεις; εὖ ἴσθι νυν</l>
 						<l>ἀναίσχυντος ὢν σιδηροῦς τ’ ἀνήρ,</l>
@@ -1405,23 +1405,23 @@ convert to P3
 						<l>οὐκ οἰόμεσθα; νοῦς ἄρ’ ἡμῖν οὐκ ἔνι.</l>
 					</sp>
 					<milestone ed="p" n="557" unit="card"/>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>ἄληθες ὦπίτριπτε καί μιαρώτατε;</l>
 						<l>ταυτὶ σὺ τολμᾷς πτωχὸς ὢν ἡμᾶς λέγειν,</l>
 						<l>καὶ συκοφάντης εἴ τις ἦν ὠνείδισας;</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l n="560">νὴ τὸν Ποσειδῶ καὶ λέγει γ’ ἅπερ λέγει</l>
 						<l>δίκαια πάντα κοὐδὲν αὐτῶν ψεύδεται.</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>εἶτ’ εἰ δίκαια, τοῦτον εἰπεῖν αὔτ’ ἐχρῆν;</l>
 						<l>ἀλλ’ οὔτι χαίρων ταῦτα τολμήσει λέγειν.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>οὗτος σὺ ποῖ θεῖς; οὐ μενεῖς; ὡς εἰ θενεῖς</l>
 						<l n="565">τὸν ἄνδρα τοῦτον, αὐτὸς ἀρθήσει τάχα.</l>
@@ -1429,7 +1429,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>ἰὼ Λάμαχ’ ὦ βλέπων ἀστραπάς,</l>
 						<l>βοήθησον ὦ γοργολόφα φανείς,</l>
@@ -1439,7 +1439,7 @@ convert to P3
 						<l>τις ἀνύσας. ἐγὼ γὰρ ἔχομαι μέσος.</l>
 						<milestone ed="p" n="572" unit="card"/>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>πόθεν βοῆς ἤκουσα πολεμιστηρίας;</l>
 						<l>ποῖ χρὴ βοηθεῖν; ποῖ κυδοιμὸν ἐμβαλεῖν;</l>
@@ -1449,12 +1449,12 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l n="575">ὦ Λάμαχ’ ἥρως, τῶν λόφων καὶ τῶν λόχων.</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>ὦ Λάμαχ’, οὐ γὰρ οὗτος ἅνθρωπος πάλαι</l>
 						<l>ἅπασαν ἡμῶν τὴν πόλιν κακορροθεῖ;</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>οὗτος σὺ τολμᾷς πτωχὸς ὢν λέγειν τάδε;</l>
 					</sp>
@@ -1463,7 +1463,7 @@ convert to P3
 						<l>ὦ Λάμαχ’ ἥρως, ἀλλὰ συγγνώμην ἔχε,</l>
 						<l>εἰ πτωχὸς ὢν εἶπόν τι κἀστωμυλάμην.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>τί δ’ εἶπας ἡμᾶς; οὐκ ἐρεῖς;</l>
 					</sp>
@@ -1473,7 +1473,7 @@ convert to P3
 						<l n="581">ὑπὸ τοῦ δέους γὰρ τῶν ὅπλων εἰλιγγιῶ.</l>
 						<l>ἀλλ’ ἀντιβολῶ σ’ ἀπένεγκέ μου τὴν μορμόνα.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>ἰδού.</l>
 					</sp>
@@ -1481,7 +1481,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">παράθες νυν ὑπτίαν αὐτὴν ἐμοί.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>κεῖται.</l>
 					</sp>
@@ -1489,7 +1489,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">φέρε νυν ἀπὸ τοῦ κράνους μοι τὸ πτερόν.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>τουτὶ πτίλον σοι.</l>
 					</sp>
@@ -1498,7 +1498,7 @@ convert to P3
 						<l part="Y">τῆς κεφαλῆς νύν μου λαβοῦ,</l>
 						<l n="586">ἵν’ ἐξεμέσω· βδελύττομαι γὰρ τοὺς λόφους.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>οὗτος τί δράσεις; τῷ πτίλῳ μέλλεις ἐμεῖν;</l>
 						<l>πτίλον γάρ ἐστιν—</l>
@@ -1508,7 +1508,7 @@ convert to P3
 						<l part="Y">εἰπέ μοι τίνος ποτὲ</l>
 						<l>ὄρνιθός ἐστιν; ἆρα κομπολακύθου;</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l n="590">οἴμ’ ὡς τεθνήξεις.</l>
 					</sp>
@@ -1518,7 +1518,7 @@ convert to P3
 						<l>οὐ γὰρ κατ’ ἰσχύν ἐστιν· εἰ δ’ ἰσχυρὸς εἶ,</l>
 						<l>τί μ’ οὐκ ἀπεψώλησας; εὔοπλος γὰρ εἶ.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>ταυτὶ λέγεις σὺ τὸν στρατηγὸν πτωχὸς ὤν;</l>
 					</sp>
@@ -1526,7 +1526,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἐγὼ γάρ εἰμι πτωχός;</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l part="Y">ἀλλὰ τίς γὰρ εἶ;</l>
 					</sp>
@@ -1536,7 +1536,7 @@ convert to P3
 						<l>ἀλλ’ ἐξ ὅτου περ ὁ πόλεμος, στρατωνίδης,</l>
 						<l>σὺ δ’ ἐξ ὅτου περ ὁ πόλεμος, μισθαρχίδης.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>ἐχειροτόνησαν γάρ με —</l>
 					</sp>
@@ -1552,7 +1552,7 @@ convert to P3
 						<l n="605">Γερητοθεοδώρους Διομειαλαζόνας,</l>
 						<l>τοὺς δ’ ἐν Καμαρίνῃ κἀν Γέλα κἀν Καταγέλᾳ.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>ἐχειροτονήθησαν γάρ.</l>
 					</sp>
@@ -1570,7 +1570,7 @@ convert to P3
 						<l>ὥσπερ ἀπόνιπτρον ἐκχέοντες ἑσπέρας,</l>
 						<l>ἅπαντες ‘ἐξίστω’ παρῄνουν οἱ φίλοι.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>ὦ δημοκρατία ταῦτα δῆτ’ ἀνασχετά;</l>
 					</sp>
@@ -1578,7 +1578,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>οὐ δῆτ’ ἐὰν μὴ μισθοφορῇ γε Λάμαχος.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l n="620">ἀλλ’ οὖν ἐγὼ μὲν πᾶσι Πελοποννησίοις</l>
 						<l>ἀεὶ πολεμήσω καὶ ταράξω πανταχῇ</l>
@@ -1595,7 +1595,7 @@ convert to P3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἁνὴρ νικᾷ τοῖσι λόγοισιν, καὶ τὸν δῆμον μεταπείθει</l>
 						<l>περὶ τῶν σπονδῶν. ἀλλ’ ἀποδύντες τοῖς ἀναπαίστοις ἐπίωμεν.</l>
@@ -1603,7 +1603,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="parabasis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐξ οὗ γε χοροῖσιν ἐφέστηκεν τρυγικοῖς ὁ διδάσκαλος ἡμῶν,</l>
 						<l n="629">οὔπω παρέβη πρὸς τὸ θέατρον λέξων ὡς δεξιός ἐστιν·</l>
@@ -1640,7 +1640,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρὸς ταῦτα Κλέων καὶ παλαμάσθω</l>
 						<l n="660">καὶ πᾶν ἐπ’ ἐμοὶ τεκταινέσθω.</l>
@@ -1652,7 +1652,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεῦρο Μοῦσ’ ἐλθὲ φλεγυρὰ πυρὸς ἔχουσα μένος ἔντονος Ἀχαρνική.</l>
 						<l>οἷον ἐξ ἀνθράκων πρινίνων φέψαλος ἀνήλατ’ ἐρεθιζόμενος οὐρίᾳ ῥιπίδι,</l>
@@ -1664,7 +1664,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrhema">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἱ γέροντες οἱ παλαιοὶ μεμφόμεσθα τῇ πόλει·</l>
 						<l>οὐ γὰρ ἀξίως ἐκείνων ὧν ἐναυμαχήσαμεν</l>
@@ -1686,7 +1686,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ταῦτα πῶς εἰκότα, γέροντ’ ἀπολέσαι πολιὸν ἄνδρα περὶ κλεψύδραν,</l>
 						<l>πολλὰ δὴ ξυμπονήσαντα καὶ θερμὸν ἀπομορξάμενον ἀνδρικὸν ἱδρῶτα δὴ καὶ πολύν,</l>
@@ -1698,7 +1698,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrhema">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τῷ γὰρ εἰκὸς ἄνδρα κυφὸν ἡλίκον Θουκυδίδην</l>
 						<l>ἐξολέσθαι συμπλακέντα τῇ Σκυθῶν ἐρημίᾳ,</l>
@@ -1734,7 +1734,7 @@ convert to P3
 					<l>ἐγὼ δὲ τὴν στήλην καθ’ ἣν ἐσπεισάμην</l>
 					<l>μέτειμ’, ἵνα στήσω φανερὰν ἐν τἀγορᾷ.</l>
 				</sp>
-				<sp who="#megareys">
+				<sp who="#megareus">
 					<speaker>Μεγαρεύς</speaker>
 					<l>ἀγορὰ ν’ Ἀθάναις χαῖρε Μεγαρεῦσιν φίλα.</l>
 					<l n="730">ἐπόθουν τυ ναὶ τὸν φίλιον ᾇπερ ματέρα.</l>
@@ -1748,7 +1748,7 @@ convert to P3
 						<speaker>Κόρα</speaker>
 						<l n="735">πεπρᾶσθαι πεπρᾶσθαι.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>ἐγώνγα καὐτός φαμι. τίς δ’ οὕτως ἄνους</l>
 						<l>ὃς ὑμέ κα πρίαιτο φανερὰν ζαμίαν;</l>
@@ -1770,7 +1770,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l n="750">τί; ἀνὴρ Μεγαρικός;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">ἀγορασοῦντες ἵκομες.</l>
 					</sp>
@@ -1778,7 +1778,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>πῶς ἔχετε;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">διαπεινᾶμες ἀεὶ ποττὸ πῦρ.</l>
 					</sp>
@@ -1787,7 +1787,7 @@ convert to P3
 						<l>ἀλλ’ ἡδύ τοι νὴ τὸν Δί’, ἢν αὐλὸς παρῇ.</l>
 						<l>τί δ’ ἄλλο πράττεθ’ οἱ Μεγαρῆς νῦν;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">οἷα δή.</l>
 						<l>ὅκα μὲν ἐγὼν τηνῶθεν ἐμπορευόμαν,</l>
@@ -1798,7 +1798,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>αὐτίκ’ ἄρ’ ἀπαλλάξεσθε πραγμάτων.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">σά μάν;</l>
 					</sp>
@@ -1806,7 +1806,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τί δ’ ἄλλο Μεγαροῖ; πῶς ὁ σῖτος ὤνιος;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l n="759">παρ’ ἁμὶ πολυτίματος ᾇπερ τοὶ θεοί.</l>
 					</sp>
@@ -1814,7 +1814,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἅλας οὖν φέρεις;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">οὐχ ὑμὲς αὐτῶν ἄρχετε;</l>
 					</sp>
@@ -1822,7 +1822,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>οὐδὲ σκόροδα;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">ποῖα σκόροδ’; ὑμὲς τῶν ἀεί,</l>
 						<l>ὅκκ’ ἐσβάλητε, τὼς ἀρωραῖοι μύες</l>
@@ -1832,7 +1832,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τί δαὶ φέρεις;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">χοίρως ἐγώνγα μυστικάς.</l>
 					</sp>
@@ -1840,7 +1840,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>καλῶς λέγεις· ἐπίδειξον.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">ἀλλὰ μὰν καλαί.</l>
 						<l n="766">ἄντεινον αἰ λῇς· ὡς παχεῖα καὶ καλά.</l>
@@ -1849,7 +1849,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τουτὶ τί ἦν τὸ πρᾶγμα;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">χοῖρος ναὶ Δία.</l>
 					</sp>
@@ -1857,7 +1857,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τί λέγεις σύ; ποδαπὴ δή ’στι χοῖρος;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">Μεγαρικά.</l>
 						<l>ἢ οὐ χοῖρός ἐσθ’ ἅδ’;</l>
@@ -1866,7 +1866,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">οὐκ ἔμοιγε φαίνεται.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l n="770">οὐ δεινά; θᾶσθε τῶδε τὰς ἀπιστίας·</l>
 						<l>οὔ φατι τάνδε χοῖρον εἶμεν. ἀλλὰ μάν,</l>
@@ -1877,7 +1877,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀλλ’ ἔστιν ἀνθρώπου γε.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">ναὶ τὸν Διοκλέα</l>
 						<l n="775">ἐμά γα. τὺ δέ νιν εἴμεναι τίνος δοκεῖς;</l>
@@ -1888,7 +1888,7 @@ convert to P3
 						<l part="Y">νὴ τοὺς θεοὺς</l>
 						<l>ἔγωγε.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">φώνει δὴ τὺ ταχέως χοιρίον.</l>
 						<l>οὐ χρῆσθα; σιγῇς ὦ κάκιστ’ ἀπολουμένα;</l>
@@ -1898,7 +1898,7 @@ convert to P3
 						<speaker>Κόρη</speaker>
 						<l n="780">κοῒ κοΐ.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>αὕτα ’στὶ χοῖρος;</l>
 					</sp>
@@ -1907,7 +1907,7 @@ convert to P3
 						<l part="Y">νῦν γε χοῖρος φαίνεται.</l>
 						<l>ἀτὰρ ἐκτραφείς γε κύσθος ἔσται.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">πέντ’ ἑτῶν,</l>
 						<l>σάφ’ ἴσθι, ποττὰν ματέρ’ εἰκασθήσεται.</l>
@@ -1916,7 +1916,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀλλ’ οὐδὲ θύσιμός ἐστιν αὑτηγί.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">σά μάν;</l>
 						<l n="785">πᾷ δ’ οὐχὶ θύσιμός ἐστι;</l>
@@ -1925,7 +1925,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">κέρκον οὐκ ἔχει.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>νεαρὰ γάρ ἐστιν· ἀλλὰ δελφακουμένα</l>
 						<l>ἑξεῖ μεγάλαν τε καὶ παχεῖαν κἠρυθράν.</l>
@@ -1935,7 +1935,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ὡς ξυγγενὴς ὁ κύσθος αὐτῆς θατέρᾳ.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l n="790">ὁμοματρία γάρ ἐστι κἠκ τωὐτῶ πατρός.</l>
 						<l>αἰ δ’ ἂν παχυνθῇ κἀναχνοιανθῇ τριχί,</l>
@@ -1945,7 +1945,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀλλ’ οὐχὶ χοῖρος τἀφροδίτῃ θύεται.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>οὐ χοῖρος Ἀφροδίτᾳ; μόνᾳ γα δαιμόνων.</l>
 						<l n="795">καὶ γίνεταί γα τᾶνδε τᾶν χοίρων τὸ κρῆς</l>
@@ -1955,7 +1955,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἤδη δ’ ἄνευ τῆς μητρὸς ἐσθίοιεν ἄν;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>ναὶ τὸν Ποτειδᾶν καί κ’ ἄνις γα τῶ πατρός.</l>
 						<milestone ed="p" n="799" unit="card"/>
@@ -1964,7 +1964,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τί δ’ ἐσθίει μάλιστα;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">πάνθ’ ἅ κα διδῷς.</l>
 						<l>αὐτὸς δ’ ἐρώτη.</l>
@@ -2009,7 +2009,7 @@ convert to P3
 						<l>οἷον ῥοθιάζουσ’ ὦ πολυτίμηθ’ Ἡράκλεις.</l>
 						<l>ποδαπὰ τὰ χοιρί’; ὡς Τραγασαῖα φαίνεται.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>ἀλλ’ οὔτι πάσας κατέτραγον τὰς ἰσχάδας.</l>
 						<l n="810">ἐγὼ γὰρ αὐτᾶν τάνδε μίαν ἀνειλόμαν.</l>
@@ -2019,7 +2019,7 @@ convert to P3
 						<l>νὴ τὸν Δί’ ἀστείω γε τὼ βοσκήματε·</l>
 						<l>πόσου πρίωμαί σοι τὰ χοιρίδια; λέγε.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>τὸ μὲν ἅτερον τούτων σκορόδων τροπαλίδος,</l>
 						<l>τὸ δ’ ἅτερον, αἰ λῇς, χοίνικος μόνας ἁλῶν.</l>
@@ -2028,35 +2028,35 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l n="815">ὠνήσομαί σοι· περίμεν’ αὐτοῦ.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">ταῦτα δή.</l>
 						<l>Ἑρμᾶ ’μπολαῖε τὰν γυναῖκα τὰν ἐμὰν</l>
 						<l>οὕτω μ’ ἀποδόσθαι τάν τ’ ἐμωυτῶ τ’ ἐμωυτῶ ματέρα.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>ὦνθρωπε ποδαπός;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">χοιροπώλας Μεγαρικός.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>τὰ χοιρίδια τοίνυν ἐγὼ φανῶ ταδὶ</l>
 						<l n="820">πολέμια καὶ σέ.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">τοῦτ’ ἐκεῖν’, ἵκει πάλιν</l>
 						<l>ὅθενπερ ἀρχὰ τῶν κακῶν ἁμῖν ἔφυ.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>κλάων μεγαριεῖς. οὐκ ἀφήσεις τὸν σάκον;</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>Δικαιόπολι Δικαιόπολι φαντάδδομαι.</l>
 					</sp>
@@ -2066,7 +2066,7 @@ convert to P3
 						<l n="825">τοὺς συκοφάντας οὐ θύραζ’ ἐξείρξετε;</l>
 						<l>τί δὴ μαθὼν φαίνεις ἄνευ θρυαλλίδος;</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>οὐ γὰρ φανῶ τοὺς πολεμίους;</l>
 					</sp>
@@ -2075,7 +2075,7 @@ convert to P3
 						<l part="Y">κλάων γε σύ,</l>
 						<l>εἰ μὴ ’τέρωσε συκοφαντήσεις τρέχων.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>οἷον τὸ κακὸν ἐν ταῖς Ἀθάναις τοῦτ’ ἔνι.</l>
 					</sp>
@@ -2085,7 +2085,7 @@ convert to P3
 						<l>τιμῆς, λαβὲ ταυτὶ τὰ σκόροδα καὶ τοὺς ἅλας,</l>
 						<l>καὶ χαῖρε πόλλ’.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l part="Y">ἀλλ’ ἁμὶν οὐκ ἐπιχώριον.</l>
 					</sp>
@@ -2093,7 +2093,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>πολυπραγμοσύνη νυν ἐς κεφαλὴν τράποιτ’ ἐμοί.</l>
 					</sp>
-					<sp who="#megareys">
+					<sp who="#megareus">
 						<speaker>Μεγαρεύς</speaker>
 						<l>ὦ χοιρίδια πειρῆσθε κἄνις τῶ πατρὸς</l>
 						<l n="835">παίειν ἐφ’ ἁλὶ τὰν μᾶδδαν, αἴκα τις διδῷ.</l>
@@ -2103,7 +2103,7 @@ convert to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐδαιμονεῖ γ’ ἅνθρωπος. οὐκ ἤκουσας οἷ προβαίνει</l>
 						<l>τὸ πρᾶγμα τοῦ βουλεύματος; καρπώσεται γὰρ ἁνὴρ</l>
@@ -2115,7 +2115,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδ’ ἄλλος ἀνθρώπων ὑποψωνῶν σε πημανεῖ τι,</l>
 						<l>οὐδ’ ἐξομόρξεται Πρέπις τὴν εὐρυπρωκτίαν σοι,</l>
@@ -2127,7 +2127,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδ’ ἐντυχὼν ἐν τἀγορᾷ πρόσεισί σοι βαδίζων</l>
 						<l>Κρατῖνος ἀεὶ κεκαρμένος μοιχὸν μιᾷ μαχαίρᾳ,</l>
@@ -2139,7 +2139,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδ’ αὖθις αὖ σε σκώψεται Παύσων ὁ παμπόνηρος</l>
 						<l n="855">Λυσίστρατός τ’ ἐν τἀγορᾷ, Χολαργέων ὄνειδος,</l>
@@ -2275,7 +2275,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l part="Y">ἀλλ’ ἅπαν κακόν.</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l n="910">ταυτὶ τίνος τὰ φορτί’ ἐστί;</l>
 				</sp>
@@ -2284,7 +2284,7 @@ convert to P3
 					<l part="Y">τῶδ’ ἐμὰ</l>
 					<l>Θείβαθεν, ἴττω Δεύς.</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l part="Y">ἐγὼ τοίνυν ὁδὶ</l>
 					<l>φαίνω πολέμια ταῦτα.</l>
@@ -2294,7 +2294,7 @@ convert to P3
 					<l part="Y">τί δὲ κακὸν παθὼν</l>
 					<l>ὀρναπετίοισι πόλεμον ἤρα καί μάχαν;</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l>καὶ σέ γε φανῶ πρὸς τοῖσδε.</l>
 				</sp>
@@ -2302,7 +2302,7 @@ convert to P3
 					<speaker>Βοιωτός</speaker>
 					<l part="Y">τί ἀδικείμενος;</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l n="915">ἐγὼ φράσω σοι τῶν περιεστώτων χάριν·</l>
 					<l>ἐκ τῶν πολεμίων γ’ εἰσάγεις θρυαλλίδας.</l>
@@ -2311,7 +2311,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ἔπειτα φαίνεις δῆτα διὰ θρυαλλίδα;</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l>αὕτη γὰρ ἐμπρήσειεν ἂν τὸ νεώριον.</l>
 				</sp>
@@ -2319,7 +2319,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>νεώριον θρυαλλίς;</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l part="Y">οἶμαι·</l>
 				</sp>
@@ -2327,7 +2327,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l part="Y">τίνι τρόπῳ;</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l n="920">ἐνθεὶς ἂν ἐς τίφην ἀνὴρ Βοιώτιος</l>
 					<l>ἅψας ἄν ἐσπέμψειεν ἐς τὸ νεώριον</l>
@@ -2340,7 +2340,7 @@ convert to P3
 					<l part="Y">ὦ κάκιστ’ ἀπολούμενε,</l>
 					<l n="925">σελαγοῖντ’ ἂν ὑπὸ τίφης τε καὶ θρυαλλίδος;</l>
 				</sp>
-				<sp who="#nikarxos">
+				<sp who="#nikarchos">
 					<speaker>Νίκαρχος</speaker>
 					<l>μαρτύρομαι.</l>
 				</sp>
@@ -2354,7 +2354,7 @@ convert to P3
 			</div1>
 			<div1 type="Lyric-Scene">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔνδησον ὦ βέλτιστε τῷ</l>
 						<l n="930">ξένῳ καλῶς τὴν ἐμπολὴν</l>
@@ -2368,7 +2368,7 @@ convert to P3
 						<l>πυρορραγὲς</l>
 						<l>κἄλλως θεοῖσιν ἐχθρόν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="935">τί χρήσεταί ποτ’ αὐτῷ;</l>
 					</sp>
@@ -2383,7 +2383,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς δ’ ἂν πεποιθοίη τις ἀγγείῳ</l>
 						<l n="941">τοιούτῳ χρώμενος</l>
@@ -2397,7 +2397,7 @@ convert to P3
 						<l>ἐκ ποδῶν</l>
 						<l n="945">κατωκάρα κρέμαιτο.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἤδη καλῶς ἔχει σοι.</l>
 					</sp>
@@ -2405,7 +2405,7 @@ convert to P3
 						<speaker>Βοιωτός</speaker>
 						<l>μέλλω γά τοι θερίδδειν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ὦ ξένων βέλτιστε συνθέριζε</l>
 						<l>καὶ τοῦτον λαβὼν</l>
@@ -2432,7 +2432,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#theraponlamaxoy">
+				<sp who="#therapon_lamachou">
 					<speaker>Θεράπων Λαμάχου</speaker>
 					<l>Δικαιόπολι.</l>
 				</sp>
@@ -2440,7 +2440,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l part="Y">τίς ἔστι; τί με βωστρεῖς;</l>
 				</sp>
-				<sp who="#theraponlamaxoy">
+				<sp who="#therapon_lamachou">
 					<speaker>Θεράπων Λαμάχου</speaker>
 					<l>ὅ τι;</l>
 					<l n="960">ἐκέλευε Λάμαχός σε ταυτησὶ δραχμῆς</l>
@@ -2451,7 +2451,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ὁ ποῖος οὗτος Λάμαχος τὴν ἔγχελυν;</l>
 				</sp>
-				<sp who="#theraponlamaxoy">
+				<sp who="#therapon_lamachou">
 					<speaker>Θεράπων Λαμάχου</speaker>
 					<l>ὁ δεινός, ὁ ταλαύρινος, ὃς τὴν Γοργόνα</l>
 					<l n="965">πάλλει κραδαίνων τρισὶ κατάσκιος λόφοις.</l>
@@ -2468,7 +2468,7 @@ convert to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἶδες ὦ εἶδες ὦ πᾶσα πόλι τὸν φρόνιμον ἄνδρα τὸν ὑπέρσοφον,</l>
 						<l>οἷ’ ἔχει σπεισάμενος ἐμπορικὰ χρήματα διεμπολᾶν,</l>
@@ -2487,7 +2487,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>&lt;οὑτοσὶ δ’&gt; ἐπτέρωταί τ’ ἐπὶ τὸ δεῖπνον ἅμα καὶ μεγάλα δὴ φρονεῖ,</l>
 						<l>τοῦ βίου δ’ ἐξέβαλε δεῖγμα &lt;τάδε&gt; τὰ πτερὰ πρὸ τῶν θυρῶν.</l>
@@ -2507,7 +2507,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="Lyric-Scene">
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="1000">ἀκούετε λεῴ· κατὰ τὰ πάτρια τοὺς Χοᾶς</l>
 					<l>πίνειν ὑπὸ τῆς σάλπιγγος· ὃς δ’ ἂν ἐκπίῃ</l>
@@ -2523,7 +2523,7 @@ convert to P3
 					<milestone ed="p" n="1008" unit="card"/>
 				</sp>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ζηλῶ σε τῆς εὐβουλίας,</l>
 						<l>μᾶλλον δὲ τῆς εὐωχίας</l>
@@ -2533,7 +2533,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τί δῆτ’ ἐπειδὰν τὰς κίχλας ὀπτωμένας ἴδητε;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἶμαί σε καὶ τοῦτ’ εὖ λέγειν.</l>
 					</sp>
@@ -2541,7 +2541,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">τὸ πῦρ ὑποσκάλευε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1015">ἤκουσας ὡς μαγειρικῶς</l>
 						<l>κομψῶς τε καὶ δειπνητικῶς</l>
@@ -2634,7 +2634,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἁνὴρ ἀνηύρηκέν τι ταῖς</l>
 						<l>σπονδαῖσιν ἡδύ, κοὐκ ἔοικεν</l>
@@ -2644,7 +2644,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>κατάχει σὺ τῆς χορδῆς τὸ μέλι, τὰς σηπίας στάθευε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἤκουσας ὀρθιασμάτων;</l>
 					</sp>
@@ -2652,7 +2652,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">ὀπτᾶτε τἀγχέλεια.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀποκτενεῖς λιμῷ ’μὲ καὶ</l>
 						<l n="1045">τοὺς γείτονας κνίσῃ τε καὶ</l>
@@ -2663,7 +2663,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ὀπτᾶτε ταυτὶ καὶ καλῶς ξανθίζετε.</l>
 					</sp>
-					<sp who="#paranymfos">
+					<sp who="#paranymphos">
 						<speaker>Παράνυμφος</speaker>
 						<l>Δικαιόπολι.</l>
 					</sp>
@@ -2671,7 +2671,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">τίς οὑτοσί; τίς οὑτοσί;</l>
 					</sp>
-					<sp who="#paranymfos">
+					<sp who="#paranymphos">
 						<speaker>Παράνυμφος</speaker>
 						<l>ἔπεμψέ τίς σοι νυμφίος ταυτὶ κρέα</l>
 						<l n="1050">ἐκ τῶν γάμων.</l>
@@ -2680,7 +2680,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">καλῶς γε ποιῶν ὅστις ἦν.</l>
 					</sp>
-					<sp who="#paranymfos">
+					<sp who="#paranymphos">
 						<speaker>Παράνυμφος</speaker>
 						<l>ἐκέλευε δ’ ἐγχέαι σε τῶν κρεῶν χάριν,</l>
 						<l>ἵνα μὴ στρατεύοιτ’ ἀλλὰ βινοίη μένων,</l>
@@ -2692,7 +2692,7 @@ convert to P3
 						<l n="1055">ὡς οὐκ ἂν ἐγχέαιμι μυρίων δραχμῶν.</l>
 						<l>ἀλλ’ αὑτηὶ τίς ἔστιν;</l>
 					</sp>
-					<sp who="#paranymfos">
+					<sp who="#paranymphos">
 						<speaker>Παράνυμφος</speaker>
 						<l part="Y">ἡ νυμφεύτρια</l>
 						<l>δεῖται παρὰ τῆς νύμφης τι σοὶ λέξαι μόνῳ.</l>
@@ -2715,20 +2715,20 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ μὴν ὁδί τις τὰς ὀφρῦς ἀνεσπακὼς·</l>
 					<l n="1070">ὥσπερ τι δεινὸν ἀγγελῶν ἐπείγεται.</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l>ἰὼ πόνοι τε καὶ μάχαι καὶ Λάμαχοι.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>τίς ἀμφὶ χαλκοφάλαρα δώματα κτυπεῖ;</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l>ἰέναι σ’ ἐκέλευον οἱ στρατηγοὶ τήμερον</l>
 					<l>ταχέως λαβόντα τοὺς λόχους καὶ τοὺς λόφους·</l>
@@ -2736,7 +2736,7 @@ convert to P3
 					<l>ὑπὸ τοὺς Χοᾶς γὰρ καὶ Χύτρους αὐτοῖσί τις</l>
 					<l>ἤγγειλε λῃστὰς ἐμβαλεῖν Βοιωτίους.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ἰὼ στρατηγοὶ πλείονες ἢ βελτίονες.</l>
 					<l>οὐ δεινὰ μὴ ’ξεῖναί με μηδ’ ἑορτάσαι;</l>
@@ -2745,7 +2745,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l n="1080">ἰὼ στράτευμα πολεμολαμαχαϊκόν.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>οἴμοι κακοδαίμων καταγελᾷς ἤδη σύ μου.</l>
 				</sp>
@@ -2753,7 +2753,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>βούλει μάχεσθαι Γηρυόνῃ τετραπτίλῳ;</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>αἰαῖ</l>
 					<l>οἵαν ὁ κῆρυξ ἀγγελίαν ἤγγειλέ μοι.</l>
@@ -2762,7 +2762,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>αἰαῖ τίνα δ’ αὖ μοι προστρέχει τις ἀγγελῶν;</l>
 				</sp>
-				<sp who="#aggelosb">
+				<sp who="#angelos_b">
 					<speaker>Ἄγγελος Β</speaker>
 					<l n="1085">Δικαιόπολι.</l>
 				</sp>
@@ -2770,7 +2770,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l part="Y">τί ἔστιν;</l>
 				</sp>
-				<sp who="#aggelosb">
+				<sp who="#angelos_b">
 					<speaker>Ἄγγελος Β</speaker>
 					<l part="Y">ἐπὶ δεῖπνον ταχὺ</l>
 					<l>βάδιζε τὴν κίστην λαβὼν καὶ τὸν χοᾶ.</l>
@@ -2783,7 +2783,7 @@ convert to P3
 					<l>ὀρχηστρίδες, τὰ φίλταθ’ Ἁρμοδίου, καλαί.</l>
 					<l>ἀλλ’ ὡς τάχιστα σπεῦδε.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l part="Y">κακοδαίμων ἐγώ.</l>
 					<milestone ed="p" n="1095" unit="card"/>
@@ -2793,7 +2793,7 @@ convert to P3
 					<l n="1095">καὶ γὰρ σὺ μεγάλην ἐπεγράφου τὴν Γοργόνα.</l>
 					<l>σύγκλῃε, καὶ δεῖπνόν τις ἐνσκευαζέτω.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>παῖ παῖ φέρ’ ἔξω δεῦρο τὸν γυλιὸν ἐμοί.</l>
 				</sp>
@@ -2801,7 +2801,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>παῖ παῖ φέρ’ ἔξω δεῦρο τὴν κίστην ἐμοί.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ἅλας θυμίτας οἶσε παῖ καὶ κρόμμυα.</l>
 				</sp>
@@ -2809,7 +2809,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l n="1100">ἐμοὶ δὲ τεμάχη· κρομμύοις γὰρ ἄχθομαι.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>θρῖον ταρίχους οἶσε δεῦρο παῖ σαπροῦ.</l>
 				</sp>
@@ -2817,7 +2817,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>κἀμοὶ σὺ δημοῦ θρῖον· ὀπρήσω δ’ ἐκεῖ.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ἔνεγκε δεῦρο τὼ πτερὼ τὼ κ’ τοῦ κράνους.</l>
 				</sp>
@@ -2825,7 +2825,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ἐμοὶ δὲ τὰς φάττας γε φέρε καὶ τὰς κίχλας.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l n="1105">καλόν γε καὶ λευκὸν τὸ τῆς στρούθου πτερόν.</l>
 				</sp>
@@ -2833,7 +2833,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>καλόν γε καὶ ξανθὸν τὸ τῆς φάττης κρέας.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ὦνθρωπε παῦσαι καταγελῶν μου τῶν ὅπλων.</l>
 				</sp>
@@ -2841,7 +2841,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ὦνθρωπε βούλει μὴ βλέπειν ἐς τὰς κίχλας;</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>τὸ λοφεῖον ἐξένεγκε τῶν τριῶν λόφων.</l>
 				</sp>
@@ -2849,7 +2849,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l n="1110">κἀμοὶ λεκάνιον τῶν λαγῴων δὸς κρεῶν.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ἀλλ’ ἢ τριχόβρωτες τοὺς λόφους που κατέφαγον.</l>
 				</sp>
@@ -2857,7 +2857,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ἀλλ’ ἤ πρὸ δείπνου τὴν μίμαρκυν κατέδομαι.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ὦνθρωπε βούλει μὴ προσαγορεύειν ἐμέ;</l>
 				</sp>
@@ -2867,7 +2867,7 @@ convert to P3
 					<l n="1115">βούλει περιδόσθαι κἀπιτρέψαι Λαμάχῳ,</l>
 					<l>πότερον ἀκρίδες ἥδιόν ἐστιν ἤ κίχλαι;</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>οἴμ’ ὡς ὑβρίζεις.</l>
 				</sp>
@@ -2875,7 +2875,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l part="Y">τὰς ἀκρίδας κρίνει πολύ.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>παῖ παῖ καθελών μοι τὸ δόρυ δεῦρ’ ἔξω φέρε.</l>
 				</sp>
@@ -2883,7 +2883,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>παῖ παῖ σὺ δ’ ἀφελὼν δεῦρο τὴν χορδὴν φέρε.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l n="1120">φέρε τοῦ δόρατος ἀφελκύσωμαι τοὔλυτρον.</l>
 					<l>ἔχ’, ἀντέχου παῖ.</l>
@@ -2892,7 +2892,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l part="Y">καὶ σὺ παῖ τοῦδ’ ἀντέχου.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>τοὺς κιλλίβαντας οἶσε παῖ τῆς ἀσπίδος.</l>
 				</sp>
@@ -2900,7 +2900,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>καὶ τῆς ἐμῆς τοὺς κριβανίτας ἔκφερε.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>φέρε δεῦρο γοργόνωτον ἀσπίδος κύκλον.</l>
 				</sp>
@@ -2908,7 +2908,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l n="1125">κἀμοὶ πλακοῦντος τυρόνωτον δὸς κύκλον.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ταῦτ’ οὐ κατάγελώς ἐστιν ἀνθρώποις πλατύς;</l>
 				</sp>
@@ -2916,7 +2916,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ταῦτ’ οὐ πλακοῦς δῆτ’ ἐστὶν ἀνθρώποις γλυκύς;</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>κατάχει σὺ παῖ τοὔλαιον. ἐν τῷ χαλκίῳ</l>
 					<l>ἐνορῶ γέροντα δειλίας φευξούμενον.</l>
@@ -2926,7 +2926,7 @@ convert to P3
 					<l n="1130">κατάχει σὺ τὸ μέλι. κἀνθάδ’ ἔνδηλος γέρων</l>
 					<l>κλάειν κελεύων Λάμαχον τὸν Γοργάσου.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>φέρε δεῦρο παῖ θώρακα πολεμιστήριον.</l>
 				</sp>
@@ -2934,7 +2934,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ἔξαιρε παῖ θώρακα κἀμοὶ τὸν χοᾶ.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ἐν τῷδε πρὸς τοὺς πολεμίους θωρήξομαι.</l>
 				</sp>
@@ -2942,7 +2942,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l n="1135">ἐν τῷδε πρὸς τοὺς συμπότας θωρήξομαι.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>τὰ στρώματ’ ὦ παῖ δῆσον ἐκ τῆς ἀσπίδος.</l>
 				</sp>
@@ -2950,7 +2950,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>τὸ δεῖπνον ὦ παῖ δῆσον ἐκ τῆς κιστίδος.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l>ἐγὼ δ’ ἐμαυτῷ τὸν γυλιὸν οἴσω λαβών.</l>
 				</sp>
@@ -2958,7 +2958,7 @@ convert to P3
 					<speaker>Δικαιόπολις</speaker>
 					<l>ἐγὼ δὲ θοἰμάτιον λαβὼν ἐξέρχομαι.</l>
 				</sp>
-				<sp who="#lamaxos">
+				<sp who="#lamachos">
 					<speaker>Λάμαχος</speaker>
 					<l n="1140">τὴν ἀσπίδ’ αἴρου καὶ βάδιζ’ ὦ παῖ λαβών.</l>
 					<l>νείφει. βαβαιάξ· χειμέρια τὰ πράγματα.</l>
@@ -2969,7 +2969,7 @@ convert to P3
 					<milestone ed="p" n="1143" unit="card"/>
 				</sp>
 				<div2 met="anapests" type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴτε δὴ χαίροντες ἐπὶ στρατιάν.</l>
 						<l>ὡς ἀνομοίαν ἔρχεσθον ὁδόν·</l>
@@ -2982,7 +2982,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἀντίμαχον τὸν ψακάδος †τὸν ξυγγραφῆ† τὸν μελέων ποιητήν,</l>
 						<l n="1151">ὡς μὲν ἁπλῷ, κακῶς ἐξολέσειεν ὁ Ζεύς·</l>
@@ -2997,7 +2997,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοῦτο μὲν αὐτῷ κακὸν ἕν, κᾆθ’ ἕτερον νυκτερινὸν γένοιτο.</l>
 						<l n="1165">ἠπιαλῶν γὰρ οἴκαδ’ ἐξ ἱππασίας βαδίζων,</l>
@@ -3013,7 +3013,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#theraponlamaxoy">
+				<sp who="#therapon_lamachou">
 					<speaker>Θεράπων Λαμάχου</speaker>
 					<l>ὦ δμῶες οἳ κατ’ οἶκόν ἐστε Λαμάχου,</l>
 					<l n="1175">ὕδωρ ὕδωρ ἐν χυτριδίῳ θερμαίνετε·</l>
@@ -3033,7 +3033,7 @@ convert to P3
 					<l>ὁδὶ δὲ καὐτός· ἀλλ’ ἄνοιγε τὴν θύραν.</l>
 				</sp>
 				<div2 type="strophe">
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l n="1190">ἀτταταῖ ἀτταταῖ</l>
 						<l>στυγερὰ τάδε γε κρυερὰ πάθεα· τάλας ἐγώ.</l>
@@ -3056,7 +3056,7 @@ convert to P3
 						<l>τὸν γὰρ χοᾶ πρῶτος ἐκπέπωκα.</l>
 						<milestone ed="p" n="1204" unit="card"/>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>ὦ συμφορὰ τάλαινα τῶν ἐμῶν κακῶν.</l>
 						<l n="1205">ἰὼ ἰὼ τραυμάτων ἐπωδύνων.</l>
@@ -3068,7 +3068,7 @@ convert to P3
 						</l>
 						<l>ἰὴ ἰὴ χαῖρε Λαμαχίππιον.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>στυγερὸς ἐγώ.</l>
 					</sp>
@@ -3076,7 +3076,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">τί με σὺ κυνεῖς;</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>μογερὸς ἐγώ.</l>
 					</sp>
@@ -3084,7 +3084,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l part="Y">τί με σὺ δάκνεις;</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l n="1210">τάλας ἐγὼ ξυμβολῆς βαρείας.</l>
 					</sp>
@@ -3092,7 +3092,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>τοῖς Χουσὶ γάρ τις ξυμβολὰς ἐπράττετο;</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>ἰὼ ἰὼ Παιὰν Παιάν.</l>
 					</sp>
@@ -3100,7 +3100,7 @@ convert to P3
 						<speaker>Δικαιόπολις</speaker>
 						<l>ἀλλ’ οὐχὶ νυνὶ τήμερον Παιώνια.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>λάβεσθέ μου λάβεσθε τοῦ σκέλους παπαῖ,</l>
 						<l n="1215">προσλάβεσθ’ ὦ φίλοι.</l>
@@ -3110,7 +3110,7 @@ convert to P3
 						<l>ἐμοῦ δέ γε σφὼ τοῦ πέους ἄμφω μέσου</l>
 						<l>προσλάβεσθ’ ὦ φίλαι.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>εἰλιγγιῶ κάρα λίθῳ πεπληγμένος</l>
 						<l>καὶ σκοτοδινιῶ.</l>
@@ -3120,7 +3120,7 @@ convert to P3
 						<l n="1220">κἀγὼ καθεύδειν βούλομαι καὶ στύομαι</l>
 						<l>καὶ σκοτοβινιῶ</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>θύραζέ μ’ ἐξενέγκατ’ ἐς τοῦ Πιττάλου</l>
 						<l>παιωνίαισι χερσίν.</l>
@@ -3130,7 +3130,7 @@ convert to P3
 						<l>ὡς τοὺς κριτάς με φέρετε· ποῦ ’στιν ὁ βασιλεύς;</l>
 						<l n="1225">ἀπόδοτέ μοι τὸν ἀσκόν.</l>
 					</sp>
-					<sp who="#lamaxos">
+					<sp who="#lamachos">
 						<speaker>Λάμαχος</speaker>
 						<l>λόγχη τις ἐμπέπηγέ μοι δῑ ὀστέων ὀδυρτά.</l>
 						<milestone ed="p" n="1227" unit="card"/>
@@ -3145,7 +3145,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τήνελλα δῆτ’, εἴπερ καλεῖς γ’, ὦ πρέσβυ, καλλίνικος.</l>
 					</sp>
@@ -3157,7 +3157,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1230">τήνελλά νυν ὦ γεννάδα· χώρει λαβὼν τὸν ἀσκόν.</l>
 					</sp>
@@ -3169,7 +3169,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἑψόμεσθα σὴν χάριν</l>
 						<l>τήνελλα καλλίνικος ᾄδοντες</l>

--- a/tei/aristophanes-birds.xml
+++ b/tei/aristophanes-birds.xml
@@ -52,13 +52,13 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="aggelosa">
+					<person xml:id="angelos_a">
 						<persName>Ἄγγελος Α</persName>
 					</person>
-					<person xml:id="xresmologos">
+					<person xml:id="chresmologos">
 						<persName>Χρησμολόγος</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
 					<person xml:id="triballos">
@@ -67,28 +67,28 @@
 					<person xml:id="kinesias">
 						<persName>Κινησίας</persName>
 					</person>
-					<person xml:id="psefismatopoles">
+					<person xml:id="psephismatopoles">
 						<persName>Ψηφισματοπώλης</persName>
 					</person>
-					<person xml:id="theraponepopos">
+					<person xml:id="therapon_epopos">
 						<persName>Θεράπων Ἔποπος</persName>
 					</person>
 					<person xml:id="episkopos">
 						<persName>Ἐπίσκοπος</persName>
 					</person>
-					<person xml:id="iereys">
+					<person xml:id="hiereus">
 						<persName>Ἱερεύς</persName>
 					</person>
-					<person xml:id="eyelpides">
+					<person xml:id="euelpides">
 						<persName>Ἐυελπίδης</persName>
 					</person>
-					<person xml:id="ornistis">
+					<person xml:id="ornis_tis">
 						<persName>Ὄρνις Τις</persName>
 					</person>
-					<person xml:id="keryks">
+					<person xml:id="keryx">
 						<persName>Κῆρυξ</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="iris">
@@ -106,16 +106,16 @@
 					<person xml:id="meton">
 						<persName>Μέτων</persName>
 					</person>
-					<person xml:id="sykofantes">
+					<person xml:id="sykophantes">
 						<persName>Συκοφάντης</persName>
 					</person>
-					<person xml:id="erakles">
+					<person xml:id="herakles">
 						<persName>Ἡρακλῆς</persName>
 					</person>
-					<person xml:id="prometheys">
+					<person xml:id="prometheus">
 						<persName>Προμηθεύς</persName>
 					</person>
-					<person xml:id="aggelosb">
+					<person xml:id="angelos_b">
 						<persName>Ἄγγελος Β</persName>
 					</person>
 					<person xml:id="pisthetairos">
@@ -213,7 +213,7 @@ convert to p3
 		<body>
 			<div1 type="Prologue">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ὀρθὴν κελεύεις, ᾗ τὸ δένδρον φαίνεται;</l>
 				</sp>
@@ -221,7 +221,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>διαρραγείης· ἥδε δ’ αὖ κρώζει πάλιν.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>τί ὦ πόνηρ’ ἄνω κάτω πλανύττομεν;</l>
 					<l>ἀπολούμεθ’ ἄλλως τὴν ὁδὸν προφορουμένω.</l>
@@ -231,7 +231,7 @@ convert to p3
 					<l n="5">τὸ δ’ ἐμὲ κορώνῃ πειθόμενον τὸν ἄθλιον</l>
 					<l>ὁδοῦ περιελθεῖν στάδια πλεῖν ἢ χίλια.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>τὸ δ’ ἐμὲ κολοιῷ πειθόμενον τὸν δύσμορον</l>
 					<l>ἀποσποδῆσαι τοὺς ὄνυχας τῶν δακτύλων.</l>
@@ -240,7 +240,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>ἀλλ’ οὐδ’ ὅπου γῆς ἐσμὲν οἶδ’ ἔγωγ’ ἔτι.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l n="10">ἐντευθενὶ τὴν πατρίδ’ ἂν ἐξεύροις σύ που;</l>
 				</sp>
@@ -248,7 +248,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>οὐδ’ ἂν μὰ Δία γ’ ἐντεῦθεν Ἐξηκεστίδης.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>οἴμοι.</l>
 				</sp>
@@ -256,7 +256,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">σὺ μὲν ὦ τᾶν τὴν ὁδὸν ταύτην ἴθι.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ἦ δεινὰ νὼ δέδρακεν οὑκ τῶν ὀρνέων,</l>
 					<l>ὁ πινακοπώλης φιλοκράτης μελαγχολῶν,</l>
@@ -273,7 +273,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">οὐδὲ μὰ Δί’ ἐνταῦθά γ’ ἀτραπὸς οὐδαμοῦ.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>οὐδ’ ἡ κορώνη τῆς ὁδοῦ τι λέγει πέρι;</l>
 				</sp>
@@ -281,7 +281,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>οὐ ταὐτὰ κρώζει μὰ Δία νῦν τε καὶ τότε.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l n="25">τί δὴ λέγει περὶ τῆς ὁδοῦ;</l>
 				</sp>
@@ -290,7 +290,7 @@ convert to p3
 					<l part="Y">τί δ’ ἄλλο γ’ ἢ</l>
 					<l>βρύκουσ’ ἀπέδεσθαί φησί μου τοὺς δακτύλους;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>οὐ δεινὸν οὖν δῆτ’ ἐστὶν ἡμᾶς δεομένους</l>
 					<l>ἐς κόρακας ἐλθεῖν καὶ παρεσκευασμένους</l>
@@ -320,7 +320,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>οὗτος.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">τί ἔστιν;</l>
 				</sp>
@@ -329,7 +329,7 @@ convert to p3
 					<l part="Y">ἡ κορώνη μοι πάλαι</l>
 					<l n="50">ἄνω τι φράζει.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">χὠ κολοιὸς οὑτοσὶ</l>
 					<l>ἄνω κέχηνεν ὡσπερεὶ δεικνύς τί μοι,</l>
@@ -340,7 +340,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>ἀλλ’ οἶσθ’ ὃ δρᾶσον; τῷ σκέλει θένε τὴν πέτραν.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l n="55">σὺ δὲ τῇ κεφαλῇ γ’, ἵν’ ᾖ διπλάσιος ὁ ψόφος.</l>
 				</sp>
@@ -348,7 +348,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>σὺ δ’ οὖν λίθῳ κόψον λαβών.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">πάνυ γ’, εἰ δοκεῖ.</l>
 					<l>παῖ παῖ.</l>
@@ -358,52 +358,52 @@ convert to p3
 					<l part="Y">τί λέγεις οὗτος; τὸν ἔποπα παῖ καλεῖς;</l>
 					<l>οὐκ ἀντὶ τοῦ παιδός &lt;σ’&gt; ἐχρῆν ἐποποῖ καλεῖν;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ἐποποῖ. ποιήσεις ἔτι με κόπτειν αὖθις αὖ.</l>
 					<l n="60">ἐποποῖ.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l part="Y">τίνες οὗτοι; τίς ὁ βοῶν τὸν δεσπότην;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>Ἄπολλον ἀποτρόπαιε τοῦ χασμήματος.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l>οἴμοι τάλας ὀρνιθοθήρα τουτωί.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>οὕτως τι δεινὸν οὐδὲ κάλλιον λέγειν.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l>ἀπολεῖσθον.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ἀλλ’ οὐκ ἐσμὲν ἀνθρώπω.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l part="Y">τί δαί;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l n="65">Ὑποδεδιὼς ἔγωγε Διβυκὸν ὄρνεον.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l>οὐδὲν λέγεις.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">καὶ μὴν ἐροῦ τὰ πρὸς ποδῶν.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l>ὁδὶ δὲ δὴ τίς ἐστιν ὄρνις; οὐκ ἐρεῖς;</l>
 				</sp>
@@ -411,30 +411,30 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>Ἐπικεχοδὼς ἔγωγε Φασιανικός.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ἀτὰρ σὺ τί θηρίον ποτ’ εἶ πρὸς τῶν θεῶν;</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l n="70">ὄρνις ἔγωγε δοῦλος.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ἡττήθης τινὸς</l>
 					<l>ἀλεκτρυόνος;</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l part="Y">οὐκ ἀλλ’ ὅτε περ ὁ δεσπότης</l>
 					<l>ἔποψ ἐγένετο, τότε γενέσθαι μ’ ηὔξατο</l>
 					<l>ὄρνιν, ἵν’ ἀκόλουθον διάκονόν τ’ ἔχῃ.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>δεῖται γὰρ ὄρνις καὶ διακόνου τινός;</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l n="75">οὗτός γ’, ἅτ’ οἶμαι πρότερον ἄνθρωπός ποτ’  ὤν,</l>
 					<l>τοτὲ μὲν ἐρᾷ φαγεῖν ἀφύας Φαληρικάς·</l>
@@ -442,22 +442,22 @@ convert to p3
 					<l>ἔτνους δ’ ἐπιθυμεῖ, δεῖ τορύνης καὶ χύτρας·</l>
 					<l>τρέχω ’πὶ τορύνην.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">τροχίλος ὄρνις οὑτοσί.</l>
 					<l n="80">οἶσθ’ οὖν ὃ δρᾶσον ὦ τροχίλε; τὸν δεσπότην</l>
 					<l>ἡμῖν κάλεσον.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l part="Y">ἀλλ’ ἀρτίως νὴ τὸν Δία</l>
 					<l>εὕδει καταφαγὼν μύρτα καὶ σέρφους τινάς.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ὅμως ἐπέγειρον αὐτόν.</l>
 				</sp>
-				<sp who="#theraponepopos">
+				<sp who="#therapon_epopos">
 					<speaker>Θεράπων Ἔποπος</speaker>
 					<l part="Y">οἶδα μὲν σαφῶς</l>
 					<l>ὅτι ἀχθέσεται, σφῷν δ’ αὐτὸν οὕνεκ’ ἐπεγερῶ.</l>
@@ -466,7 +466,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l n="85">κακῶς σύ γ’ ἀπόλοῑ, ὥς μ’ ἀπέκτεινας δέει.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>οἴμοι κακοδαίμων χὠ κολοιός μοἴχεται</l>
 					<l>ὑπὸ τοῦ δέους.</l>
@@ -476,7 +476,7 @@ convert to p3
 					<l part="Y">ὦ δειλότατον σὺ θηρίον,</l>
 					<l>δείσας ἀφῆκας τὸν κολοιόν;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">εἰπέ μοι,</l>
 					<l>σὺ δὲ τὴν κορώνην οὐκ ἀφῆκας καταπεσών;</l>
@@ -486,7 +486,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l n="90">μὰ Δί’ οὐκ ἔγωγε.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ποῦ γάρ ἐστ’;</l>
 				</sp>
@@ -494,7 +494,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">ἀπέπτετο.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>οὐκ ἆρ’ ἀφῆκας; ὦγάθ’ ὡς ἀνδρεῖος εἶ.</l>
 				</sp>
@@ -502,7 +502,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>ἄνοιγε τὴν ὕλην, ἵν’ ἐξέλθω ποτέ.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ὦ Ἡράκλεις τουτὶ τί ποτ’ ἐστὶ τὸ θηρίον;</l>
 					<l>τίς ἡ πτέρωσις; τίς ὁ τρόπος τῆς τριλοφίας;</l>
@@ -511,7 +511,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l n="95">τίνες εἰσί μ’ οἱ ζητοῦντες;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">οἱ δώδεκα θεοὶ</l>
 					<l>εἴξασιν ἐπιτρῖψαί σε.</l>
@@ -522,7 +522,7 @@ convert to p3
 					<l>ὁρῶντε τὴν πτέρωσιν; ἦν γὰρ ὦ ξένοι</l>
 					<l>ἄνθρωπος.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">οὐ σοῦ καταγελῶμεν.</l>
 				</sp>
@@ -530,7 +530,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l part="Y">ἀλλὰ τοῦ;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>τὸ ῥάμφος ἡμῖν σου γέλοιον φαίνεται.</l>
 				</sp>
@@ -539,7 +539,7 @@ convert to p3
 					<l n="100">τοιαῦτα μέντοι Σοφοκλέης λυμαίνεται</l>
 					<l>ἐν ταῖς τραγῳδίαισιν ἐμὲ τὸν Τηρέα.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>Τηρεὺς γὰρ εἶ σύ; πότερον ὄρνις ἢ ταὧς;</l>
 				</sp>
@@ -547,7 +547,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>ὄρνις ἔγωγε.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">κᾆτά σοι ποῦ τὰ πτερά;</l>
 				</sp>
@@ -555,7 +555,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>ἐξερρύηκε.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">πότερον ὑπὸ νόσου τινός;</l>
 				</sp>
@@ -565,7 +565,7 @@ convert to p3
 					<l>πτερορρυεῖ τε καὖθις ἕτερα φύομεν.</l>
 					<l>ἀλλ’ εἴπατόν μοι σφὼ τίν’ ἐστόν;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">νώ; βροτώ.</l>
 				</sp>
@@ -573,7 +573,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>ποδαπὼ τὸ γένος;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ὅθεν αἱ τριήρεις αἱ καλαί.</l>
 				</sp>
@@ -581,7 +581,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>μῶν ἡλιαστά;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">μἀλλὰ θατέρου τρόπου,</l>
 					<l n="110">ἀπηλιαστά.</l>
@@ -591,7 +591,7 @@ convert to p3
 					<l part="Y">σπείρεται γὰρ τοῦτ’ ἐκεῖ</l>
 					<l>τὸ σπέρμ’;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ὀλίγον ζητῶν ἂν ἐξ ἀγροῦ λάβοις.</l>
 				</sp>
@@ -599,7 +599,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>πράγους δὲ δὴ τοῦ δεομένω δεῦρ’ ἤλθετον;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>σοὶ ξυγγενέσθαι βουλομένω.</l>
 				</sp>
@@ -607,7 +607,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l part="Y">τίνος πέρι;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ὅτι πρῶτα μὲν ἦσθ’ ἄνθρωπος ὥσπερ νὼ ποτέ,</l>
 					<l n="115">κἀργύριον ὠφείλησας ὥσπερ νὼ ποτέ,</l>
@@ -623,7 +623,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>ἔμειτα μείζω τῶν Κραναῶν ζητεῖς πόλιν;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>μείζω μὲν οὐδέν, προσφορωτέραν δὲ νῷν.</l>
 					<milestone ed="p" n="125" unit="card"/>
@@ -632,7 +632,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l n="125">ἀριστοκρατεῖσθαι δῆλος εἶ ζητῶν.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ἐγώ;</l>
 					<l>ἥκιστα· καὶ &lt;γὰρ&gt; τὸν Σκελίου βδελύττομαι.</l>
@@ -641,7 +641,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>ποίαν τιν’ οὖν ἥδιστ’ ἂν οἰκοῖτ’ ἂν πόλιν;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ὅπου τὰ μέγιστα πράγματ’ εἴη τοιάδε·</l>
 					<l>ἐπὶ τὴν θύραν μου πρῴ τις ἐλθὼν τῶν φίλων</l>
@@ -679,7 +679,7 @@ convert to p3
 					<l>ἀτὰρ ἔστι γ’ ὁποίαν λέγετον εὐδαίμων πόλις</l>
 					<l n="145">παρὰ τὴν ἐρυθρὰν θάλατταν.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">οἴμοι μηδαμῶς</l>
 					<l>ἡμῖν παρὰ τὴν θάλατταν, ἵν’ ἀνακύψεται</l>
@@ -691,7 +691,7 @@ convert to p3
 					<l>τί οὐ τὸν Ἠλεῖον Λέπρεον οἰκίζετον</l>
 					<l n="150">ἐλθόνθ’;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ὁτιὴ νὴ τοὺς θεοὺς ὅσ’ οὐκ ἰδὼν</l>
 					<l>βδελύττομαι τὸν Λέπρεον ἀπὸ Μελανθίου.</l>
@@ -701,7 +701,7 @@ convert to p3
 					<l>ἀλλ’ εἰσὶν ἕτεροι τῆς Λοκρίδος Ὀπούντιοι,</l>
 					<l>ἵνα χρὴ κατοικεῖν.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ἀλλ’ ἔγωγ’ Ὀπούντιος</l>
 					<l>οὐκ ἂν γενοίμην ἐπὶ ταλάντῳ χρυσίου.</l>
@@ -713,7 +713,7 @@ convert to p3
 					<l part="Y">οὐκ ἄχαρις ἐς τὴν τριβήν·</l>
 					<l>οὗ πρῶτα μὲν δεῖ ζῆν ἄνευ βαλλαντίου.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>πολλήν γ’ ἀφεῖλες τοῦ βίου κιβδηλίαν.</l>
 				</sp>
@@ -722,7 +722,7 @@ convert to p3
 					<l>νεμόμεσθα δ’ ἐν κήποις τὰ λευκὰ σήσαμα</l>
 					<l n="160">καὶ μύρτα καὶ μήκωνα καὶ σισύμβρια.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ὑμεῖς μὲν ἆρα ζῆτε νυμφίων βίον.</l>
 				</sp>
@@ -890,7 +890,7 @@ convert to p3
 						<l>ὦ Ζεῦ βασιλεῦ τοῦ φθέγματος τοὐρνιθίου·</l>
 						<l>οἶον κατεμελίτωσε τὴν λόχμην ὃλην.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l n="225">οὗτος.</l>
 					</sp>
@@ -898,7 +898,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">τί ἔστιν; οὐ σιωπήσει;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">τί δαί;</l>
 					</sp>
@@ -944,7 +944,7 @@ convert to p3
 						<l>ἀλλ’ ἴτ’ ἐς λόγους ἅπαντα,</l>
 						<l>δεῦρο δεῦρο δεῦρο δεῦρο.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l n="260">τοροτοροτοροτοροτίξ.</l>
 						<l>κικκαβαῦ κικκαβαῦ.</l>
@@ -956,7 +956,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ὁρᾷς τιν’ ὄρνιν;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">μὰ τὸν Ἀπόλλω ’γὼ μὲν οὔ·</l>
 						<l>καίτοι κέχηνά γ’ ἐς τὸν οὐρανὸν βλέπων.</l>
@@ -970,7 +970,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#ornistis">
+					<sp who="#ornis_tis">
 						<speaker>Ὄρνις Τις</speaker>
 						<l>τοροτὶξ τοροτίξ.</l>
 					</sp>
@@ -978,7 +978,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ὦγάθ’ ἀλλ’ &lt;εἶς&gt; οὑτοσὶ καὶ δή τις ὄρνις ἔρχεται.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>νὴ Δί’ ὄρνις δῆτα. τίς ποτ’ ἐστίν; οὐ δήπου ταὧς;</l>
 					</sp>
@@ -991,7 +991,7 @@ convert to p3
 						<l>οὗτος οὐ τῶν ἠθάδων τῶνδ’ ὧν ὁρᾶθ’ ὑμεῖς ἀεί,</l>
 						<l>ἀλλὰ λιμναῖος.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">βαβαὶ καλός γε καὶ φοινικιοῦς.</l>
 					</sp>
@@ -999,7 +999,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>εἰκότως &lt;γε&gt;· καὶ γὰρ ὄνομ’ αὐτῷ ’στὶ φοινικόπτερος.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>οὗτος ὦ σέ τοι.</l>
 					</sp>
@@ -1007,7 +1007,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">τί βωστρεῖς;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">ἕτερος ὄρνις οὑτοσί.</l>
 					</sp>
@@ -1025,7 +1025,7 @@ convert to p3
 						<l part="Y">Μῆδος; ὦναξ Ἡράκλεις·</l>
 						<l>εἶτα πῶς ἄνευ καμήλου Μῆδος ὤν εἰσέπτετο;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ἕτερος αὖ λόφον κατειληφώς τις ὄρνις οὑτοσί.</l>
 					</sp>
@@ -1044,7 +1044,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>Καλλίας ἄρ’ οὗτος οὕρνις ἐστίν· ὡς πτερορρυεῖ.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l n="285">ἅτε γὰρ ὢν γενναῖος ὑπό &lt;τε&gt; συκοφαντῶν τίλλεται,</l>
 						<l>αἵ τε θήλειαι προσεκτίλλουσιν αὐτοῦ τὰ πτερά.</l>
@@ -1062,7 +1062,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἔστι γὰρ κατωφαγᾶς τις ἄλλος ἢ Κλεώνυμος;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l n="290">πῶς ἂν οὖν Κλεώνυμός γ’ ὢν οὐκ ἀπέβαλε τὸν  λόφον;</l>
 					</sp>
@@ -1081,7 +1081,7 @@ convert to p3
 						<l>ὦ Πόσειδον οὐχ ὁρᾷς ὅσον συνείλεκται κακὸν</l>
 						<l n="295">ὀρνέων;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">ὦναξ Ἄπολλον τοῦ νέφους. ἰοὺ ἰού,</l>
 						<l>οὐδ’ ἰδεῖν ἔτ’ ἔσθ’ ὑπ’ αὐτῶν πετομένων τὴν εἴσοδον.</l>
@@ -1108,7 +1108,7 @@ convert to p3
 						<l part="Y">οὐ γάρ ἐστι Σποργίλος;</l>
 						<l>χαὐτηί γε γλαῦξ.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">τί φῄς; τίς γλαῦκ’ Ἀθήναζ’ ἤγαγεν;</l>
 					</sp>
@@ -1126,12 +1126,12 @@ convert to p3
 						<l>καὶ βλέπουσιν ἐς σὲ κἀμέ.</l>
 						 
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">τοῦτο μὲν κἀμοὶ δοκεῖ.</l>
 						<milestone ed="p" n="310" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="310">ποποποποποποποποποποῖ ποῦ μ’ ἄρ’ ὃς</l>
 						<l>ἐκάλεσε; τίνα τόπον ἄρα ποτὲ νέμεται;</l>
@@ -1140,7 +1140,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>οὑτοσὶ πάλαι πάρειμι κοὐκ ἀποστατῶ φίλων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί τί τί τί τί τί τί τί· τίνα λόγον ἄρα ποτὲ</l>
 						<l n="315">πρὸς ἐμὲ φίλον ἔχων;</l>
@@ -1150,7 +1150,7 @@ convert to p3
 						<l>κοινὸν ἀσφαλῆ δίκαιον ἡδὺν ὠφελήσιμον.</l>
 						<l>ἄνδρε γὰρ λεπτὼ λογιστὰ δεῦρ’ ἀφῖχθον ὡς ἐμέ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποῦ; πᾷ; πῶς φῄς;</l>
 					</sp>
@@ -1159,7 +1159,7 @@ convert to p3
 						<l n="320">φήμ’ ἀπ’ ἀνθρώπων ἀφῖχθαι δεῦρο πρεσβύτα δύο·</l>
 						<l>ἥκετον δ’ ἔχοντε πρέμνον πράγματος πελωρίου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ μέγιστον ἐξαμαρτὼν ἐξ ὅτου ’τράφην ἐγώ,</l>
 						<l>πῶς λέγεις;</l>
@@ -1168,7 +1168,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l part="Y">μήπω φοβηθῇς τὸν λόγον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τί μ’ ἠργάσω;</l>
 					</sp>
@@ -1176,7 +1176,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>ἄνδρ’ ἐδεξάμην ἐραστὰ τῆσδε τῆς ξυνουσίας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="325">καὶ δέδρακας τοῦτο τοὔργον;</l>
 					</sp>
@@ -1184,7 +1184,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l part="Y">καὶ δεδρακώς γ’ ἥδομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κἀστὸν ἤδη που παρ’ ἡμῖν;</l>
 					</sp>
@@ -1197,7 +1197,7 @@ convert to p3
 			</div1>
 			<div1 type="Agon">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔα ἔα,</l>
 						<l>προδεδόμεθ’ ἀνόσιά τ’ ἐπάθομεν·</l>
@@ -1213,7 +1213,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ πρὸς τοῦτον μὲν ἡμῖν ἐστιν ὕστερος λόγος·</l>
 						<l>τὼ δὲ πρεσβύτα δοκεῖ μοι τώδε δοῦναι τὴν δίκην</l>
@@ -1226,7 +1226,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>αἴτιος μέντοι σὺ νῷν εἶ τῶν κακῶν τούτων  μόνος.</l>
 						<l n="340">ἐπὶ τί γάρ μ’ ἐκεῖθεν ἦγες;</l>
@@ -1235,7 +1235,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">ἵν’ ἀκολουθοίης ἐμοί.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ἵνα μὲν οὖν κλάοιμι μεγάλα.</l>
 					</sp>
@@ -1247,7 +1247,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰώ,</l>
 						<l>ἔπαγ’ ἔπιθ’ ἐπίφερε πολέμιον</l>
@@ -1263,7 +1263,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antikatakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ μὴ μέλλωμεν ἤδη τώδε τίλλειν καὶ δάκνειν.</l>
 						<l>ποῦ ’σθ’ ὁ ταξίαρχος; ἐπαγέτω τὸ δεξιὸν κέρας.</l>
@@ -1271,7 +1271,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>τοῦτ’ ἐκεῖνο· ποῖφύγω δύστηνος;</l>
 					</sp>
@@ -1279,7 +1279,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">οὗτος οὐ μενεῖς;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l n="355">ἵν’ ὑπὸ τούτων διαφορηθῶ;</l>
 					</sp>
@@ -1288,7 +1288,7 @@ convert to p3
 						<l part="Y">πῶς γὰρ ἂν τούτους δοκεῖς</l>
 						<l>ἐκφυγεῖν;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">οὐκ οἶδ’ ὅπως ἄν.</l>
 					</sp>
@@ -1297,7 +1297,7 @@ convert to p3
 						<l part="Y">ἀλλ’ ἐγώ τοί σοι λέγω,</l>
 						<l>ὅτι μένοντε δεῖ μάχεσθαι λαμβάνειν τε τῶν χυτρῶν.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>τί δὲ χύτρα νώ γ’ ὠφελήσει;</l>
 					</sp>
@@ -1305,7 +1305,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">γλαῦξ μὲν οὐ πρόσεισι νῷν.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>τοῖς δὲ γαμψώνυξι τοισδί;</l>
 					</sp>
@@ -1314,7 +1314,7 @@ convert to p3
 						<l part="Y">τὸν ὀβελίσκον ἁρπάσας</l>
 						<l n="360">εἶτα κατάπηξον πρὸ σαυτοῦ.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">τοῖσι δ’ ὀφθαλμοῖσι τί;</l>
 					</sp>
@@ -1322,12 +1322,12 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ὀξύβαφον ἐντευθενὶ προσδοῦ λαβὼν ἢ τρύβλιον.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ὦ σοφώτατ’, εὖ γ’ ἀνηῦρες αὐτὸ καὶ στρατηγικῶς·</l>
 						<l>ὑπερακοντίζεις σύ γ’ ἤδη Νικίαν ταῖς μηχαναῖς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐλελελεῦ χώρει κάθες τὸ ῥύγχος· οὐ μέλλειν ἐχρῆν.</l>
 						<l n="365">ἕλκε τίλλε παῖε δεῖρε, κόπτε πρώτην τὴν χύτραν.</l>
@@ -1338,7 +1338,7 @@ convert to p3
 						<l>ἀπολέσαι παθόντες οὐδὲν ἄνδρε καὶ διασπάσαι</l>
 						<l>τῆς ἐμῆς γυναικὸς ὄντε ξυγγενεῖ καὶ φυλέτα;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φεισόμεσθα γάρ τι τῶνδε μᾶλλον ἡμεῖς ἢ λύκων;</l>
 						<l n="370">ἢ τίνας τεισαίμεθ’ ἄλλους τῶνδ’ ἂν ἐχθίους  ἔτι;</l>
@@ -1348,7 +1348,7 @@ convert to p3
 						<l>εἰ δὲ τὴν φύσιν μὲν ἐχθροὶ τὸν δὲ νοῦν εἰσιν φίλοι,</l>
 						<l>καὶ διδάξοντές τι δεῦρ’ ἥκουσιν ὑμᾶς χρήσιμον;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς δ’ ἂν οἵδ’ ἡμᾶς τι χρήσιμον διδάξειάν ποτε</l>
 						<l>ἢ φράσειαν, ὄντες ἐχθροὶ τοῖσι πάπποις τοῖς ἐμοῖς;</l>
@@ -1362,7 +1362,7 @@ convert to p3
 						<l>ἐκπονεῖν θ’ ὑψηλὰ τείχη ναῦς τε κεκτῆσθαι μακράς·</l>
 						<l n="380">τὸ δὲ μάθημα τοῦτο σῴζει παῖδας οἶκον χρήματα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔστι μὲν λόγων ἀκοῦσαι πρῶτον, ὡς ἡμῖν δοκεῖ,</l>
 						<l>χρήσιμον· μάθοι γὰρ ἄν τις κἀπὸ τῶν ἐχθρῶν σοφόν.</l>
@@ -1375,7 +1375,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>καὶ δίκαιόν γ’ ἐστὶ κἀμοὶ δεῖ νέμειν ὑμᾶς χάριν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="385">ἀλλὰ μὴν οὐδ’ ἄλλο σοί πω πρᾶγμ’ ἐνηντιώμεθα.</l>
 						<milestone ed="p" n="386" unit="card"/>
@@ -1392,7 +1392,7 @@ convert to p3
 						<l>τὴν χύτραν ἄκραν ὁρῶντας</l>
 						<l>ἐγγύς· ὡς οὐ φευκτέον νῷν.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ἐτεὸν ἢν δ’ ἄρ’ ἀποθάνωμεν,</l>
 						<l>κατορυχθησόμεσθα ποῦ γῆς;</l>
@@ -1411,7 +1411,7 @@ convert to p3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="400">ἄναγ’ ἐς τάξιν πάλιν ἐς ταὐτόν,</l>
 						<l>καὶ τὸν θυμὸν κατάθου κύψας</l>
@@ -1429,7 +1429,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>καλεῖς δὲ τοῦ κλύειν θέλων;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίνες ποθ’ οἵδε καὶ πόθεν;</l>
 					</sp>
@@ -1437,7 +1437,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>ξείνω σοφῆς ἀφ’ Ἑλλάδος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="410">τύχη δὲ ποία κομίζει</l>
 						<l>ποτ’ αὐτὼ πρὸς ὄρνιθας</l>
@@ -1450,7 +1450,7 @@ convert to p3
 						<l>σοῦ ξυνοικεῖν τέ σοι</l>
 						<l n="415">καὶ ξυνεῖναι τὸ πᾶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί φῄς;</l>
 						<l>λέγουσι δὴ τίνας λόγους;</l>
@@ -1459,7 +1459,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>ἄπιστα καὶ πέρα κλύειν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρᾷ τι κέρδος ἐνθάδ’ ἄξιον</l>
 						<l>μονῆς, ὅτῳ πέποιθ’</l>
@@ -1475,7 +1475,7 @@ convert to p3
 						<l n="425">τὸ τῇδε καὶ τὸ κεῖσε καὶ</l>
 						<l>τὸ δεῦρο προσβιβᾷ λέγων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πότερα μαινόμενος;</l>
 					</sp>
@@ -1483,7 +1483,7 @@ convert to p3
 						<speaker>Ἔποψ</speaker>
 						<l>ἄφατον ὡς φρόνιμος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔνι σοφόν τι φρενί;</l>
 					</sp>
@@ -1492,7 +1492,7 @@ convert to p3
 						<l n="430">πυκνότατον κίναδος,</l>
 						<l>σόφισμα κύρμα τρῖμμα παιπάλημ’ ὅλον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λέγειν λέγειν κέλευέ μοι.</l>
 						<l>κλύων γὰρ ὧν σύ μοι λέγεις</l>
@@ -1518,7 +1518,7 @@ convert to p3
 					<l>ὁ μαχαιροποιός, μήτε δάκνειν τούτους ἐμὲ</l>
 					<l>μήτ’ ὀρχίπεδ’ ἕλκειν μήτ’ ὀρύττειν —</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">οὔτι που</l>
 					<l>τόν —; οὐδαμῶς.</l>
@@ -1527,7 +1527,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">οὔκ, ἀλλὰ τὠφθαλμὼ λέγω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>διατίθεμαι ’γώ.</l>
 				</sp>
@@ -1535,7 +1535,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">κατόμοσόν νυν ταῦτά μοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="445">ὄμνυμ’ ἐπὶ τούτοις, πᾶσι νικᾶν τοῖς κριταῖς</l>
 					<l>καὶ τοῖς θεαταῖς πᾶσιν.</l>
@@ -1544,11 +1544,11 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">ἔσται ταυταγί.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἰ δὲ παραβαίην, ἑνὶ κριτῇ νικᾶν μόνον.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἀκούετε λεῴ· τοὺς ὁπλίτας νυνμενὶ</l>
 					<l>ἀνελομένους θὤπλ’ ἀπιέναι πάλιν οἴκαδε,</l>
@@ -1558,7 +1558,7 @@ convert to p3
 			</div1>
 			<div1 type="Agon">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δολερὸν μὲν ἀεὶ κατὰ πάντα δὴ τρόπον</l>
 						<l>πέφυκεν ἄνθρωπος· σὺ δ’ ὅμως λέγε μοι.</l>
@@ -1573,7 +1573,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="katakeleusmos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="460">ἀλλ’ ἐφ’ ὅτῳπερ πράγματι τὴν σὴν ἥκεις γνώμην  ἀναπείσας,</l>
 						<l>λέγε θαρρήσας· ὡς τὰς σπονδὰς οὐ μὴ πρότεροι παραβῶμεν.</l>
@@ -1587,7 +1587,7 @@ convert to p3
 						<l>ὃν διαμάττειν οὐ κωλύει· φέρε παῖ στέφανον· καταχεῖσθαι</l>
 						<l>κατὰ χειρὸς ὕδωρ φερέτω ταχύ τις.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">δειπνήσειν μέλλομεν; ἢ τί;</l>
 					</sp>
@@ -1597,7 +1597,7 @@ convert to p3
 						<l>ὅ το τὴν τούτων θραύσει ψυχήν· οὕτως ὑμῶν ὑπεραλγῶ,</l>
 						<l>οἵτινες ὄντες πρότερον βασιλῆς —</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἡμεῖς βασιλῆς; τίνος;</l>
 					</sp>
@@ -1608,7 +1608,7 @@ convert to p3
 						<l>ἀρχαιότεροι πρότεροί τε Κρόνου καὶ Τιτάνων ἐγένεσθε,</l>
 						<l>καὶ γῆς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">καὶ γῆς;</l>
 					</sp>
@@ -1616,7 +1616,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">νὴ τὸν Ἀπόλλω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="470">τουτὶ μὰ Δί’ οὐκ ἐπεπύσμην.</l>
 					</sp>
@@ -1628,7 +1628,7 @@ convert to p3
 						<l>γῆν δ’ οὐκ εἶναι, τὸν δὲ προκεῖσθαι πεμπταῖον· τὴν δ’ ἀποροῦσαν</l>
 						<l n="475">ὑπ’ ἀμηχανίας τὸν πατέρ’ αὑτῆς ἐν τῇ κεφαλῇ  κατορύξαι.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ὁ πατὴρ ἄρα τῆς κορυδοῦ νυνὶ κεῖται τεθνεὼς Κεφαλῆσιν.</l>
 					</sp>
@@ -1637,7 +1637,7 @@ convert to p3
 						<l>οὔκουν δῆτ’ εἰ πρότεροι μὲν γῆς πρότεροι δὲ θεῶν ἐγένοντο,</l>
 						<l>ὡς πρεσβυτάτων αὐτῶν ὄντῶν ὀρθῶς ἐσθ’ ἡ βασιλεία;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>νὴ τὸν Ἀπόλλω· πάνυ τοίνυν χρὴ ῥύγχος βόσκειν σε τὸ  λοιπόν·</l>
 						<l n="480">οὐκ ἀποδώσει ταχέως ὁ Ζεὺς τὸ σκῆπτρον τῷ δρυκολάπτῃ.</l>
@@ -1650,7 +1650,7 @@ convert to p3
 						<l>ἦρχέ τε Περσῶν πρῶτον πάντων Δαρείου καὶ Μεγαβάζου,</l>
 						<l n="485">ὥστε καλεῖται Περσικὸς ὄρνις ἀπὸ τῆς ἀρχῆς ἔτ’ ἐκείνης.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>διὰ ταῦτ’ ἄρ’ ἔχων καὶ νῦν ὥσπερ βασιλεὺς ὁ μέγας  διαβάσκει</l>
 						<l>ἐπὶ τῆς κεφαλῆς τὴν κυρβασίαν τῶν ὀρνίθων μόνος ὀρθήν.</l>
@@ -1663,7 +1663,7 @@ convert to p3
 						<l>σκυτῆς βαλανῆς ἀλφιταμοιβοὶ τορνευτολυρασπιδοπηγοί·</l>
 						<l>οἱ δὲ βαδίζουσ’ ὑποδησάμενοι νύκτωρ.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">ἐμὲ τοῦτό γ’ ἐρώτα.</l>
 						<l>χλαῖναν γὰρ ἀπώλεσ’ ὁ μοχθηρὸς Φρυγίων ἐρίων διὰ τοῦτον.</l>
@@ -1678,7 +1678,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἰκτῖνος δ’ οὖν τῶν Ἑλλήνων ἦρχεν τότε κἀβασίλευεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="500">τῶν Ἑλλήνων;</l>
 					</sp>
@@ -1687,7 +1687,7 @@ convert to p3
 						<l part="Y">καὶ κατέδειξέν γ’ οὗτος πρῶτος βασιλεύων</l>
 						<l>προκυλινδεῖσθαι τοῖς ἰκτίνοις.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">νὴ τὸν Διόνυσον, ἐγὼ γοῦν</l>
 						<l>ἐκυλινδούμην ἰκτῖνον ἰδών· κᾆθ’ ὕπτιος ὢν ἀναχάσκων</l>
@@ -1699,7 +1699,7 @@ convert to p3
 						<l n="505">χὠπόθ’ ὁ κόκκυξ εἴποι ‘κόκκυ,’ τότ’ ἂν οἱ Φοίνικες  ἅπαντες</l>
 						<l>τοὺς πυροὺς ἂν καὶ τὰς κριθὰς ἐν τοῖς πεδίοις ἐθέριζον.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>τοῦτ’ ἄρ’ ἐκεῖν’ ἦν τοὔπος ἀληθῶς· ‘κόκκυψωλοὶ  πεδίονδε.’</l>
 					</sp>
@@ -1709,7 +1709,7 @@ convert to p3
 						<l>ἐν ταῖς πόλεσιν τῶν Ἑλλήνων Ἀγαμέμνων ἢ Μενέλαος,</l>
 						<l n="510">ἐπὶ τῶν σκήπτρων ἐκάθητ’ ὄρνις μετέχων ὅ τι δωροδοκοίη.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>τουτὶ τοίνυν οὐκ ᾔδη ’γώ· καὶ δῆτά μ’ ἐλάμβανε θαῦμα,</l>
 						<l>ὁπότ’ ἐξέλθοι Πρίαμός τις ἔχων ὄρνιν ἐν τοῖσι τραγῳδοῖς,</l>
@@ -1721,7 +1721,7 @@ convert to p3
 						<l n="515">αἰετὸν ὄρνιν ἕστηκεν ἔχων ἐπὶ τῆς κεφαλῆς βασιλεὺς ὤν,</l>
 						<l>ἡ δ’ αὖ θυγάτηρ γλαῦχ’, ὁ δ’ Ἀπόλλων ὥσπερ θεράπων ἱέρακα.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>νὴ τὴν Δήμητρ’ εὖ ταῦτα λέγεις. τίνος οὕνεκα ταῦτ’ ἄρ’  ἔχουσιν;</l>
 					</sp>
@@ -1758,7 +1758,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολὺ δὴ πολὺ δὴ χαλεπωτάτους λόγους</l>
 						<l n="540">ἤνεγκας ἄνθρωφ’. ὡς ἐδάκρυσά γ’ ἐμῶν</l>
@@ -1773,7 +1773,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="antikatakeleusmos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ὅ τι χρὴ δρᾶν, σὺ δίδασκε παρών· ὡς ζῆν οὐκ  ἄξιον ἡμῖν,</l>
 						<l>εἰ μὴ κομιούμεθα παντὶ τρόπῳ τὴν ἡμετέραν βασιλείαν.</l>
@@ -1810,11 +1810,11 @@ convert to p3
 						<l>κἂν Διὶ θύῃ βασιλεῖ κριόν, βασιλεύς ἐστ’ ὀρχίλος ὄρνις,</l>
 						<l>ᾧ προτέρῳ δεῖ τοῦ Διὸς αὐτοῦ σέρφον ἐνόρχην σφαγιάζειν.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l n="570">ἥσθην σέρφῳ σφαγιαζομένῳ. βροντάτω νῦν ὁ μέγας  Ζάν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ πῶς ἡμᾶς νομιοῦσι θεοὺς ἄνθρωποι κοὐχὶ κολοιούς,</l>
 						<l>οἳ πετόμεσθα πτέρυγάς τ’ ἔχομεν;</l>
@@ -1826,7 +1826,7 @@ convert to p3
 						<l>αὐτίκα Νίκη πέτεται πτερύγοιν χρυσαῖν καὶ νὴ Δί’ Ἔρως γε·</l>
 						<l n="575">Ἥρην δέ γ’ Ὅμηρος ἔφασκ’ ἰκέλην εἶναι τρήρωνι  πελείῃ.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ὁ Ζεὺς δ’ ἡμῖν οὐ βροντήσας πέμψει πτερόεντα κεραυνόν;</l>
 					</sp>
@@ -1837,7 +1837,7 @@ convert to p3
 						<l>καὶ σπερμολόγων ἐκ τῶν ἀγρῶν τὸ σπέρμ’ αὐτῶν ἀνακάψαι·</l>
 						<l n="580">κἄπειτ’ αὐτοῖς ἡ Δημήτηρ πυροὺς πεινῶσι  μετρείτω.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>οὐκ ἐθελήσει μὰ Δί’, ἀλλ’ ὄψει προφάσεις αὐτὴν παρέχουσαν.</l>
 					</sp>
@@ -1847,7 +1847,7 @@ convert to p3
 						<l>καὶ τῶν προβάτων τοὺς ὀφθαλμοὺς ἐκκοψάντων ἐπὶ πείρᾳ·</l>
 						<l>εἶθ’ ὅ γ’ Ἀπόλλων ἰατρός &lt;γ’&gt; ὢν ἰάσθω· μισθοφορεῖ δέ.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l n="585">μὴ πρίν γ’ ἂν ἐγὼ τὼ βοιδαρίω τὠμὼ πρώτιστ’  ἀποδῶμαι.</l>
 					</sp>
@@ -1887,7 +1887,7 @@ convert to p3
 						<l>προερεῖ τις ἀεὶ τῶν ὀρνίθων μαντευομένῳ περὶ τοῦ πλοῦ·</l>
 						<l>‘νυνὶ μὴ πλεῖ, χειμὼν ἔσται·’ ‘νυνὶ πλεῖ, κέρδος  ἐπέσται.’</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>γαῦλον κτῶμαι καὶ ναυκληρῶ, κοὐκ ἂν μείναιμι παρ’ ὑμῖν.</l>
 					</sp>
@@ -1897,7 +1897,7 @@ convert to p3
 						<l n="600">τῶν ἀργυρίων· οὗτοι γὰρ ἴσασι· λέγουσι δέ τοι τάδε  πάντες,</l>
 						<l>‘οὐδεὶς οἶδεν τὸν θησαυρὸν τὸν ἐμὸν πλὴν εἴ τις ἄρ’  ὄρνις.’</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>πωλῶ γαῦλον, κτῶμαι σμινύην, καὶ τὰς ὑδρίας ἀνορύττω.</l>
 					</sp>
@@ -1929,7 +1929,7 @@ convert to p3
 						<l part="Y">παρ’ ὅτου; παρ’ ἑαυτῶν.</l>
 						<l>οὐκ οἶσθ’ ὅτι πέντ’ ἀνδρῶν γενεὰς ζώει λακέρυζα κορώνη;</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l n="610">αἰβοῖ πολλῷ κρείττους οὗτοι τοῦ Διὸς ἡμῖν βασιλεύειν.</l>
 						<milestone ed="p" n="611" unit="card"/>
@@ -1960,7 +1960,7 @@ convert to p3
 			</div1>
 			<div1 type="Lyric-Scene">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ φίλτατ’ ἐμοὶ πολὺ πρεσβυτῶν ἐξ ἐχθίστου μεταπίπτων,</l>
 						<l>οὐκ ἔστιν ὅπως ἂν ἐγώ ποθ’ ἑκὼν τῆς σῆς γνώμης ἔτ’  ἀφείμην.</l>
@@ -2055,7 +2055,7 @@ convert to p3
 					<milestone ed="p" n="658" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὗτος σὲ καλῶ, σὲ λέγω.</l>
 					</sp>
@@ -2067,7 +2067,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τούτους μὲν ἄγων μετὰ σαυτοῦ</l>
 						<l>ἀρίστισον εὖ· τὴν δ’ ἡδυμελῆ ξύμφωνον ἀηδόνα Μούσαις</l>
@@ -2078,7 +2078,7 @@ convert to p3
 						<l>ὦ τοῦτο μεντοι νὴ Δί’ αὐτοῖσιν πιθοῦ·</l>
 						<l>ἐκβίβασον ἐκ τοῦ βουτόμου τοὐρνίθιον.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ἐκβίβασον αὐτοῦ πρὸς θεῶν αὐτήν, ἵνα</l>
 						<l>καὶ νὼ θεασώμεσθα τὴν ἀηδόνα.</l>
@@ -2093,7 +2093,7 @@ convert to p3
 						<l>ὦ Ζεῦ πολυτίμηθ’ ὡς καλὸν τοὐρνίθιον,</l>
 						<l>ὡς δ’ ἁπαλόν, ὡς δὲ λευκόν.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l part="Y">ἆρά γ’ οἶσθ’ ὅτι</l>
 						<l>ἐγὼ διαμηρίζοιμ’ ἂν αὐτὴν ἡδέως;</l>
@@ -2102,7 +2102,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l n="670">ὅσον δ’ ἔχει τὸν χρυσόν, ὥσπερ παρθένος.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ἐγὼ μὲν αὐτὴν κἂν φιλῆσαί μοι δοκῶ.</l>
 					</sp>
@@ -2110,7 +2110,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἀλλ’ ὦ κακόδαιμον ῥύγχος ὀβελίσκοιν ἔχει.</l>
 					</sp>
-					<sp who="#eyelpides">
+					<sp who="#euelpides">
 						<speaker>Ἐυελπίδης</speaker>
 						<l>ἀλλ’ ὥσπερ ᾠὸν νὴ Δί’ ἀπολέψαντα χρὴ</l>
 						<l>ἀπὸ τῆς κεφαλῆς τὸ λέμμα κᾆθ’ οὕτω φιλεῖν.</l>
@@ -2128,7 +2128,7 @@ convert to p3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ φίλη, ὦ ξουθή,</l>
 						<l>ὦ φίλτατον ὀρνέων</l>
@@ -2144,7 +2144,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="parabasis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="685">ἄγε δὴ φύσιν ἄνδρες ἀμαυρόβιοι, φύλλων γενεᾷ  προσόμοιοι,</l>
 						<l>ὀλιγοδρανέες, πλάσματα πηλοῦ, σκιοειδέα φῦλ’ ἀμενηνά,</l>
@@ -2173,7 +2173,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="parabasis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάντα δὲ θνητοῖς ἐστὶν ἀφ’ ἡμῶν τῶν ὀρνίθων τὰ μέγιστα.</l>
 						<l>πρῶτα μὲν ὥρας φαίνομεν ἡμεῖς ἦρος χειμῶνος ὀπώρας·</l>
@@ -2196,7 +2196,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἢν οὖν ἡμᾶς νομίσητε θεούς,</l>
 						<l>ἕξετε χρῆσθαι μάντεσι Μούσαις</l>
@@ -2216,7 +2216,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Μοῦσα λοχμαία,</l>
 						<l>τιὸ τιὸ τιὸ τιὸ τιὸ τιὸ τιοτίγξ,</l>
@@ -2237,7 +2237,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ μετ’ ὀρνίθων τις ὑμῶν ὦ θεαταὶ βούλεται</l>
 						<l>διαπλέκειν ζῶν ἡδέως τὸ λοιπόν, ὡς ἡμᾶς ἴτω.</l>
@@ -2259,7 +2259,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοιάδε κύκνοι,</l>
 						<l n="770">τιὸ τιὸ τιὰ τιὸ τιὸ τιοτίγξ,</l>
@@ -2280,7 +2280,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="785">οὐδέν ἐστ’ ἄμεινον οὐδ’ ἥδιον ἢ φῦσαι πτερά.</l>
 						<l>αὐτίχ’ ὑμῶν τῶν θεατῶν εἴ τις ἧν ὑπόπτερος,</l>
@@ -2308,7 +2308,7 @@ convert to p3
 					<l>ταυτὶ τοιαυτί· μὰ Δί’ ἐγὼ μὲν πρᾶγμά πω</l>
 					<l>γελοιότερον οὐκ εἶδον οὐδεπώποτε.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ἐπὶ τῷ γελᾷς;</l>
 				</sp>
@@ -2318,7 +2318,7 @@ convert to p3
 					<l>οἶσθ’ ᾧ μάλιστ’ ἔοικας ἐπτερωμένος;</l>
 					<l n="805">εἰς εὐτέλειαν χηνὶ συγγεγραμμένῳ.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>σὺ δὲ κοψίχῳ γε σκάφιον ἀποτετιλμένῳ.</l>
 				</sp>
@@ -2337,7 +2337,7 @@ convert to p3
 					<l n="810">θέσθαι τι μέγα καὶ κλεινόν, εἶτα τοῖς θεοῖς</l>
 					<l>θῦσαι μετὰ τοῦτο.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ταῦτα κἀμοὶ συνδοκεῖ.</l>
 				</sp>
@@ -2345,7 +2345,7 @@ convert to p3
 					<speaker>Ἔποψ</speaker>
 					<l>φέρ’ ἴδω, τί δ’ ἡμῖν τοὔνομ’ ἔσται τῇ πόλει;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>βούλεσθε τὸ μέγα τοῦτο τοὐκ Λακεδαίμονος</l>
 					<l>Σπάρτην ὄνομα καλῶμεν αὐτήν;</l>
@@ -2356,7 +2356,7 @@ convert to p3
 					<l n="815">Σπάρτην γὰρ ἂν θείμην ἐγὼ τἠμῇ πόλει;</l>
 					<l>οὐδ’ ἂν χαμεύνῃ πάνυ γε κειρίαν γ’ ἔχων.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>τί δῆτ’ ὄνομ’ αὐτῇ θησόμεσθ’;</l>
 				</sp>
@@ -2375,7 +2375,7 @@ convert to p3
 					<l>ἰοὺ ἰού·</l>
 					<l n="820">καλόν γ’ ἀτεχνῶς &lt;σὺ&gt; καὶ μέγ’ ηὗρες  τοὔνομα.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>ἆρ’ ἐστὶν αὑτηγὶ Νεφελοκοκκυγία,</l>
 					<l>ἵνα καὶ τὰ Θεογένους τὰ πολλὰ χρήματα</l>
@@ -2392,7 +2392,7 @@ convert to p3
 					<l>λιπαρὸν τὸ χρῆμα τῆς πόλεως. τίς δαὶ θεὸς</l>
 					<l>πολιοῦχος ἔσται; τῷ ξανοῦμεν τὸν πέπλον;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>τί δ’ οὐκ Ἀθηναίαν ἐῶμεν Πολιάδα;</l>
 				</sp>
@@ -2402,7 +2402,7 @@ convert to p3
 					<l n="830">ὅπου θεὸς γυνὴ γεγονυῖα πανοπλίαν</l>
 					<l>ἕστηκ’ ἔχουσα, Κλεισθένης δὲ κερκίδα;</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l>τίς δαὶ καθέξει τῆς πόλεως τὸ Πελαργικόν;</l>
 				</sp>
@@ -2412,7 +2412,7 @@ convert to p3
 					<l>ὅσπερ λέγεται δεινότατος εἶναι πανταχοῦ</l>
 					<l n="835">Ἄρεως νεοττός.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">ὦ νεοττὲ δέσποτα·</l>
 					<l>ὡς δ’ ὁ θεὸς ἐπιτήδειος οἰκεῖν ἐπὶ πετρῶν.</l>
@@ -2429,7 +2429,7 @@ convert to p3
 					<l>ἕτερον δ’ ἄνωθεν ἆυ παρ’ ἀνθρώπους κάτω,</l>
 					<l n="845">κἀκεῖθεν αὖθις παρ’ ἐμέ.</l>
 				</sp>
-				<sp who="#eyelpides">
+				<sp who="#euelpides">
 					<speaker>Ἐυελπίδης</speaker>
 					<l part="Y">σὺ δέ γ’ αὐτοῦ μένων</l>
 					<l>οἴμωζε παρ’ ἔμ’.</l>
@@ -2444,7 +2444,7 @@ convert to p3
 					<milestone ed="p" n="851" unit="card"/>
 				</sp>
 				<div2 n="1" type="strophe">
-					<sp who="#iereys">
+					<sp who="#hiereus">
 						<speaker>Ἱερεύς</speaker>
 						<l>ὁμορροθῶ, συνθέλω,</l>
 						<l>συμπαραινέσας ἔχω</l>
@@ -2461,7 +2461,7 @@ convert to p3
 						<l>οὔπω κόρακ’ εἶδον ἐμπεφορβειωμένον.</l>
 						<l>ἱερεῦ σὸν ἔργον, θῦε τοῖς καινοῖς θεοῖς.</l>
 					</sp>
-					<sp who="#iereys">
+					<sp who="#hiereus">
 						<speaker>Ἱερεύς</speaker>
 						<l met="prose" n="864">δράσω τάδ’. ἀλλὰ ποῦ ’στιν ὁ τὸ κανοῦν ἔχων;</l>
 						<l met="prose">εὔχεσθε τῇ Ἑστίᾳ τῇ ὀρνιθείῳ καὶ τῷ ἰκτίνῳ τῷ  ἑστιούχῳ καὶ ὄρνισιν Ὀλυμπίοις καὶ Ὀλυμπίῃσι πᾶσι καὶ πάσῃσιν —</l>
@@ -2470,7 +2470,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ὦ Σουνιέρακε χαῖρ’ ἄναξ Πελαργικέ.</l>
 					</sp>
-					<sp who="#iereys">
+					<sp who="#hiereus">
 						<speaker>Ἱερεύς</speaker>
 						<l met="dactyl">καὶ κύκνῳ Πυθίῳ καὶ Δηλίῳ καὶ Λητοῖ Ὀρτυγομήτρᾳ καὶ Ἀρτέμιδι Ἀκαλανθίδι —</l>
 					</sp>
@@ -2478,7 +2478,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>οὐκέτι Κολαινὶς ἀλλ’ Ἀκαλανθὶς Ἄρτεμις.</l>
 					</sp>
-					<sp who="#iereys">
+					<sp who="#hiereus">
 						<speaker>Ἱερεύς</speaker>
 						<l met="prose" n="876">καὶ φρυγίλῳ Σαβαζίῳ καὶ στρούθῳ μεγάλῃ μητρὶ θεῶν  καὶ ἀνθρώπων —</l>
 					</sp>
@@ -2486,7 +2486,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>δέσποινα Κυβέλη, στροῦθε, μῆτερ Κλεοκρίτου.</l>
 					</sp>
-					<sp who="#iereys">
+					<sp who="#hiereus">
 						<speaker>Ἱερεύς</speaker>
 						<l met="prose">διδόναι Νεφελοκοκκυγιεῦσιν ὑγιείαν καὶ σωτηρίαν αὐτοῖσι καὶ Χίοισι  —</l>
 					</sp>
@@ -2494,7 +2494,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l n="880">Χίοισιν ἥσθην πανταχοῦ προσκειμένοις.</l>
 					</sp>
-					<sp who="#iereys">
+					<sp who="#hiereus">
 						<speaker>Ἱερεύς</speaker>
 						<l met="prose">καὶ ἥρωσιν ὄρνισι καὶ ἡρώων παισί, πορφυρίωνι καὶ πελεκᾶντι καὶ πελεκίνῳ καὶ φλέξιδι καὶ τέτρακι καὶ ταὧνι καὶ ἐλεᾷ καὶ βασκᾷ καὶ ἐλασᾷ καὶ ἐρωδιῷ καὶ καταρράκτῃ καὶ μελαγκορύφῳ καὶ αἰγιθάλλῳ —</l>
 					</sp>
@@ -2510,7 +2510,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#iereys">
+					<sp who="#hiereus">
 						<speaker>Ἱερεύς</speaker>
 						<l>εἶτ’ αὖθις αὖ τἄρα σοι</l>
 						<l n="896">δεῖ με δεύτερον μέλος</l>
@@ -2636,7 +2636,7 @@ convert to p3
 						<l>αὖθις σὺ περιχώρει λαβὼν τὴν χέρνιβα.</l>
 						<l>εὐφημία ’στω.</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l>μὴ κατάρξῃ τοῦ τράγου.</l>
 					</sp>
@@ -2644,7 +2644,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l n="960">σὺ δ’ εἶ τίς;</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l part="Y">ὅστις; χρησμολόγος.</l>
 					</sp>
@@ -2652,7 +2652,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">οἴμωζέ νυν.</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l>ὦ δαιμόνιε τὰ θεῖα μὴ φαύλως φέρε·</l>
 						<l>ὡς ἔστι Βάκιδος χρησμὸς ἄντικρυς λέγων</l>
@@ -2664,7 +2664,7 @@ convert to p3
 						<l>ταῦτ’ οὐκ ἐχρησμολόγεις σὺ πρὶν ἐμὲ τὴν πόλιν</l>
 						<l n="965">τήνδ’ οἰκίσαι;</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l part="Y">τὸ θεῖον ἐνεπόδιζέ με.</l>
 					</sp>
@@ -2673,7 +2673,7 @@ convert to p3
 						<l>ἀλλ’ οὐδὲν οἷόν ἐστ’ ἀκοῦσαι τῶν ἐπῶν.</l>
 						<milestone ed="p" n="967" unit="card"/>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l met="dactyls">ἀλλ’ ὅταν οἰκήσωσι λύκοι πολιαί τε κορῶναι</l>
 						<l met="dactyls">ἐν ταὐτῷ τὸ μεταξὺ Κορίνθου καὶ Σικυῶνος, —</l>
@@ -2682,7 +2682,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>τί οὖν προσήκει δῆτ’ ἐμοὶ Κορινθίων;</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l n="970">ᾐνίξαθ’ ὁ Βάκις τοῦτο πρὸς τὸν ἀέρα.</l>
 						<l met="dactyls">πρῶτον Πανδώρᾳ θῦσαι λευκότριχα κριόν·</l>
@@ -2693,7 +2693,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἔνεστι καὶ τὰ πέδιλα;</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l part="Y">λαβὲ τὸ βιβλίον.</l>
 						<l met="dactyls" n="975">καὶ φιάλην δοῦναι, καὶ σπλάγχνων χεῖρ’ ἐπιπλῆσαι.</l>
@@ -2702,7 +2702,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>καὶ σπλάγχνα διδόν’ ἔνεστι;</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l part="Y">λαβὲ τὸ βιβλίον.</l>
 						<l met="dactyls">κἂν μὲν θέσπιε κοῦρε ποιῇς ταῦθ’ ὡς ἐπιτέλλω,</l>
@@ -2713,7 +2713,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l n="980">καὶ ταῦτ’ ἔνεστ’ ἐνταῦθα;</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l part="Y">λαβὲ τὸ βιβλίον.</l>
 					</sp>
@@ -2725,7 +2725,7 @@ convert to p3
 						<l>λυπῇ θύοντας καὶ σπλαγχνεύειν ἐπιθυμῇ,</l>
 						<l n="985">δὴ τότε χρὴ τύπτειν αὐτὸν πλευρῶν τὸ μεταξὺ —</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l>οὐδὲν λέγειν οἶμαί σε.</l>
 					</sp>
@@ -2736,7 +2736,7 @@ convert to p3
 						<l met="dactyls">μήτ’ ἢν Λάμπων ᾖ μήτ’ ἢν ὁ μέγας Διοπείθης.</l>
 						<milestone ed="p" n="989" unit="card"/>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l>καὶ ταῦτ’ ἔνεστ’ ἐνταῦθα;</l>
 					</sp>
@@ -2745,7 +2745,7 @@ convert to p3
 						<l part="Y">λαβὲ τὸ βιβλίον.</l>
 						<l n="990">οὐκ εἶ θύραζ’; ἐς κόρακας.</l>
 					</sp>
-					<sp who="#xresmologos">
+					<sp who="#chresmologos">
 						<speaker>Χρησμολόγος</speaker>
 						<l part="Y">οἴμοι δείλαιος.</l>
 					</sp>
@@ -2920,7 +2920,7 @@ convert to p3
 						<l>οὐ δεινά; καὶ πέμπουσιν ἤδη ’πισκόπους</l>
 						<l>ἐς τὴν πόλιν, πρὶν καὶ τεθύσθαι τοῖς θεοῖς;</l>
 					</sp>
-					<sp who="#psefismatopoles">
+					<sp who="#psephismatopoles">
 						<speaker>Ψηφισματοπώλης</speaker>
 						<l n="1035">ἐὰν δ’ ὁ Νεφελοκοκκυγιεὺς τὸν Ἀθηναῖον ἀδικῇ  —</l>
 					</sp>
@@ -2928,7 +2928,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>τουτὶ τί ἔστιν αὖ κακὸν τὸ βιβλίον;</l>
 					</sp>
-					<sp who="#psefismatopoles">
+					<sp who="#psephismatopoles">
 						<speaker>Ψηφισματοπώλης</speaker>
 						<l>ψηφισματοπώλης εἰμὶ καὶ νόμους νέους</l>
 						<l>ἥκω παρ’ ὑμᾶς δεῦρο πωλήσων.</l>
@@ -2937,7 +2937,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">τὸ τί;</l>
 					</sp>
-					<sp who="#psefismatopoles">
+					<sp who="#psephismatopoles">
 						<speaker>Ψηφισματοπώλης</speaker>
 						<l met="prose" n="1040">χρῆσθαι Νεφελοκοκκυγιᾶς τοῖσδε τοῖς μέτροισι καὶ σταθμοῖσι καὶ ψηφίσμασι καθάπερ Ὀλοφύξιοι.</l>
 					</sp>
@@ -2945,7 +2945,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>σὺ δέ γ’ οἷσπερ ὡτοτύξιοι χρήσει τάχα.</l>
 					</sp>
-					<sp who="#psefismatopoles">
+					<sp who="#psephismatopoles">
 						<speaker>Ψηφισματοπώλης</speaker>
 						<l>οὗτος τί πάσχεις;</l>
 					</sp>
@@ -2962,7 +2962,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἄληθες οὗτος; ἔτι γὰρ ἐνταῦθ’ ἦσθα σύ;</l>
 					</sp>
-					<sp who="#psefismatopoles">
+					<sp who="#psephismatopoles">
 						<speaker>Ψηφισματοπώλης</speaker>
 						<l met="prose" n="1050">ἐὰν δέ τις ἐξελαύνῃ τοὺς ἄρχοντας καὶ μὴ  δέχηται κατὰ τὴν στήλην —</l>
 					</sp>
@@ -2978,7 +2978,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἐγὼ δὲ σοῦ γε τὼ κάδω διασκεδῶ.</l>
 					</sp>
-					<sp who="#psefismatopoles">
+					<sp who="#psephismatopoles">
 						<speaker>Ψηφισματοπώλης</speaker>
 						<l>μέμνησ’ ὅτε τῆς στήλης κατετίλας ἑσπέρας;</l>
 					</sp>
@@ -2993,7 +2993,7 @@ convert to p3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἤδη ’μοὶ τῷ παντόπτᾳ</l>
 						<l>καὶ παντάρχᾳ θνητοὶ πάντες</l>
@@ -3012,7 +3012,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τῇδε μέντοι θἠμέρᾳ μάλιστ’ ἐπαναγορεύεται,</l>
 						<l>ἢν ἀποκτείνῃ τις ὑμῶν Διαγόραν τὸν Μήλιον,</l>
@@ -3034,7 +3034,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὔδαιμον φῦλον πτηνῶν</l>
 						<l>οἰωνῶν, οἳ χειμῶνος μὲν</l>
@@ -3053,7 +3053,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοῖς κριταῖς εἰπεῖν τι βουλόμεσθα τῆς νίκης πέρι,</l>
 						<l>ὅσ’ ἀγάθ’, ἢν κρίνωσιν ἡμᾶς, πᾶσιν αὐτοῖς δώσομεν,</l>
@@ -3083,7 +3083,7 @@ convert to p3
 					<l n="1120">οὐδείς, ὅτου πευσόμεθα τἀκεῖ πράγματα.</l>
 					<l>ἀλλ’ οὑτοσὶ τρέχει τις Ἀλφειὸν πνέων.</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l>ποῦ ποῦ ’στι, ποῦ ποῦ ποῦ ’στι, ποῦ ποῦ ποῦ ’στι ποῦ,</l>
 					<l>ποῦ Πισθέταιρός ἐστιν ἅρχων;</l>
@@ -3092,7 +3092,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">οὑτοσί.</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l>ἐξῳκοδόμηταί σοι τὸ τεῖχος.</l>
 				</sp>
@@ -3100,7 +3100,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">εὖ λέγεις.</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l n="1125">κάλλιστον ἔργον καὶ μεγαλοπρεπέστατον·</l>
 					<l>ὥστ’ ἂν ἐπάνω μὲν Προξενίδης ὁ Κομπασεὺς</l>
@@ -3112,7 +3112,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">Ἡράκλεις.</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l n="1130">τὸ δὲ μῆκός ἐστι, καὶ γὰρ ἐμέτρησ’ αὔτ’  ἐγώ,</l>
 					<l>ἑκατοντορόγυιον.</l>
@@ -3122,7 +3122,7 @@ convert to p3
 					<l part="Y">ὦ Πόσειδον τοῦ μάκρους.</l>
 					<l>τίνες ᾠκοδόμησαν αὐτὸ τηλικουτονί;</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l>ὄρνιθες, οὐδεὶς ἄλλος, οὐκ Αἰγύπτιος</l>
 					<l>πλινθοφόρος, οὐ λιθουργός, οὐ τέκτων παρῆν,</l>
@@ -3138,7 +3138,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>ἐπηλοφόρουν δ’ αὐτοῖσι τίνες;</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l part="Y">ἐρωδιοὶ</l>
 					<l>λεκάναισι.</l>
@@ -3147,7 +3147,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l part="Y">τὸν δὲ πηλὸν ἐνεβάλλοντο πῶς;</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l>τοῦτ’ ὦγάθ’ ἐξηύρητο καὶ σοφώτατα·</l>
 					<l n="1145">οἱ χῆνες ὑποτύπτοντες ὥσπερ ταῖς ἄμαις</l>
@@ -3158,7 +3158,7 @@ convert to p3
 					<l>τί δῆτα πόδες ἂν οὐκ ἂν ἐργασαίατο;</l>
 					<milestone ed="p" n="1148" unit="card"/>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l>καὶ νὴ Δί’ αἱ νῆτταί γε περιεζωσμέναι</l>
 					<l>ἐπλινθοφόρουν· ἄνω δὲ τὸν ὑπαγωγέα</l>
@@ -3171,7 +3171,7 @@ convert to p3
 					<l>φέρ’ ἴδω, τί δαί; τὰ ξύλινα τοῦ τείχους τίνες</l>
 					<l>ἀπηργάσαντ’;</l>
 				</sp>
-				<sp who="#aggelosa">
+				<sp who="#angelos_a">
 					<speaker>Ἄγγελος Α</speaker>
 					<l part="Y">ὄρνιθες ἦσαν τέκτονες</l>
 					<l n="1155">σοφώτατοι πελεκᾶντες, οἳ τοῖς ῥύγχεσιν</l>
@@ -3184,7 +3184,7 @@ convert to p3
 					<l>ἐν τοῖσι πύργοις. ἀλλ’ ἐγὼ μὲν ἀποτρέχων</l>
 					<l>ἀπονίψομαι· σὺ δ’ αὐτὸς ἤδη τἄλλα δρᾶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὗτος τί ποιεῖς; ἆρα θαυμάζεις ὅτι</l>
 					<l n="1165">οὕτω τὸ τεῖχος ἐκτετείχισται ταχύ;</l>
@@ -3196,7 +3196,7 @@ convert to p3
 					<l>ἀλλ’ ὅδε φύλαξ γὰρ τῶν ἐκεῖθεν ἄγγελος</l>
 					<l>ἐσθεῖ πρὸς ἡμᾶς δεῦρο πυρρίχην βλέπων.</l>
 				</sp>
-				<sp who="#aggelosb">
+				<sp who="#angelos_b">
 					<speaker>Ἄγγελος Β</speaker>
 					<l n="1170">ἰοὺ ἰού, ἰοὺ ἰού, ἰοὺ ἰού.</l>
 				</sp>
@@ -3204,7 +3204,7 @@ convert to p3
 					<speaker>Πισθέταιρος</speaker>
 					<l>τί τὸ πρᾶγμα τουτί;</l>
 				</sp>
-				<sp who="#aggelosb">
+				<sp who="#angelos_b">
 					<speaker>Ἄγγελος Β.</speaker>
 					<l part="Y">δεινότατα πεπόνθαμεν.</l>
 					<l>τῶν γὰρ θεῶν τις ἄρτι τῶν παρὰ τοῦ Διὸς</l>
@@ -3216,7 +3216,7 @@ convert to p3
 					<l n="1175">ὦ δεινὸν ἔργον καὶ σχέτλιον εἰργασμένος.</l>
 					<l>τίς τῶν θεῶν;</l>
 				</sp>
-				<sp who="#aggelosb">
+				<sp who="#angelos_b">
 					<speaker>Ἄγγελος Β.</speaker>
 					<l part="Y">οὐκ ἴσμεν· ὅτι δ’ εἶχε πτερά,</l>
 					<l>τοῦτ’ ἴσμεν.</l>
@@ -3226,7 +3226,7 @@ convert to p3
 					<l part="Y">οὔκουν δῆτα περιπόλους ἐχρῆν</l>
 					<l>πέμψαι κατ’ αὐτὸν εὐθύς;</l>
 				</sp>
-				<sp who="#aggelosb">
+				<sp who="#angelos_b">
 					<speaker>Ἄγγελος Β.</speaker>
 					<l part="Y">ἀλλ’ ἐπέμψαμεν</l>
 					<l>τρισμυρίους ἱέρακας ἱπποτοξότας,</l>
@@ -3245,7 +3245,7 @@ convert to p3
 					<milestone ed="p" n="1189" unit="card"/>
 				</sp>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πόλεμος αἴρεται, πόλεμος οὐ φατὸς</l>
 						<l n="1190">πρὸς ἐμὲ καὶ θεούς. ἀλλὰ φύλαττε πᾶς</l>
@@ -3253,7 +3253,7 @@ convert to p3
 						<l n="1195">μή σε λάθῃ θεῶν τις ταύτῃ περῶν·</l>
 						<milestone ed="p" n="1196" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> . . . ἄθρει δὲ πᾶς κύκλῳ σκοπῶν,</l>
 						<l>ὡς ἐγγὺς ἤδη δαίμονος πεδαρσίου</l>
@@ -3442,7 +3442,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀποκεκλῄκαμεν διογενεῖς θεοὺς</l>
 						<l>μηκέτι τὴν ἐμὴν διαπερᾶν πόλιν,</l>
@@ -3454,7 +3454,7 @@ convert to p3
 						<l>δεινόν γε τὸν κήρυκα τὸν παρὰ τοὺς βροτοὺς</l>
 						<l n="1270">οἰχόμενον, εἰ μηδέποτε νοστήσει πάλιν.</l>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>Κῆρυξ</speaker>
 						<l>ὦ Πισθέταιρ’ ὦ μακάρῑ ὦ σοφώτατε,</l>
 						<l>ὦ κλεινότατ’ ὦ σοφώτατ’ ὦ γλαφυρώτατε,</l>
@@ -3464,7 +3464,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">τί σὺ λέγεις;</l>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>Κῆρυξ</speaker>
 						<l>στεφάνῳ σε χρυσῷ τῷδε σοφίας οὕνεκα</l>
 						<l n="1275">στεφανοῦσι καὶ τιμῶσιν οἱ πάντες λεῴ.</l>
@@ -3473,7 +3473,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>δέχομαι. τί δ’ οὕτως οἱ λεὼ| τιμῶσί με;</l>
 					</sp>
-					<sp who="#keryks">
+					<sp who="#keryx">
 						<speaker>Κῆρυξ</speaker>
 						<l>ὦ κλεινοτάτην αἰθέριον οἰκίσας πόλιν,</l>
 						<l>οὐκ οἷσθ’ ὅσην τιμὴν παρ’ ἀνθρώποις φέρει,</l>
@@ -3520,7 +3520,7 @@ convert to p3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ταχὺ δὴ πολυάνορα τάνδε πόλιν</l>
 						<l>καλεῖ τις ἀνθρώπων.</l>
@@ -3529,7 +3529,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l n="1315">τύχη μόνον προσείη.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κατέχουσι δ’ ἔρωτες ἐμᾶς πόλεως.</l>
 					</sp>
@@ -3537,7 +3537,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>θάττον φέρειν κελεύω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί γὰρ οὐκ ἔνι ταύτῃ</l>
 						<l>καλὸν ἀνδρὶ μετοικεῖν;</l>
@@ -3552,7 +3552,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1325">φερέτω κάλαθον ταχύ τις πτερύγων,</l>
 						<l>σὺ δ’ αὖθις ἐξόρμα —</l>
@@ -3561,7 +3561,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>τύπτων γε τοῦτον ὡδί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάνυ γὰρ βραδύς ἐστί τις ὥσπερ ὄνος.</l>
 					</sp>
@@ -3569,7 +3569,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>Μανῆς γάρ ἐστι δειλός.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1330">σὺ δὲ τὰ πτερὰ πρῶτον</l>
 						<l>διάθες τάδε κόσμῳ,</l>
@@ -3765,7 +3765,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l n="1410">ὄρνιθες τίνες οὐδὲν ἔχοντες πτεροποίκιλοι,</l>
 						<l>τανυσίπτερε ποικίλα χελιδοῖ;</l>
@@ -3775,7 +3775,7 @@ convert to p3
 						<l>τουτὶ τὸ κακὸν οὐ φαῦλον ἐξεγρήγορεν.</l>
 						<l>ὅδ’ αὖ μινυρίζων δεῦρό τις προσέρχεται.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l n="1415">τανυσίπτερε ποικίλα μάλ’ αὖθις.</l>
 					</sp>
@@ -3784,7 +3784,7 @@ convert to p3
 						<l>ἐς θοἰμάτιον τὸ σκόλιον ᾄδειν μοι δοκεῖ,</l>
 						<l>δεῖσθαι δ’ ἔοικεν οὐκ ὀλίγων χελιδόνων.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>τίς ὁ πτερῶν δεῦρ’ ἐστὶ τοὺς ἀφικνουμένους;</l>
 					</sp>
@@ -3792,7 +3792,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ὁδὶ πάρεστιν· ἀλλ’ ὅτου δεῖ χρὴ λέγειν.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l n="1420">πτερῶν πτερῶν δεῖ· μὴ πύθῃ τὸ δεύτερον.</l>
 					</sp>
@@ -3800,7 +3800,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>μῶν εὐθὺ Πελλήνης πέτεσθαι διανοεῖ;</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>μὰ Δί’ ἀλλὰ κλητήρ εἰμι νησιωτικὸς</l>
 						<l>καὶ συκοφάντης —</l>
@@ -3809,7 +3809,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">ὦ μακάριε τῆς τέχνης.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>καὶ πραγματοδίφης. εἶτα δέομαι πτερὰ λαβὼν</l>
 						<l n="1425">κύκλῳ περισοβεῖν τὰς πόλεις καλούμενος.</l>
@@ -3818,7 +3818,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ὑπὸ πτερύγων τι προσκαλεῖ σοφώτερον;</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>μὰ Δί’ ἀλλ’ ἵν’ οἱ λῃσταί τε μὴ λυπῶσί με,</l>
 						<l>μετὰ τῶν γεράνων τ’ ἐκεῖθεν ἀναχωρῶ πάλιν,</l>
@@ -3829,7 +3829,7 @@ convert to p3
 						<l n="1430">τουτὶ γὰρ ἐργάζει σὺ τοὔργον; εἰπέ μοι,</l>
 						<l>νεανίας ὢν συκοφαντεῖς τοὺς ξένους;</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>τί γὰρ πάθω; σκάπτειν γὰρ οὐκ ἐπίσταμαι.</l>
 					</sp>
@@ -3840,7 +3840,7 @@ convert to p3
 						<l n="1435">ἐκ τοῦ δικαίου μᾶλλον ἢ δικορραφεῖν.</l>
 						<milestone ed="p" n="1436" unit="card"/>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>ὦ δαιμόνιε μὴ νουθέτει μ’ ἀλλὰ πτέρου.</l>
 					</sp>
@@ -3848,7 +3848,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>νῦν τοι λέγων πτερῶ σε.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l part="Y">καὶ πῶς ἂν λόγοις</l>
 						<l>ἄνδρα πτερώσειας σύ;</l>
@@ -3858,7 +3858,7 @@ convert to p3
 						<l part="Y">πάντες τοῖς λόγοις</l>
 						<l>ἀναπτεροῦνται.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l part="Y">πάντες;</l>
 					</sp>
@@ -3872,7 +3872,7 @@ convert to p3
 						<l>ὁ δέ τις τὸν αὑτοῦ φησιν ἐπὶ τραγῳδίᾳ</l>
 						<l n="1445">ἀνεπτερῶσθαι καὶ πεποτῆσθαι τὰς φρένας.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>λόγοισί τἄρα καὶ πτεροῦνται;</l>
 					</sp>
@@ -3884,7 +3884,7 @@ convert to p3
 						<l>ἀναπτερώσας βούλομαι χρηστοῖς λόγοις</l>
 						<l n="1450">τρέψαι πρὸς ἔργον νόμιμον.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l part="Y">ἀλλ’ οὐ βούλομαι.</l>
 					</sp>
@@ -3892,7 +3892,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>τί δαὶ ποιήσεις;</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l part="Y">τὸ γένος οὐ καταισχυνῶ.</l>
 						<l>παππῷος ὁ βίος συκοφαντεῖν ἐστί μοι.</l>
@@ -3907,7 +3907,7 @@ convert to p3
 						<l>ὡδὶ λέγεις· ὅπως ἂν ὠφλήκῃ δίκην</l>
 						<l>ἐνθάδε πρὶν ἥκειν ὁ ξένος.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l part="Y">πάνυ μανθάνεις.</l>
 					</sp>
@@ -3916,7 +3916,7 @@ convert to p3
 						<l>κἄπειθ’ ὁ μὲν πλεῖ δεῦρο, σὺ δ’ ἐκεῖσ’ αὖ  πέτει</l>
 						<l n="1460">ἁρπασόμενος τὰ χρήματ’ αὐτοῦ.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l part="Y">πάντ’ ἔχεις.</l>
 						<l>βέμβικος οὐδὲν διαφέρειν δεῖ.</l>
@@ -3927,7 +3927,7 @@ convert to p3
 						<l>βέμβικα· καὶ μὴν ἔστι μοι νὴ τὸν Δία</l>
 						<l>κάλλιστα Κορκυραῖα τοιαυτὶ πτερά.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>οἴμοι τάλας μάστιγ’ ἔχεις.</l>
 					</sp>
@@ -3936,7 +3936,7 @@ convert to p3
 						<l part="Y">πτερὼ μὲν οὖν,</l>
 						<l n="1465">οἷσί σε ποιήσω τήμερον βεμβικιᾶν.</l>
 					</sp>
-					<sp who="#sykofantes">
+					<sp who="#sykophantes">
 						<speaker>Συκοφάντης</speaker>
 						<l>οἴμοι τάλας.</l>
 					</sp>
@@ -3952,7 +3952,7 @@ convert to p3
 			</div1>
 			<div1 type="Lyric-Scene">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1470">πολλὰ δὴ καὶ καινὰ καὶ θαυμάστ’</l>
 						<l>ἐπεπτόμεσθα καὶ</l>
@@ -3970,7 +3970,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔστι δ’ αὗ χώρα πρὸς αὐτῷ</l>
 						<l>τῷ σκότῳ πόρρω τις ἐν</l>
@@ -3986,7 +3986,7 @@ convert to p3
 						<l>πάντα τἀπιδέξια.</l>
 						<milestone ed="p" n="1494" unit="card"/>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>οἴμοι τάλας, ὁ Ζεὺς ὅπως μή μ’ ὄψεται.</l>
 						<l n="1495">ποῦ Πισθέταιρός ἐστ’;</l>
@@ -3996,7 +3996,7 @@ convert to p3
 						<l part="Y">ἔα τουτὶ τί ἦν;</l>
 						<l>τίς ὁ συγκαλυμμός;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">τῶν θεῶν ὁρᾷς τινα</l>
 						<l>ἐμοῦ κατόπιν ἐνταῦθα;</l>
@@ -4006,7 +4006,7 @@ convert to p3
 						<l part="Y">μὰ Δί’ ἐγὼ μὲν οὔ.</l>
 						<l>τίς δ’ εἶ σύ;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">πηνίκ’ ἐστὶν ἄρα τῆς ἡμέρας;</l>
 					</sp>
@@ -4015,7 +4015,7 @@ convert to p3
 						<l>ὁπηνίκα; σμικρόν τι μετὰ μεσημβρίαν.</l>
 						<l n="1500">ἀλλὰ σὺ τίς εἶ;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">βουλυτὸς ἢ περαιτέρω;</l>
 					</sp>
@@ -4023,7 +4023,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>οἴμ’ ὡς βδελύττομαί σε.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">τί γὰρ ὁ Ζεὺς ποιεῖ;</l>
 						<l>ἀπαιθριάζει τὰς νεφέλας ἢ ξυννέφει;</l>
@@ -4032,7 +4032,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>οἴμωζε μεγάλ’.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">οὕτω μὲν ἐκκεκαλύψομαι.</l>
 					</sp>
@@ -4040,7 +4040,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ὦ φίλε Προμηθεῦ.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">παῦε παῦε, μὴ βόα.</l>
 					</sp>
@@ -4048,7 +4048,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l n="1505">τί γὰρ ἔστι;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">σίγα, μὴ κάλει μου τοὔνομα·</l>
 						<l>ἀπὸ γάρ μ’ ὀλεῖς, εἴ μ’ ἐνθάδ’ ὁ Ζεὺς  ὄψεται.</l>
@@ -4062,7 +4062,7 @@ convert to p3
 						<l>εὖ γ’ ἐπενόησας αὐτὸ καὶ προμηθικῶς.</l>
 						<l>ὑπόδυθι ταχὺ δὴ κᾆτα θαρρήσας λέγε.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἄκουε δή νυν.</l>
 					</sp>
@@ -4070,7 +4070,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">ὡς ἀκούοντος λέγε.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>ἀπόλωλεν ὁ Ζεύς.</l>
 					</sp>
@@ -4078,7 +4078,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">πηνίκ’ ἄττ’ ἀπώλετο;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l n="1515">ἐξ οὗπερ ὑμεῖς ᾠκίσατε τὸν ἀέρα.</l>
 						<l>θύει γὰρ οὐδεὶς οὐδὲν ἀνθρώπων ἔτι</l>
@@ -4097,7 +4097,7 @@ convert to p3
 						<l n="1525">εἰσὶν γὰρ ἕτεροι βάρβαροι θεοί τινες</l>
 						<l>ἄνωθεν ὑμῶν;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">οὐ γάρ εἰσι βάρβαροι,</l>
 						<l>ὅθεν ὁ πατρῷός ἐστιν Ἐξηκεστίδῃ;</l>
@@ -4107,7 +4107,7 @@ convert to p3
 						<l>ὄνομα δὲ τούτοις τοῖς θεοῖς τοῖς βαρβάροις</l>
 						<l>τί ἔστιν;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">ὅ τι ἔστιν; Τριβαλλοί.</l>
 					</sp>
@@ -4116,7 +4116,7 @@ convert to p3
 						<l part="Y">μανθάνω.</l>
 						<l n="1530">ἐντεῦθεν ἆρα τοὐπιτριβείης ἐγένετο;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>μάλιστα πάντων. ἓν δέ σοι λέγω σαφές·</l>
 						<l>ἥξουσι πρέσβεις δεῦρο περὶ διαλλαγῶν</l>
@@ -4129,7 +4129,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>τίς ἐστιν ἡ Βασίλεια;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">καλλίστη κόρη,</l>
 						<l>ἥπερ ταμιεύει τὸν κεραυνὸν τοῦ Διὸς</l>
@@ -4141,7 +4141,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἅπαντά γ’ ἆρ’ αὐτῷ ταμιεύει;</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l part="Y">φήμ’ ἐγώ.</l>
 						<l>ἥν γ’ ἢν σὺ παρ’ ἐκείνου παραλάβῃς, πάντ’ ἔχεις.</l>
@@ -4152,7 +4152,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>μόνον θεῶν γὰρ διὰ σ’ ἀπανθρακίζομεν.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>μισῶ δ’ ἅπαντας τοὺς θεούς, ὡς οἶσθα σύ.</l>
 					</sp>
@@ -4160,7 +4160,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>νὴ τὸν Δί’ ἀεὶ δῆτα θεομισὴς ἔφυς.</l>
 					</sp>
-					<sp who="#prometheys">
+					<sp who="#prometheus">
 						<speaker>Προμηθεύς</speaker>
 						<l>Τίμων καθαρός. ἀλλ’ ὡς ἂν ἀποτρέχω πάλιν,</l>
 						<l n="1550">φέρε τὸ σκιάδειον, ἵνα με κἂν ὁ Ζεὺς ἴδῃ</l>
@@ -4173,7 +4173,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρὸς δὲ τοῖς Σκιάποσιν λίμνη</l>
 						<l>τις ἔστ’ ἄλουτος οὗ</l>
@@ -4209,7 +4209,7 @@ convert to p3
 						<l>ἑόρακα πάντων βαρβαρώτατον θεῶν.</l>
 						<l>ἄγε δὴ τί δρῶμεν Ἡράκλεις;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">ἀκήκοας</l>
 						<l n="1575">ἐμοῦ γ’ ὅτι τὸν ἄνθρωπον ἄγχειν βούλομαι,</l>
@@ -4220,7 +4220,7 @@ convert to p3
 						<l>ἀλλ’ ὦγάθ’ ᾑρήμεσθα περὶ διαλλαγῶν</l>
 						<l>πρέσβεις.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">διπλασίως μᾶλλον ἄγχειν μοι δοκεῖ.</l>
 					</sp>
@@ -4238,7 +4238,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l part="Y">ἀλλ’ ἐπικνῶ τὸ σίλφιον.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τὰ δὲ κρέα τοῦ ταῦτ’ ἐστίν;</l>
 					</sp>
@@ -4248,7 +4248,7 @@ convert to p3
 						<l>ἐπανιστάμενοι τοῖς δημοτικοῖσιν ὀρνέοις</l>
 						<l n="1585">ἔδοξαν ἀδικεῖν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">εἶτα δῆτα σίλφιον</l>
 						<l>εἴπικνῇς πρότερον αὐτοῖσιν;</l>
@@ -4267,7 +4267,7 @@ convert to p3
 						<speaker>Πισθέταιρος</speaker>
 						<l>ἔλαιον οὐκ ἔνεστιν ἐν τῇ ληκύθῳ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1590">καὶ μὴν τά γ’ ὀρνίθεια λιπάρ’ εἶναι πρέπει.</l>
 					</sp>
@@ -4289,7 +4289,7 @@ convert to p3
 						<l>τὸν Δί’ ἀποδοῦναι· κἂν διαλλαττώμεθα</l>
 						<l>ἐπὶ τοῖσδε, τοὺς πρέσβεις ἐπ’ ἄριστον καλῶ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἐμοὶ μὲν ἀπόχρη ταῦτα καὶ ψηφίζομαι.</l>
 					</sp>
@@ -4314,7 +4314,7 @@ convert to p3
 						<speaker>Ποσειδῶν</speaker>
 						<l>νὴ τὸν Ποσειδῶ ταῦτά γέ τοι καλῶς λέγεις.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1615">κἀμοὶ δοκεῖ.</l>
 					</sp>
@@ -4346,7 +4346,7 @@ convert to p3
 						<l>καταπτόμενος ἰκτῖνος ἁρπάσας λάθρᾳ</l>
 						<l n="1625">προβάτοιν δυοῖν τιμὴν ἀνοίσει τῷ θεῷ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τὸ σκῆπτρον ἀποδοῦναι πάλιν ψηφίζομαι</l>
 						<l>τούτοις ἐγώ.</l>
@@ -4355,7 +4355,7 @@ convert to p3
 						<speaker>Ποσειδῶν</speaker>
 						<l part="Y">καὶ τὸν Τριβαλλόν νυν ἐροῦ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ὁ Τριβαλλός, οἰμώζειν δοκεῖ σοι;</l>
 					</sp>
@@ -4364,7 +4364,7 @@ convert to p3
 						<l part="Y">σαυνάκα</l>
 						<l>βακταρικροῦσα.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">φησί μ’ εὖ λέγειν πάνυ.</l>
 					</sp>
@@ -4372,7 +4372,7 @@ convert to p3
 						<speaker>Ποσειδῶν</speaker>
 						<l n="1630">εἴ τοι δοκεῖ σφῷν ταῦτα, κἀμοὶ συνδοκεῖ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οὗτος, δοκεῖ δρᾶν ταῦτα τοῦ σκήπτρου πέρι.</l>
 					</sp>
@@ -4393,7 +4393,7 @@ convert to p3
 						<l part="Y">ὀλίγον μοι μέλει.</l>
 						<l>μάγειρε τὸ κατάχυσμα χρὴ ποιεῖν γλυκύ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ὦ δαιμόνῑ ἀνθρώπων Πόσειδον ποῖ φέρει;</l>
 						<l>ἡμεῖς περὶ γυναικὸς μιᾶς πολεμήσομεν;</l>
@@ -4402,7 +4402,7 @@ convert to p3
 						<speaker>Ποσειδῶν</speaker>
 						<l n="1640">τί δαὶ ποιῶμεν;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">ὅ τι; διαλλαττώμεθα.</l>
 					</sp>
@@ -4423,7 +4423,7 @@ convert to p3
 						<l>τῶν γὰρ πατρῴων οὐδ’ ἀκαρῆ μέτεστί σοι</l>
 						<l n="1650">κατὰ τοὺς νόμους· νόθος γὰρ εἶ κοὐ γνήσιος.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἐγὼ νόθος; τί λέγεις;</l>
 					</sp>
@@ -4434,7 +4434,7 @@ convert to p3
 						<l>ἐπίκληρον εἶναι τὴν Ἀθηναίαν δοκεῖς,</l>
 						<l>οὖσαν θυγατέρ’, ὄντων ἀδελφῶν γυησίων;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1655">τί δ’ ἢν ὁ πατὴρ ἐμοὶ διδῷ τὰ χρήματα</l>
 						<l>νοθεἶ ἀποθνῄσκων;</l>
@@ -4450,7 +4450,7 @@ convert to p3
 						<l n="1665">γνησίων. ἐὰν δὲ παῖδες μὴ ὦσι γνήσιοι, τοῖς</l>
 						<l>ἐγγυτάτω γένους μετεῖναι τῶν χρημάτων.’</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἐμοὶ δ’ ἄρ’ οὐδὲν τῶν πατρῴων χρημάτων</l>
 						<l>μέτεστιν;</l>
@@ -4460,7 +4460,7 @@ convert to p3
 						<l part="Y">οὐ μέντοι μὰ Δία. λέξον δέ μοι,</l>
 						<l>ἤδη σ’ ὁ πατὴρ εἰσήγαγ’ ἐς τοὺς φράτερας;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1670">οὐ δῆτ’ ἐμέ γε. καὶ δῆτ’ ἐθαύμαζον πάλαι.</l>
 					</sp>
@@ -4470,7 +4470,7 @@ convert to p3
 						<l>ἀλλ’ ἢν μεθ’ ἡμῶν ᾖς, καταστήσας σ’ ἐγὼ</l>
 						<l>τύραννον ὀρνίθων παρέξω σοι γάλα.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>δίκαῑ ἔμοιγε καὶ πάλαι δοκεῖς λέγειν</l>
 						<l n="1675">περὶ τῆς κόρης, κἄγωγε παραδίδωμί σοι.</l>
@@ -4492,7 +4492,7 @@ convert to p3
 						<l>καλάνι κόραυνα καὶ μεγάλα βασιλιναῦ</l>
 						<l>ὄρνιτο παραδίδωμι.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">παραδοῦναι λέγει.</l>
 					</sp>
@@ -4510,7 +4510,7 @@ convert to p3
 						<l>σφὼ νῦν διαλλάττεσθε καὶ ξυμβαίνετε·</l>
 						<l>ἐγὼ δ’, ἐπειδὴ σφῷν δοκεῖ, σιγήσομαι.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1685">ἡμῖν ἃ λέγεις σὺ πάντα συγχωρεῖν δοκεῖ.</l>
 						<l>ἀλλ’ ἴθι μεθ’ ἡμῶν αὐτὸς ἐς τὸν οὐρανόν,</l>
@@ -4521,7 +4521,7 @@ convert to p3
 						<l>ἐς καιρὸν ἆρα κατεκόπησαν οὑτοιὶ</l>
 						<l>ἐς τοὺς γάμους.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">βούλεσθε δῆτ’ ἐγὼ τέως</l>
 						<l n="1690">ὀπτῶ τὰ κρέα ταυτὶ μένων; ὑμεῖς δ’ ἴτε.</l>
@@ -4531,7 +4531,7 @@ convert to p3
 						<l>ὀπτᾷς τὰ κρέα; πολλήν γε τενθείαν λέγεις.</l>
 						<l>οὐκ εἶ μεθ’ ἡμῶν;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">εὖ γε μέντἂν διετέθην.</l>
 					</sp>
@@ -4542,7 +4542,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrohe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔστι δ’ ἐν Φαναῖσι πρὸς τῇ</l>
 						<l n="1695">Κλεψύδρᾳ πανοῦργον ἐγ‐</l>
@@ -4561,7 +4561,7 @@ convert to p3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὦ πάντ’ ἀγαθὰ πράττοντες, ὦ μείζω λόγου,</l>
 					<l>ὦ τρισμακάριον πτηνὸν ὀρνίθων γένος,</l>
@@ -4582,7 +4582,7 @@ convert to p3
 			</div1>
 			<div1 type="Exodus">
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1720">ἄναγε δίεχε πάραγε πάρεχε.</l>
 						<l>περιπέτεσθε</l>
@@ -4602,7 +4602,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἥρᾳ ποτ’ Ὀλυμπίᾳ</l>
 						<l>τῶν ἠλιβάτων θρόνων</l>
@@ -4615,7 +4615,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ δ’ ἀμφιθαλὴς Ἔρως</l>
 						<l>χρυσόπτερος ἡνίας</l>
@@ -4638,7 +4638,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ μέγα χρύσεον ἀστεροπῆς φάος,</l>
 						<l>ὦ Διὸς ἄμβροτον ἔγχος πυρφόρον,</l>
@@ -4660,7 +4660,7 @@ convert to p3
 						<l>λαβοῦσα συγχόρευσον· αἴρων</l>
 						<l>δὲ κουφιῶ σ’ ἐγώ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλαλαλαὶ ἰὴ παιών,</l>
 						<l>τήνελλα καλλίνικος, ὦ</l>

--- a/tei/aristophanes-clouds.xml
+++ b/tei/aristophanes-clouds.xml
@@ -58,13 +58,13 @@
 					<person xml:id="dikaioslogos">
 						<persName>Δίκαιος Λόγος</persName>
 					</person>
-					<person xml:id="mathetesa">
+					<person xml:id="mathetes_a">
 						<persName>Μαθητής Α</persName>
 					</person>
 					<person xml:id="strepsiades">
 						<persName>Στρεψιάδης</persName>
 					</person>
-					<person xml:id="feidippides">
+					<person xml:id="pheidippides">
 						<persName>Φειδιππίδης</persName>
 					</person>
 					<person xml:id="sokrates">
@@ -76,28 +76,28 @@
 					<person xml:id="martys">
 						<persName>Μάρτυς</persName>
 					</person>
-					<person xml:id="ermes">
+					<person xml:id="hermes">
 						<persName>Ερμῆς</persName>
 					</person>
 					<person xml:id="therapon">
 						<persName>Θεράπων</persName>
 					</person>
-					<person xml:id="mathetesg">
+					<person xml:id="mathetes_g">
 						<persName>Μαθητής Γ</persName>
 					</person>
 					<person xml:id="pasias">
 						<persName>Πασίας</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="adikoslogos">
+					<person xml:id="adikos_logos">
 						<persName>Ἄδικος Λόγος</persName>
 					</person>
-					<person xml:id="mathetesb">
+					<person xml:id="mathetes_b">
 						<persName>Μαθητής Β</persName>
 					</person>
-					<person xml:id="xairefon">
+					<person xml:id="chairephon">
 						<persName>Χαιρεφῶν</persName>
 					</person>
 				</listPerson>
@@ -201,7 +201,7 @@ convert to p3
 					<l>εἴθ’ ἐξεκόπην πρότερον τὸν ὀφθαλμὸν λίθῳ.</l>
 					<milestone ed="p" n="25" unit="card"/>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l n="25">Φίλων ἀδικεῖς· ἔλαυνε τὸν σαυτοῦ δρόμον.</l>
 				</sp>
@@ -210,7 +210,7 @@ convert to p3
 					<l>τοῦτ’ ἔστι τουτὶ τὸ κακὸν ὅ μ’ ἀπολώλεκεν·</l>
 					<l>ὀνειροπολεῖ γὰρ καὶ καθεύδων ἱππικήν.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>πόσους δρόμους ἐλᾷ τὰ πολεμιστήρια;</l>
 				</sp>
@@ -220,7 +220,7 @@ convert to p3
 					<l n="30">ἀτὰρ τί χρέος ἔβα με μετὰ τὸν Πασίαν;</l>
 					<l>τρεῖς μναῖ διφρίσκου καὶ τροχοῖν Ἀμυνίᾳ.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἄπαγε τὸν ἵππον ἐξαλίσας οἴκαδε.</l>
 				</sp>
@@ -230,7 +230,7 @@ convert to p3
 					<l>ὅτε καὶ δίκας ὤφληκα χἄτεροι τόκου</l>
 					<l n="35">ἐνεχυράσεσθαί φασιν.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">ἐτεὸν ὦ πάτερ</l>
 					<l>τί δυσκολαίνεις καὶ στρέφει τὴν νύχθ’ ὅλην;</l>
@@ -239,7 +239,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>δάκνει μὲ δήμαρχός τις ἐκ τῶν στρωμάτων.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἔασον ὦ δαιμόνιε καταδαρθεῖν τί με.</l>
 				</sp>
@@ -302,7 +302,7 @@ convert to p3
 					<l>πῶς δῆτ’ ἂν ἥδιστ’ αὐτὸν ἐπεγείραιμι; πῶς;</l>
 					<l n="80">Φειδιππίδη Φειδιππίδιον.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">τί ὦ πάτερ;</l>
 				</sp>
@@ -310,7 +310,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>κύσον με καὶ τὴν χεῖρα δὸς τὴν δεξιάν.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἰδού. τί ἔστιν;</l>
 				</sp>
@@ -318,7 +318,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l part="Y">εἰπέ μοι, φιλεῖς ἐμέ;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>νὴ τὸν Ποσειδῶ τουτονὶ τὸν ἵππιον.</l>
 				</sp>
@@ -329,7 +329,7 @@ convert to p3
 					<l>ἀλλ’ εἴπερ ἐκ τῆς καρδίας μ’ ὄντως φιλεῖς,</l>
 					<l>ὦ παῖ πιθοῦ.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">τί οὖν πίθωμαι δῆτά σοι;</l>
 				</sp>
@@ -339,7 +339,7 @@ convert to p3
 					<l>καὶ μάνθαν’ ἐλθὼν ἃν ἐγὼ παραινέσω.</l>
 					<milestone ed="p" n="90" unit="card"/>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l n="90">λέγε δή, τί κελεύεις;</l>
 				</sp>
@@ -347,7 +347,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l part="Y">καί τι πείσει;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">πείσομαι</l>
 					<l>νὴ τὸν Διόνυσον.</l>
@@ -357,7 +357,7 @@ convert to p3
 					<l part="Y">δεῦρό νυν ἀπόβλεπε.</l>
 					<l>ὁρᾷς τὸ θύριον τοῦτο καὶ τᾠκίδιον;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ὁρῶ. τί οὖν τοῦτ’ ἐστὶν ἐτεὸν ὦ πάτερ;</l>
 				</sp>
@@ -370,7 +370,7 @@ convert to p3
 					<l>οὗτοι διδάσκουσ’, ἀργύριον ἤν τις διδῷ,</l>
 					<l>λέγοντα νικᾶν καὶ δίκαια κἄδικα.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l n="100">εἰσὶν δὲ τίνες;</l>
 				</sp>
@@ -379,7 +379,7 @@ convert to p3
 					<l part="Y">οὐκ οἶδ’ ἀκριβῶς τοὔνομα·</l>
 					<l>μεριμνοφροντισταὶ καλοί τε κἀγαθοί.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>αἰβοῖ πονηροί γ’, οἶδα. τοὺς ἀλαζόνας</l>
 					<l>τοὺς ὠχριῶντας τοὺς ἀνυποδήτους λέγεις,</l>
@@ -391,7 +391,7 @@ convert to p3
 					<l>ἀλλ’ εἴ τι κήδει τῶν πατρῴων ἀλφίτων,</l>
 					<l>τούτων γενοῦ μοι σχασάμενος τὴν ἱππικήν.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>οὐκ ἂν μὰ τὸν Διόνυσον, εἰ δοίης γέ μοι</l>
 					<l>τοὺς φασιανοὺς οὓς τρέφει Λεωγόρας.</l>
@@ -401,7 +401,7 @@ convert to p3
 					<l n="110">ἴθ’ ἀντιβολῶ σ’ ὦ φίλτατ’ ἀνθρώπων ἐμοὶ</l>
 					<l>ἐλθὼν διδάσκου.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">καὶ τί σοι μαθήσομαι;</l>
 				</sp>
@@ -415,7 +415,7 @@ convert to p3
 					<l>ἃ νῦν ὀφείλω διὰ σέ, τούτων τῶν χρεῶν</l>
 					<l>οὐκ ἂν ἀποδοίην οὐδ’ ἂν ὀβολὸν οὐδενί.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>οὐκ ἂν πιθοίμην· οὐ γὰρ ἂν τλαίην ἰδεῖν</l>
 					<l n="120">τοὺς ἱππέας τὸ χρῶμα διακεκναισμένος.</l>
@@ -426,7 +426,7 @@ convert to p3
 					<l>οὔτ’ αὐτὸς οὔθ’ ὁ ζύγιος οὔθ’ ὁ σαμφόρας·</l>
 					<l>ἀλλ’ ἐξελῶ σ’ ἐς κόρακας ἐκ τῆς οἰκίας.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἀλλ’ οὐ περιόψεταί μ’ ὁ θεῖος Μεγακλέης</l>
 					<l n="125">ἄνιππον. ἀλλ’ εἴσειμι, σοῦ δ’ οὐ φροντιῶ.</l>
@@ -874,7 +874,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="275">ἀέναοι Νεφέλαι</l>
 						<l>ἀρθῶμεν φανεραὶ δροσερὰν φύσιν εὐάγητον,</l>
@@ -915,7 +915,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παρθένοι ὀμβροφόροι</l>
 						<l n="300">ἔλθωμεν λιπαρὰν χθόνα Παλλάδος, εὔανδρον γᾶν</l>
@@ -1080,7 +1080,7 @@ convert to p3
 						<l>χαίρετε τοίνυν ὦ δέσποιναι· καὶ νῦν, εἴπερ τινὶ κἄλλῳ,</l>
 						<l>οὐρανομήκη ῥήξατε κἀμοὶ φωνήν, ὦ παμβασίλειαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαῖρ’ ὦ πρεσβῦτα παλαιογενὲς θηρατὰ λόγων φιλομούσων,</l>
 						<l>σύ τε λεπτοτάτων λήρων ἱερεῦ, φράζε πρὸς ἡμᾶς ὅ τι χρῄζεις·</l>
@@ -1211,7 +1211,7 @@ convert to p3
 						<l n="410">ἡ δ’ ἄρ’ ἐφυσᾶτ’, εἶτ’ ἐξαίφνης διαλακήσασα πρὸς αὐτὼ</l>
 						<l>τὠφθαλμώ μου προσετίλησεν καὶ κατέκαυσεν τὸ πρόσωπον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ τῆς μεγάλης ἐπιθυμήσας σοφίας ἄνθρωπε παρ’ ἡμῶν,</l>
 						<l>ὡς εὐδαίμων ἐν Ἀθηναίοις καὶ τοῖς Ἕλλησι γενήσει,</l>
@@ -1238,7 +1238,7 @@ convert to p3
 						<l n="425">οὐδ’ ἂν διαλεχθείην γ’ ἀτεχνῶς τοῖς ἄλλοις οὐδ’ ἂν ἀπαντῶν·</l>
 						<l>οὐδ’ ἂν θύσαιμ’, οὐδ’ ἂν σπείσαιμ’, οὐδ’ ἐπιθείην λιβανωτόν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λέγε νυν ἡμῖν ὅ τι σοι δρῶμεν θαρρῶν, ὡς οὐκ ἀτυχήσεις</l>
 						<l>ἡμᾶς τιμῶν καὶ θαυμάζων καὶ ζητῶν δεξιὸς εἶναι.</l>
@@ -1248,7 +1248,7 @@ convert to p3
 						<l>ὦ δέσποιναι δέομαι τοίνυν ὑμῶν τουτὶ πάνυ μικρόν,</l>
 						<l n="430">τῶν Ἑλλήνων εἶναί με λέγειν ἑκατὸν σταδίοισιν ἄριστον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἔσται σοι τοῦτο παρ’ ἡμῶν· ὥστε τὸ λοιπόν γ’ ἀπὸ τουδὶ</l>
 						<l>ἐν τῷ δήμῳ γνώμας οὐδεὶς νικήσει πλείονας ἢ σύ.</l>
@@ -1258,7 +1258,7 @@ convert to p3
 						<l>μὴ ’μοί γε λέγειν γνώμας μεγάλας· οὐ γὰρ τούτων ἐπιθυμῶ,</l>
 						<l>ἀλλ’ ὅσ’ ἐμαυτῷ στρεψοδικῆσαι καὶ τοὺς χρήστας διολισθεῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="435">τεύξει τοίνυν ὧν ἱμείρεις· οὐ γὰρ μεγάλων ἐπιθυμεῖς.</l>
 						<l>ἀλλὰ σεαυτὸν θαρρῶν παράδος τοῖς ἡμετέροις προπόλοισιν.</l>
@@ -1290,7 +1290,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λῆμα μὲν πάρεστι τῷδέ γ’</l>
 						<l>οὐκ ἄτολμον ἀλλ’ ἕτοιμον. ἴσθι δ’ ὡς</l>
@@ -1301,7 +1301,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>τί πείσομαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν πάντα χρόνον μετ’ ἐμοῦ</l>
 						<l n="465">ζηλωτότατον βίον ἀνθρώπων διάξεις.</l>
@@ -1311,7 +1311,7 @@ convert to p3
 						<l>ἆρά γε τοῦτ’ ἄρ’ ἐγώ ποτ’</l>
 						<l>ὄψομαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ὥστε γέ σου πολλοὺς ἐπὶ ταῖσι θύραις ἀεὶ καθῆσθαι,</l>
 						<l n="470">βουλομένους ἀνακοινοῦσθαί τε καὶ ἐς λόγον ἐλθεῖν</l>
@@ -1321,7 +1321,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἐγχείρει τὸν πρεσβύτην ὅ τι περ μέλλεις προδιδάσκειν,</l>
 						<l>καὶ διακίνει τὸν νοῦν αὐτοῦ καὶ τῆς γνώμης ἀποπειρῶ.</l>
@@ -1447,7 +1447,7 @@ convert to p3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 met="anapests" type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="510">ἀλλ’ ἴθι χαίρων τῆς ἀνδρείας</l>
 						<l>οὕνεκα ταύτης.</l>
@@ -1509,7 +1509,7 @@ convert to p3
 					<milestone ed="p" n="563" unit="card"/>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὑψιμέδοντα μὲν θεῶν</l>
 						<l>Ζῆνα τύραννον ἐς χορὸν</l>
@@ -1526,7 +1526,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="575">ὦ σοφώτατοι θεαταὶ δεῦρο  τὸν νοῦν προσέχετε.</l>
 						<l>ἠδικημέναι γὰρ ὑμῖν μεμφόμεσθ’ ἐναντίον·</l>
@@ -1566,7 +1566,7 @@ convert to p3
 					<milestone ed="p" n="607" unit="card"/>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἡνίχ’ ἡμεῖς δεῦρ’ ἀφορμᾶσθαι παρεσκευάσμεθα,</l>
 						<l>ἡ σελήνη συντυχοῦσ’ ἡμῖν ἐπέστειλεν φράσαι,</l>
@@ -1853,7 +1853,7 @@ convert to p3
 					<milestone ed="p" n="700" unit="card"/>
 				</sp>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="700">φρόντιζε δὴ καὶ διάθρει πάντα τρόπον τε σαυτὸν</l>
 						<l>στρόβει πυκνώσας.</l>
@@ -1868,7 +1868,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l n="707">ἀτταταῖ ἀτταταῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί πάσχεις; τί κάμνεις;</l>
 					</sp>
@@ -1882,7 +1882,7 @@ convert to p3
 						<l>καὶ τὸν πρωκτὸν διορύττουσιν,</l>
 						<l n="715">καί μ’ ἀπολοῦσιν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μή νυν βαρέως ἄλγει λίαν.</l>
 					</sp>
@@ -2158,7 +2158,7 @@ convert to p3
 						<l>ἀπὸ γὰρ ὀλοῦμαι μὴ μαθὼν γλωττοστροφεῖν.</l>
 						<l>ἀλλ’ ὦ Νεφέλαι χρηστόν τι συμβουλεύσατε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἡμεῖς μὲν ὦ πρεσβῦτα συμβουλεύομεν,</l>
 						<l n="795">εἴ σοί τις υἱός ἐστιν ἐκτεθραμμένος,</l>
@@ -2169,7 +2169,7 @@ convert to p3
 						<l>ἀλλ’ ἔστ’ ἔμοιγ’ υἱὸς καλός τε κἀγαθός·</l>
 						<l>ἀλλ’ οὐκ ἐθέλει γὰρ μανθάνειν. τί ἐγὼ πάθω;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὺ δ’ ἐπιτρέπεις;</l>
 					</sp>
@@ -2184,7 +2184,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="804">ἆρ’ αἰσθάνει πλεῖστα δῑ ἡμᾶς ἀγάθ’ αὐτίχ’ ἕξων</l>
 						<l>μόνας θεῶν; ὡς</l>
@@ -2202,7 +2202,7 @@ convert to p3
 						<l>οὔτοι μὰ τὴν Ὁμίχλην ἔτ’ ἐνταυθοῖ μενεῖς·</l>
 						<l n="815">ἀλλ’ ἔσθῑ ἐλθὼν τοὺς Μεγακλέους κίονας.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ὦ δαιμόνιε, τί χρῆμα πάσχεις ὦ πάτερ;</l>
 						<l>οὐκ εὖ φρονεῖς μὰ τὸν Δία τὸν Ὀλύμπιον.</l>
@@ -2212,7 +2212,7 @@ convert to p3
 						<l>ἰδού γ’ ἰδού, Δί’ Ὀλύμπιον· τῆς μωρίας,</l>
 						<l>τὸν Δία νομίζειν ὄντα τηλικουτονί.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="820">τί δὲ τοῦτ’ ἐγέλασας ἐτεόν;</l>
 					</sp>
@@ -2224,7 +2224,7 @@ convert to p3
 						<l>καί σοι φράσω τι πρᾶγμ’ ὃ μαθὼν ἀνὴρ ἔσει.</l>
 						<l>ὅπως δὲ τοῦτο μὴ διδάξεις μηδένα.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="825">ἰδού· τί ἔστιν;</l>
 					</sp>
@@ -2232,7 +2232,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l part="Y">ὤμοσας νυνὶ Δία.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἔγωγ’.</l>
 					</sp>
@@ -2241,7 +2241,7 @@ convert to p3
 						<l part="Y">ὁρᾷς οὖν ὡς ἀγαθὸν τὸ μανθάνειν;</l>
 						<l>οὐκ ἔστιν ὦ Φειδιππίδη Ζεύς.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">ἀλλὰ τίς;</l>
 					</sp>
@@ -2249,7 +2249,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>Δῖνος βασιλεύει τὸν Δί’ ἐξεληλακώς.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>αἰβοῖ τί ληρεῖς;</l>
 					</sp>
@@ -2257,7 +2257,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l part="Y">ἴσθι τοῦθ’ οὕτως ἔχον.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="830">τίς φησι ταῦτα;</l>
 					</sp>
@@ -2266,7 +2266,7 @@ convert to p3
 						<l part="Y">Σωκράτης ὁ Μήλιος</l>
 						<l>καὶ Χαιρεφῶν, ὃς οἶδε τὰ ψυλλῶν ἴχνη.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>σὺ δ’ ἐς τοσοῦτον τῶν μανιῶν ἐλήλυθας</l>
 						<l>ὥστ’ ἀνδράσιν πείθει χολῶσιν;</l>
@@ -2281,7 +2281,7 @@ convert to p3
 						<l>ὥσπερ τεθνεῶτος καταλόει μου τὸν βίον.</l>
 						<l>ἀλλ’ ὡς τάχιστ’ ἐλθὼν ὑπὲρ ἐμοῦ μάνθανε.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="840">τί δ’ ἂν παρ’ ἐκείνων καὶ μάθοι χρηστόν τις ἄν;</l>
 					</sp>
@@ -2291,7 +2291,7 @@ convert to p3
 						<l>γνώσει δὲ σαυτὸν ὡς ἀμαθὴς εἶ καὶ παχύς.</l>
 						<l>ἀλλ’ ἐπανάμεινόν μ’ ὀλίγον ἐνταυθοῖ χρόνον.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>οἴμοι τί δράσω παραφρονοῦντος τοῦ πατρός;</l>
 						<l n="845">πότερον παρανοίας αὐτὸν εἰσαγαγὼν ἕλω,</l>
@@ -2301,7 +2301,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>φέρ’ ἴδω, σὺ τοῦτον τί ὀνομάζεις; εἰπέ μοι.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἀλεκτρυόνα.</l>
 					</sp>
@@ -2309,7 +2309,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l part="Y">καλῶς γε. ταυτηνὶ δὲ τί;</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἀλεκτρυόν’.</l>
 					</sp>
@@ -2319,7 +2319,7 @@ convert to p3
 						<l n="850">μή νυν τὸ λοιπόν, ἀλλὰ τήνδε μὲν καλεῖν</l>
 						<l>ἀλεκτρύαιναν τουτονὶ δ’ ἀλέκτορα.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἀλεκτρύαιναν; ταῦτ’ ἔμαθες τὰ δεξιὰ</l>
 						<l>εἴσω παρελθὼν ἄρτι παρὰ τοὺς γηγενεῖς;</l>
@@ -2330,7 +2330,7 @@ convert to p3
 						<l>χἄτερά γε πόλλ’· ἀλλ’ ὅ τι μάθοιμ’ ἑκάστοτε,</l>
 						<l n="855">ἐπελανθανόμην ἂν εὐθὺς ὑπὸ πλήθους ἐτῶν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>διὰ ταῦτα δὴ καὶ θοἰμάτιον ἀπώλεσας;</l>
 					</sp>
@@ -2338,7 +2338,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>ἀλλ’ οὐκ ἀπολώλεκ’, ἀλλὰ καταπεφρόντικα.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>τὰς δ’ ἐμβάδας ποῖ τέτροφας ὦνόητε σύ;</l>
 					</sp>
@@ -2351,7 +2351,7 @@ convert to p3
 						<l>ὃν πρῶτον ὀβολὸν ἔλαβον ἡλιαστικόν,</l>
 						<l>τούτου ’πριάμην σοι Διασίοις ἁμαξίδα.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="865">ἦ μὴν σὺ τούτοις τῷ χρόνῳ ποτ’ ἀχθέσει.</l>
 					</sp>
@@ -2366,7 +2366,7 @@ convert to p3
 						<l part="Y">νηπύτιος γάρ ἐστ’ ἔτι,</l>
 						<l>καὶ τῶν κρεμαθρῶν οὔπω τρίβων τῶν ἐνθάδε.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="870">αὐτὸς τρίβων εἴης ἄν, εἰ κρέμαιό γε.</l>
 					</sp>
@@ -2414,7 +2414,7 @@ convert to p3
 						<l>χώρει δευρί, δεῖξον σαυτὸν</l>
 						<l n="890">τοῖσι θεαταῖς, καίπερ θρασὺς ὤν.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>ἴθ’ ὅποι χρῄζεις. πολὺ γὰρ μᾶλλόν ’ς</l>
 						<l>ἐν τοῖς πολλοῖσι λέγων ἀπολῶ.</l>
@@ -2423,7 +2423,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>ἀπολεῖς σύ; τίς ὤν;</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">λόγος.</l>
 					</sp>
@@ -2432,7 +2432,7 @@ convert to p3
 						<l part="Y">ἥττων</l>
 						<l>γ’ ὤν.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>ἀλλά σε νικῶ τὸν ἐμοῦ κρείττω</l>
 						<l n="895">φάσκοντ’ εἶναι.</l>
@@ -2441,7 +2441,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l part="Y">τί σοφὸν ποιῶν;</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>γνώμας καινὰς ἐξευρίσκων.</l>
 					</sp>
@@ -2450,7 +2450,7 @@ convert to p3
 						<l>ταῦτα γὰρ ἀνθεῖ διὰ τουτουσὶ</l>
 						<l>τοὺς ἀνοήτους.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>οὔκ, ἀλλὰ σοφούς.</l>
 					</sp>
@@ -2458,7 +2458,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l part="Y">ἀπολῶ σε κακῶς.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="900">εἰπὲ τί ποιῶν;</l>
 					</sp>
@@ -2466,7 +2466,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l part="Y">τὰ δίκαια λέγων.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>ἀλλ’ ἀνατρέψω γ’ αὔτ’ ἀντιλέγων·</l>
 						<l>οὐδὲ γὰρ εἶναι πάνυ φημὶ δίκην.</l>
@@ -2475,7 +2475,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>οὐκ εἶναι φῄς;</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">φέρε γὰρ ποῦ ’στιν;</l>
 					</sp>
@@ -2483,7 +2483,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>παρὰ τοῖσι θεοῖς.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>πῶς δῆτα δίκης οὔσης ὁ Ζεὺς</l>
 						<l n="905">οὐκ ἀπόλωλεν τὸν πατέρ’ αὑτοῦ</l>
@@ -2494,7 +2494,7 @@ convert to p3
 						<l part="Y">αἰβοῖ τουτὶ καὶ δὴ</l>
 						<l>χωρεῖ τὸ κακόν· δότε μοι λεκάνην.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>τυφογέρων εἶ κἀνάρμοστος.</l>
 					</sp>
@@ -2502,7 +2502,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>καταπύγων εἶ κἀναίσχυντος.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="910">ῥόδα μ’ εἴρηκας.</l>
 					</sp>
@@ -2510,7 +2510,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l part="Y">καὶ βωμολόχος.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>κρίνεσι στεφανοῖς.</l>
 					</sp>
@@ -2518,7 +2518,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l part="Y">καὶ πατραλοίας.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>χρυσῷ πάττων μ’ οὐ γιγνώσκεις.</l>
 					</sp>
@@ -2526,7 +2526,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>οὐ δῆτα πρὸ τοῦ γ’, ἀλλὰ μολύβδῳ.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>νῦν δέ γε κόσμος τοῦτ’ ἐστὶν ἐμοί.</l>
 					</sp>
@@ -2534,7 +2534,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l n="915">θρασὺς εἶ πολλοῦ.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">σὺ δέ γ’ ἀρχαῖος.</l>
 					</sp>
@@ -2546,7 +2546,7 @@ convert to p3
 						<l>οἶα διδάσκεις τοὺς ἀνοήτους.</l>
 						<milestone ed="p" n="920" unit="card"/>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>αὐχμεῖς αἰσχρῶς.</l>
 					</sp>
@@ -2558,7 +2558,7 @@ convert to p3
 						<l>ἐκ πηριδίου</l>
 						<l>γνώμας τρώγων Πανδελετείους.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="925">ὤμοι σοφίας —</l>
 					</sp>
@@ -2566,7 +2566,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l part="Y">ὤμοι μανίας —</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>ἧς ἐμνήσθης —</l>
 					</sp>
@@ -2575,7 +2575,7 @@ convert to p3
 						<l>τῆς σῆς, πόλεώς θ’ ἥτις σε τρέφει</l>
 						<l>λυμαινόμενον τοῖς μειρακίοις.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>οὐχὶ διδάξεις τοῦτον Κρόνος ὤν.</l>
 					</sp>
@@ -2584,7 +2584,7 @@ convert to p3
 						<l n="930">εἴπερ γ’ αὐτὸν σωθῆναι χρὴ</l>
 						<l>καὶ μὴ λαλιὰν μόνον ἀσκῆσαι.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>δεῦρ’ ἴθι, τοῦτον δ’ ἔα μαίνεσθαι.</l>
 					</sp>
@@ -2592,7 +2592,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>κλαύσει, τὴν χεῖρ’ ἢν ἐπιβάλλῃς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παύσασθε μάχης καὶ λοιδορίας.</l>
 						<l n="935">ἀλλ’ ἐπίδειξαι σύ τε τοὺς προτέρους</l>
@@ -2604,15 +2604,15 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>δρᾶν ταῦτ’ ἐθέλω.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">κἄγωγ’ ἐθέλω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="940">φέρε δὴ πότερος λέξει πρότερος;</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>τούτῳ δώσω·</l>
 						<l>κᾆτ’ ἐκ τούτων ὧν ἂν λέξῃ</l>
@@ -2626,7 +2626,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν δείξετον τὼ πισύνω τοῖς περιδεξίοισι</l>
 						<l>λόγοισι καὶ φροντίσι καὶ γνωμοτύποις μερίμναις,</l>
@@ -2637,7 +2637,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="959">ἀλλ’ ὦ πολλοῖς τοὺς πρεσβυτέρους ἤθεσι χρηστοῖς στεφανώσας,</l>
 						<l>ῥῆξον φωνὴν ᾗτινι χαίρεις, καὶ τὴν σαυτοῦ φύσιν εἰπέ.</l>
@@ -2670,7 +2670,7 @@ convert to p3
 						<l>οὐδ’ ἄννηθον τῶν πρεσβυτέρων ἁρπάζειν οὐδὲ σέλινον,</l>
 						<l>οὐδ’ ὀψοφαγεῖν οὐδὲ κιχλίζειν οὐδ’ ἴσχειν τὼ πόδ’ ἐναλλάξ.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>ἀρχαῖά γε καὶ Διιπολιώδη καὶ τεττίγων ἀνάμεστα</l>
 						<l n="985">καὶ Κηκείδου καὶ Βουφονίων.</l>
@@ -2695,7 +2695,7 @@ convert to p3
 						<l>μνησικακῆσαι τὴν ἡλικίαν ἐξ ἧς ἐνεοττοτροφήθης.</l>
 						<milestone ed="p" n="1000" unit="card"/>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="1000">εἰ ταῦτ’ ὦ μειράκιον πείσει τούτῳ, νὴ τὸν Διόνυσον</l>
 						<l>τοῖς Ἱπποκράτους υἱέσιν εἴξεις καὶ σε καλοῦσι βλιτομάμμαν.</l>
@@ -2735,7 +2735,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ καλλίπυργον σοφίαν κλεινοτάτην ἐπασκῶν,</l>
 						<l>ὡς ἡδύ σου τοῖσι λόγοις σῶφρον ἔπεστιν ἄνθος.</l>
@@ -2746,7 +2746,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="antikatakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεινῶν δέ σοι βουλευμάτων ἔοικε δεῖν πρὸς αὐτόν,</l>
 						<l n="1035">εἴπερ τὸν ἄνδρ’ ὑπερβαλεῖ καὶ μὴ γέλωτ’ ὀφλήσεις.</l>
@@ -2754,7 +2754,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antepirrheme">
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>καὶ μὴν πάλαι γ’ ἐπνιγόμην τὰ σπλάγχνα κἀπεθύμουν</l>
 						<l>ἅπαντα ταῦτ’ ἐναντίαις γνώμαισι συνταράξαι.</l>
@@ -2771,7 +2771,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>ὁτιὴ κάκιστόν ἐστι καὶ δειλὸν ποιεῖ τὸν ἄνδρα.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>ἐπίσχες· εὐθὺς γάρ σ’ ἔχω μέσον λαβὼν ἄφυκτον.</l>
 						<l>καί μοι φράσον, τῶν τοῦ Διὸς παίδων τίν’ ἄνδρ’ ἄριστον</l>
@@ -2781,7 +2781,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l n="1050">ἐγὼ μὲν οὐδέν’ Ἡρακλέους βελτίον’ ἄνδρα κρίνω.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>ποῦ ψυχρὰ δῆτα πώποτ’ εἶδες Ἡράκλεια λουτρά;</l>
 						<l>καίτοι τίς ἀνδρειότερος ἦν;</l>
@@ -2792,7 +2792,7 @@ convert to p3
 						<l>ἃ τῶν νεανίσκων ἀεὶ δῑ ἡμέρας λαλούντων</l>
 						<l>πλῆρες τὸ βαλανεῖον ποιεῖ, κενὰς δὲ τὰς παλαίστρας.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="1055">εἶτ’ ἐν ἀγορᾷ τὴν διατριβὴν ψέγεις· ἐγὼ δ’ ἐπαινῶ.</l>
 						<l>εἰ γὰρ πονηρὸν ἦν, Ὅμηρος οὐδέποτ’ ἂν ἐποίει</l>
@@ -2807,7 +2807,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>πολλοῖς. ὁ γοῦν Πηλεὺς ἔλαβε διὰ τοῦτο τὴν μάχαιραν.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>μάχαιραν; ἀστεῖόν γε κέρδος ἔλαβεν ὁ κακοδαίμων.</l>
 						<l n="1065">Ὑπέρβολος δ’ οὑκ τῶν λύχνων πλεῖν ἢ τάλαντα πολλὰ</l>
@@ -2818,7 +2818,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>καὶ τὴν Θέτιν γ’ ἔγημε διὰ τὸ σωφρονεῖν ὁ Πηλεύς.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>κᾆτ’ ἀπολιποῦσά γ’ αὐτὸν ᾤχετ’· οὐ γὰρ ἦν ὑβριστὴς</l>
 						<l>οὐδ’ ἡδὺς ἐν τοῖς στρώμασιν τὴν νύκτα παννυχίζειν·</l>
@@ -2841,7 +2841,7 @@ convert to p3
 						<l>τί δ’ ἢν ῥαφανιδωθῇ πιθόμενός σοι τέφρᾳ τε τιλθῇ,</l>
 						<l>ἕξει τινὰ γνώμην λέγειν τὸ μὴ εὐρύπρωκτος εἶναι;</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="1085">ἢν δ’ εὐρύπρωκτος ᾖ, τί πείσεται κακόν;</l>
 						<milestone ed="p" n="1086" unit="card"/>
@@ -2852,7 +2852,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>τί μὲν οὖν ἂν ἔτι μεῖζον πάθοι τούτου ποτέ;</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l>τί δῆτ’ ἐρεῖς, ἢν τοῦτο νικηθῇς ἐμοῦ;</l>
 					</sp>
@@ -2860,7 +2860,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>σιγήσομαι. τί δ’ ἄλλο;</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">φέρε δή μοι φράσον·</l>
 						<l>συνηγοροῦσιν ἐκ τίνων;</l>
@@ -2869,7 +2869,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l n="1090">ἐξ εὐρυπρώκτων.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">πείθομαι.</l>
 						<l>τί δαί; τραγῳδοῦσ’ ἐκ τίνων;</l>
@@ -2878,7 +2878,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>ἐξ εὐρυπρώκτων.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">εὖ λέγεις.</l>
 						<l>δημηγοροῦσι δ’ ἐκ τίνων;</l>
@@ -2887,7 +2887,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l>ἐξ εὐρυπρώκτων.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l part="Y">ἆρα δῆτ’</l>
 						<l n="1095">ἔγνωκας ὡς οὐδὲν λέγεις;</l>
@@ -2898,7 +2898,7 @@ convert to p3
 						<speaker>Δίκαιος Λόγος</speaker>
 						<l part="Y">καὶ δὴ σκοπῶ.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="1097b">τί δῆθ’ ὁρᾷς;</l>
 					</sp>
@@ -2909,7 +2909,7 @@ convert to p3
 						<l n="1100">γοῦν οἶδ’ ἐγὼ κἀκεινονὶ</l>
 						<l>καὶ τὸν κομήτην τουτονί.</l>
 					</sp>
-					<sp who="#adikoslogos">
+					<sp who="#adikos_logos">
 						<speaker>Ἄδικος Λόγος</speaker>
 						<l n="1101b">τί δῆτ’ ἐρεῖς;</l>
 					</sp>
@@ -2940,7 +2940,7 @@ convert to p3
 					<speaker>Σωκράτης</speaker>
 					<l>ἀμέλει κομιεῖ τοῦτον σοφιστὴν δεξιόν.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ὠχρὸν μὲν οὖν οἶμαί γε καὶ κακοδαίμονα.</l>
 					<milestone ed="p" n="1113" unit="card"/>
@@ -2948,7 +2948,7 @@ convert to p3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 met="trochees" type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χωρεῖτέ νυν. οἶμαι δέ σοι</l>
 						<l>ταῦτα μεταμελήσειν.</l>
@@ -2956,7 +2956,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1115">τοὺς κριτὰς ἃ κερδανοῦσιν, ἤν τι τόνδε τὸν χορὸν</l>
 						<l>ὠφελῶσ’ ἐκ τῶν δικαίων, βουλόμεσθ’ ἡμεῖς φράσαι.</l>
@@ -3071,7 +3071,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>φοβεῖ δὲ δὴ τί;</l>
 					</sp>
@@ -3079,7 +3079,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l part="Y">τὴν ἕνην τε καὶ νέαν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἕνη γάρ ἐστι καὶ νέα τις ἡμέρα;</l>
 					</sp>
@@ -3087,7 +3087,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l n="1180">εἰς ἥν γε θήσειν τὰ πρυτανεῖά φασί μοι.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἀπολοῦσ’ ἄρ’ αὔθ’ οἱ θέντες· οὐ γὰρ ἔσθ’ ὅπως</l>
 						<l>μί’ ἡμέρα γένοιτ’ ἂν ἡμέρα δύο.</l>
@@ -3096,7 +3096,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>οὐκ ἂν γένοιτο;</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">πῶς γάρ; εἰ μή πέρ γ’ ἅμα</l>
 						<l>αὑτὴ γένοιτ’ ἂν γραῦς τε καὶ νέα γυνή.</l>
@@ -3105,7 +3105,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l n="1185">καὶ μὴν νενόμισταί γ’.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">οὐ γάρ, οἶμαι, τὸν νόμον</l>
 						<l>ἴσασιν ὀρθῶς ὅ τι νοεῖ.</l>
@@ -3114,7 +3114,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l part="Y">νοεῖ δὲ τί;</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ὁ Σόλων ὁ παλαιὸς ἦν φιλόδημος τὴν φύσιν.</l>
 					</sp>
@@ -3122,7 +3122,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>τουτὶ μὲν οὐδέν πω πρὸς ἕνην τε καὶ νέαν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἐκεῖνος οὖν τὴν κλῆσιν ἐς δύ’ ἡμέρας</l>
 						<l n="1190">ἔθηκεν, ἔς γε τὴν ἕνην τε καὶ νέαν,</l>
@@ -3132,7 +3132,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>ἵνα δὴ τί τὴν ἕνην προσέθηχ’;</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">ἵν’ ὦ μέλε</l>
 						<l>παρόντες οἱ φεύγοντες ἡμέρᾳ μιᾷ</l>
@@ -3144,7 +3144,7 @@ convert to p3
 						<l>πῶς οὐ δέχονται δῆτα τῇ νουμηνίᾳ</l>
 						<l>ἁρχαὶ τὰ πρυτανεῖ’, ἀλλ’ ἕνῃ τε καὶ νέᾳ;</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ὅπερ οἱ προτένθαι γὰρ δοκοῦσί μοι ποιεῖν·</l>
 						<l>ὅπως τάχιστα τὰ πρυτανεῖ’ ὑφελοίατο,</l>
@@ -3475,7 +3475,7 @@ convert to p3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἷον τὸ πραγμάτων ἐρᾶν φλαύρων· ὁ γὰρ</l>
 						<l>γέρων ὅδ’ ἐρασθεὶς</l>
@@ -3489,7 +3489,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἶμαι γὰρ αὐτὸν αὐτίχ’ εὑρήσειν ὅπερ</l>
 						<l n="1312">πάλαι ποτ’ †ἐπεζήτει†</l>
@@ -3512,7 +3512,7 @@ convert to p3
 					<l>οἴμοι κακοδαίμων τῆς κεφαλῆς καὶ τῆς γνάθου.</l>
 					<l n="1325">ὦ μιαρὲ τύπτεις τὸν πατέρα;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">φήμ’ ὦ πάτερ.</l>
 				</sp>
@@ -3520,7 +3520,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>ὁρᾶθ’ ὁμολογοῦνθ’ ὅτι με τύπτει.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">καὶ μάλα.</l>
 				</sp>
@@ -3528,7 +3528,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>ὦ μιαρὲ καὶ πατραλοῖα καὶ τοιχωρύχε.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>αὖθίς με ταὐτὰ ταῦτα καὶ πλείω λέγε.</l>
 					<l>ἆρ’ οἶσθ’ ὅτι χαίρω πόλλ’ ἀκούων καὶ κακά;</l>
@@ -3537,7 +3537,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l n="1330">ὦ λακκόπρωκτε.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">πάττε πολλοῖς τοῖς ῥόδοις.</l>
 				</sp>
@@ -3545,7 +3545,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>τὸν πατέρα τύπτεις;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">κἀποφανῶ γε νὴ Δία</l>
 					<l>ὡς ἐν δίκῃ σ’ ἔτυπτον.</l>
@@ -3555,7 +3555,7 @@ convert to p3
 					<l part="Y">ὦ μιαρώτατε,</l>
 					<l>καὶ πῶς γένοιτ’ ἂν πατέρα τύπτειν ἐν δίκῃ;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἔγωγ’ ἀποδείξω καί σε νικήσω λέγων.</l>
 				</sp>
@@ -3563,7 +3563,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l n="1335">τουτὶ σὺ νικήσεις;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">πολύ γε καὶ ῥᾳδίως.</l>
 					<l>ἑλοῦ δ’ ὁπότερον τοῖν λόγοιν βούλει λέγειν.</l>
@@ -3572,7 +3572,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>ποίοιν λόγοιν;</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">τὸν κρείττον’ ἢ τὸν ἥττονα.</l>
 				</sp>
@@ -3583,7 +3583,7 @@ convert to p3
 					<l n="1340">μέλλεις ἀναπείσειν, ὡς δίκαιον καὶ καλὸν</l>
 					<l>τὸν πατέρα τύπτεσθ’ ἐστὶν ὑπὸ τῶν υἱέων.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἀλλ’ οἴομαι μέντοι σ’ ἀναπείσειν, ὥστε γε</l>
 					<l>οὐδ’ αὐτὸς ἀκροασάμενος οὐδὲν ἀντερεῖς.</l>
@@ -3596,7 +3596,7 @@ convert to p3
 			</div1>
 			<div1 type="Agon">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1345">σὸν ἔργον ὦ πρεσβῦτα φροντίζειν ὅπῃ</l>
 						<l>τὸν ἄνδρα κρατήσεις,</l>
@@ -3608,7 +3608,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="iambics" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἐξ ὅτου τὸ πρῶτον ἤρξαθ’ ἡ μάχη γενέσθαι,</l>
 						<l>ἤδη λέγειν χρὴ πρὸς χορόν· πάντως δὲ τοῦτο δράσεις.</l>
@@ -3625,7 +3625,7 @@ convert to p3
 						<l>ὁ δ’ εὐθέως ἀρχαῖον εἶν’ ἔφασκε τὸ κιθαρίζειν</l>
 						<l>ᾄδειν τε πίνονθ’ ὡσπερεὶ κάχρυς γυναῖκ’ ἀλοῦσαν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>οὐ γὰρ τότ’ εὐθὺς χρῆν σ’ ἄρα τύπτεσθαί τε καὶ πατεῖσθαι,</l>
 						<l n="1360">ᾄδειν κελεύονθ’ ὡσπερεὶ τέττιγας ἑστιῶντα;</l>
@@ -3649,7 +3649,7 @@ convert to p3
 						<l n="1375">ἔπος πρὸς ἔπος ἠρειδόμεσθ’· εἶθ’ οὗτος ἐπαναπηδᾶ,</l>
 						<l>κἄπειτ’ ἔφλα με κἀσπόδει κἄπνιγε κἀπέθλιβεν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>οὔκουν δικαίως, ὅστις οὐκ Εὐριπίδην ἐπαινεῖς</l>
 						<l>σοφώτατον;</l>
@@ -3659,7 +3659,7 @@ convert to p3
 						<l part="Y">σοφώτατόν γ’ ἐκεῖνον·ὦ — τί σ’ εἴπω;</l>
 						<l>ἀλλ’ αὖθις αὖ τυπτήσομαι.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">νὴ τὸν Δί’ ἐν δίκῃ γ’ ἄν.</l>
 					</sp>
@@ -3686,7 +3686,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἶμαί γε τῶν νεωτέρων τὰς καρδίας</l>
 						<l>πηδᾶν ὅ τι λέξει.</l>
@@ -3698,7 +3698,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="iambics" type="antikatakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὸν ἔργον ὦ καινῶν ἐπῶν κινητὰ καὶ μοχλευτὰ</l>
 						<l>πειθώ τινα ζητεῖν, ὅπως δόξεις λέγειν δίκαια.</l>
@@ -3706,7 +3706,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="iambics" type="antepirrheme">
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ὡς ἡδὺ καινοῖς πράγμασιν καὶ δεξιοῖς ὁμιλεῖν,</l>
 						<l n="1400">καὶ τῶν καθεστώτων νόμων ὑπερφρονεῖν δύνασθαι.</l>
@@ -3721,7 +3721,7 @@ convert to p3
 						<l>ἵππευε τοίνυν νὴ Δί’, ὡς ἔμοιγε κρεῖττόν ἐστιν</l>
 						<l>ἵππων τρέφειν τέθριππον ἢ τυπτόμενον ἐπιτριβῆναι.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>ἐκεῖσε δ’ ὅθεν ἀπέσχισάς με τοῦ λόγου μέτειμι,</l>
 						<l>καὶ πρῶτ’ ἐρήσομαί σε τουτί· παῖδά μ’ ὄντ’ ἔτυπτες;</l>
@@ -3730,7 +3730,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l n="1410">ἔγωγέ σ’ εὐνοῶν τε καὶ κηδόμενος.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">εἰπὲ δή μοι,</l>
 						<l>οὐ κἀμέ σοι δίκαιόν ἐστιν εὐνοεῖν ὁμοίως</l>
@@ -3747,7 +3747,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l n="1420">ἀλλ’ οὐδαμοῦ νομίζεται τὸν πατέρα τοῦτο πάσχειν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>οὔκουν ἀνὴρ ὁ τὸν νόμον θεὶς τοῦτον ἦν τὸ πρῶτον</l>
 						<l>ὥσπερ σὺ κἀγώ, καὶ λέγων ἔπειθε τοὺς παλαιούς;</l>
@@ -3764,7 +3764,7 @@ convert to p3
 						<l n="1430">τί δῆτ’, ἐπειδὴ τοὺς ἀλεκτρυόνας ἅπαντα μιμεῖ,</l>
 						<l>οὐκ ἐσθίεις καὶ τὴν κόπρον κἀπὶ ξύλου καθεύδεις;</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>οὐ ταὐτὸν ὦ τᾶν ἐστίν, οὐδ’ ἂν Σωκράτει δοκοίη.</l>
 					</sp>
@@ -3772,7 +3772,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>πρὸς ταῦτα μὴ τύπτ’· εἰ δὲ μή, σαυτόν ποτ’ αἰτιάσει.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>καὶ πῶς;</l>
 					</sp>
@@ -3781,7 +3781,7 @@ convert to p3
 						<l part="Y">ἐπεὶ σὲ μὲν δίκαιός εἰμ’ ἐγὼ κολάζειν,</l>
 						<l n="1435">σὺ δ’, ἢν γένηταί σοι, τὸν υἱόν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">ἢν δὲ μὴ γένηται,</l>
 						<l>μάτην ἐμοὶ κεκλαύσεται, σὺ δ’ ἐγχανὼν τεθνήξεις.</l>
@@ -3793,7 +3793,7 @@ convert to p3
 						<l>κἄμοιγε συγχωρεῖν δοκεῖ τούτοισι τἀπιεικῆ.</l>
 						<l>κλάειν γὰρ ἡμᾶς εἰκός ἐστ’, ἢν μὴ δίκαια δρῶμεν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="1440">σκέψαι δὲ χἀτέραν ἔτι γνώμην.</l>
 					</sp>
@@ -3801,7 +3801,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l part="Y">ἀπὸ γὰρ</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>καὶ μὴν ἴσως γ’ οὐκ ἀχθέσει παθὼν ἃ νῦν πέπονθας.</l>
 					</sp>
@@ -3809,7 +3809,7 @@ convert to p3
 						<speaker>Στρεψιάδης</speaker>
 						<l>πῶς δή; δίδαξον γὰρ τί μ’ ἐκ τούτων ἐπωφελήσεις.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l>τὴν μητέρ’ ὥσπερ καὶ σὲ τυπτήσω.</l>
 					</sp>
@@ -3818,14 +3818,14 @@ convert to p3
 						<l part="Y">τί φῄς, τί φὴ|ς σύ;</l>
 						<l>τοῦθ’ ἕτερον αὖ μεῖζον κακόν.</l>
 					</sp>
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l part="Y">τί δ’ ἢν ἔχων τὸν ἥττω</l>
 						<milestone ed="p" n="1445" unit="card"/>
 					</sp>
 				</div2>
 				<div2 met="iambics" type="antipnigos">
-					<sp who="#feidippides">
+					<sp who="#pheidippides">
 						<speaker>Φειδιππίδης</speaker>
 						<l n="1445">λόγον σε νικήσω λέγων</l>
 						<l>τὴν μητέρ’ ὡς τύπτειν χρεών;</l>
@@ -3847,7 +3847,7 @@ convert to p3
 					<l>ταυτὶ δῑ ὑμᾶς ὦ Νεθέλαι πέπονθ’ ἐγώ,</l>
 					<l>ὑμῖν ἀναθεὶς ἅπαντα τἀμὰ πράγματα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>αὐτὸς μὲν οὖν σαυτῷ σὺ τούτων αἴτιος,</l>
 					<l n="1455">στρέψας σεαυτὸν ἐς πονηρὰ πράγματα.</l>
@@ -3857,7 +3857,7 @@ convert to p3
 					<l>τί δῆτα ταῦτ’ οὔ μοι τότ’ ἠγορεύετε,</l>
 					<l>ἀλλ’ ἄνδρ’ ἄγροικον καὶ γέροντ’ ἐπῄρετε;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμεῖς ποιοῦμεν ταῦθ’ ἑκάστοθ’ ὅταν τινὰ</l>
 					<l>γνῶμεν πονηρῶν ὄντ’ ἐραστὴν πραγμάτων,</l>
@@ -3872,7 +3872,7 @@ convert to p3
 					<l n="1465">τὸν Χαιρεφῶντα τὸν μιαρὸν καὶ Σωκράτη</l>
 					<l>ἀπολεῖς μετ’ ἐμοῦ ’λθών, οἳ σὲ κἄμ’ ἐξηπάτων.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἀλλ’ οὐκ ἂν ἀδικήσαιμι τοὺς διδασκάλους.</l>
 				</sp>
@@ -3880,7 +3880,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>ναὶ ναὶ καταιδέσθητι πατρῷον Δία.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l>ἰδού γε Δία πατρῷον· ὡς ἀρχαῖος εἶ.</l>
 					<l n="1470">Ζεὺς γάρ τις ἔστιν;</l>
@@ -3889,7 +3889,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l part="Y">ἔστιν.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l part="Y">οὐκ ἔστ’, οὔκ, ἐπεὶ</l>
 					<l>Δῖνος βασιλεύει τὸν Δί’ ἐξεληλακώς.</l>
@@ -3900,7 +3900,7 @@ convert to p3
 					<l>διὰ τουτονὶ τὸν δῖνον. οἴμοι δείλαιος</l>
 					<l>ὅτε καὶ σὲ χυτρεοῦν ὄντα θεὸν ἡγησάμην.</l>
 				</sp>
-				<sp who="#feidippides">
+				<sp who="#pheidippides">
 					<speaker>Φειδιππίδης</speaker>
 					<l n="1475">ἐνταῦθα σαυτῷ παραφρόνει καὶ φληνάφα.</l>
 					<milestone ed="p" n="1476" unit="card"/>
@@ -3925,7 +3925,7 @@ convert to p3
 					<l>κἀγώ τιν’ αὐτῶν τήμερον δοῦναι δίκην</l>
 					<l>ἐμοὶ ποιήσω, κεἰ σφόδρ’ εἴσ’ ἀλαζόνες.</l>
 				</sp>
-				<sp who="#mathetesa">
+				<sp who="#mathetes_a">
 					<speaker>Μαθητής Α</speaker>
 					<l>ἰοὺ ἰού.</l>
 				</sp>
@@ -3933,7 +3933,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>σὸν ἔργον ὦ δὰ|ς ἱέναι πολλὴν φλόγα.</l>
 				</sp>
-				<sp who="#mathetesa">
+				<sp who="#mathetes_a">
 					<speaker>Μαθητής Α</speaker>
 					<l n="1495"> ἄνθρωπε, τί ποιεῖς;</l>
 				</sp>
@@ -3942,7 +3942,7 @@ convert to p3
 					<l part="Y">ὅ τι ποιῶ; τί δ’ ἄλλο γ’ ἢ</l>
 					<l>διαλεπτολογοῦμαι ταῖς δοκοῖς τῆς οἰκίας;</l>
 				</sp>
-				<sp who="#mathetesb">
+				<sp who="#mathetes_b">
 					<speaker>Μαθητής Β</speaker>
 					<l>οἴμοι τίς ἡμῶν πυρπολεῖ τὴν οἰκίαν;</l>
 				</sp>
@@ -3950,7 +3950,7 @@ convert to p3
 					<speaker>Στρεψιάδης</speaker>
 					<l>ἐκεῖνος οὗπερ θοἰμάτιον εἰλήφατε.</l>
 				</sp>
-				<sp who="#mathetesg">
+				<sp who="#mathetes_g">
 					<speaker>Μαθητής Γ</speaker>
 					<l>ἀπολεῖς ἀπολεῖς.</l>
 				</sp>
@@ -3972,7 +3972,7 @@ convert to p3
 					<speaker>Σωκράτης</speaker>
 					<l>οἴμοι τάλας δείλαιος ἀποπνιγήσομαι.</l>
 				</sp>
-				<sp who="#xairefon">
+				<sp who="#chairephon">
 					<speaker>Χαιρεφῶν</speaker>
 					<l n="1505">ἐγὼ δὲ κακοδαίμων γε κατακαυθήσομαι.</l>
 				</sp>
@@ -3981,7 +3981,7 @@ convert to p3
 					<l>τί γὰρ μαθόντες τοὺς θεοὺς ὑβρίζετε,</l>
 					<l>καὶ τῆς σελήνης ἐσκοπεῖσθε τὴν ἕδραν;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ερμῆς</speaker>
 					<l>δίωκε βάλλε παῖε, πολλῶν οὕνεκα,</l>
 					<l>μάλιστα δ’ εἰδὼς τοὺς θεοὺς ὡς ἠδίκουν.</l>
@@ -3989,7 +3989,7 @@ convert to p3
 			</div1>
 			<div1 type="Exodus">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1510">ἡγεῖσθ’ ἔξω· κεχόρευται γὰρ μετρίως τό γε τήμερον ἡμῖν.</l>
 					</sp>

--- a/tei/aristophanes-ecclesiazusae.xml
+++ b/tei/aristophanes-ecclesiazusae.xml
@@ -52,13 +52,13 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="gyneb">
+					<person xml:id="gyne_b">
 						<persName>Γυνὴ Β</persName>
 					</person>
-					<person xml:id="graysb">
+					<person xml:id="graus_b">
 						<persName>Γραῦς Β</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορὸς</name>
 					</personGrp>
 					<person xml:id="kerykaina">
@@ -67,7 +67,7 @@
 					<person xml:id="blepyros">
 						<persName>Βλέπυρος</persName>
 					</person>
-					<person xml:id="xremes">
+					<person xml:id="chremes">
 						<persName>Χρέμης</persName>
 					</person>
 					<person xml:id="aner">
@@ -76,31 +76,31 @@
 					<person xml:id="therapaina">
 						<persName>Θεραπαίνα</persName>
 					</person>
-					<person xml:id="graysa">
+					<person xml:id="graus_a">
 						<persName>Γραῦς Α</persName>
 					</person>
-					<person xml:id="anerb">
+					<person xml:id="aner_b">
 						<persName>Ἀνὴρ Β</persName>
 					</person>
-					<person xml:id="praksagora">
+					<person xml:id="praxagora">
 						<persName>Πραξάγορα</persName>
 					</person>
 					<person xml:id="neanis">
 						<persName>Νεᾶνις</persName>
 					</person>
-					<person xml:id="anera">
+					<person xml:id="aner_a">
 						<persName>Ἀνὴρ Α</persName>
 					</person>
-					<person xml:id="gynea">
+					<person xml:id="gyne_a">
 						<persName>Γυνὴ Α</persName>
 					</person>
 					<person xml:id="neanias">
 						<persName>Νεανίας</persName>
 					</person>
-					<person xml:id="graysg">
+					<person xml:id="graus_g">
 						<persName>Γραῦς Γ</persName>
 					</person>
-					<person xml:id="gyneg">
+					<person xml:id="gyne_g">
 						<persName>Γυνὴ Γ</persName>
 					</person>
 				</listPerson>
@@ -186,7 +186,7 @@ convert to p3
 		<body>
 			<div1 type="Prologue">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>Ὦ λαμπρὸν ὄμμα τοῦ τροχηλάτου λύχνου</l>
 					<l>κάλλιστ’ ἐν εὐστόχοισιν ἐζητημένον·</l>
@@ -218,19 +218,19 @@ convert to p3
 					<l>προσιόντα. φέρε νυν ἐπαναχωρήσω πάλιν,</l>
 					<l>μὴ καί τις ὢν ἀνὴρ ὁ προσιὼν τυγχάνῃ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="30">ὥρα βαδίζειν, ὡς ὁ κῆρυξ ἀρτίως</l>
 					<l>ἡμῶν προσιουσῶν δεύτερον κεκόκκυκεν.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἐγὼ δέ γ’ ὑμᾶς προσδοκῶσ’ ἠγρηγόρη</l>
 					<l>τὴν νύκτα πᾶσαν. ἀλλὰ φέρε τὴν γείτονα</l>
 					<l>τήνδ’ ἐκκαλέσωμαι θρυγονῶσα τὴν θύραν.</l>
 					<l n="35">δεῖ γὰρ τὸν ἄνδρ’ αὐτῆς λαθεῖν.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l part="Y">ἤκουσά τοι</l>
 					<l>ὑποδουμένη τὸ κνῦμά σου τῶν δακτύλων,</l>
@@ -240,51 +240,51 @@ convert to p3
 					<l n="40">ὥστ’ ἄρτι τουτὶ θοἰμάτιον αὐτοῦ ’λαβον.</l>
 					<milestone ed="p" n="41" unit="card"/>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>καὶ μὴν ὁρῶ καὶ Κλειναρέτην καὶ Σωστράτην</l>
 					<l>προσιοῦσαν ἤδη τήνδε καὶ Φιλαινέτην.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>οὔκουν ἐπείξεσθ’; ὡς Γλύκη κατώμοσεν</l>
 					<l>τὴν ὑστάτην ἥκουσαν οἴνου τρεῖς χοᾶς</l>
 					<l n="45">ἡμῶν ἀποτείσειν κἀρεβίνθων χοίνικα.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>τὴν Σμικυθίωνος δ’ οὐχ ὁρᾷς Μελιστίχην</l>
 					<l>σπεύδουσαν ἐν ταῖς ἐμβάσιν;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">καίτοι δοκεῖ</l>
 					<l>κατὰ σχολὴν παρὰ τἀνδρὸς ἐξελθεῖν μόνη.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>τὴν τοῦ καπήλου δ’ οὐχ ὁρᾷς Γευσιστράτην</l>
 					<l n="50">ἔχουσαν ἐν τῇ δεξιᾷ τὴν λαμπάδα;</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>καὶ τὴν Φιλοδωρήτου τε καὶ Χαιρητάδου</l>
 					<l>ὁρῶ προσιούσας χἀτέρας πολλὰς πάνυ</l>
 					<l>γυναῖκας, ὅ τι πέρ ἐστ’ ὄφελος ἐν τῇ πόλει.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>καὶ πάνυ ταλαιπώρως ἔγωγ’ ὦ φιλτάτη</l>
 					<l n="55">ἐκδρᾶσα παρέδυν. ὁ γὰρ ἀνὴρ τὴν νύχθ’ ὅλην</l>
 					<l>ἔβηττε τριχίδων ἑσπέρας ἐμπλήμενος.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>κάθησθε τοίνυν, ὡς &lt;ἂν&gt; ἀνέρωμαι τάδε</l>
 					<l>ὑμᾶς, ἐπειδὴ συλλελεγμένας ὁρῶ,</l>
 					<l>ὅσα Σκίροις ἔδοξεν εἰ δεδράκατε.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="60">ἔγωγε. πρῶτον μέν γ’ ἔχω τὰς μασχάλας</l>
 					<l>λόχμης δασυτέρας, καθάπερ ἦν ξυγκείμενον·</l>
@@ -292,49 +292,49 @@ convert to p3
 					<l>ἀλειψαμένη τὸ σῶμ’ ὅλον δῑ ἡμέρας</l>
 					<l>ἐχραινόμην ἑστῶσα πρὸς τὸν ἥλιον.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l n="65">κἄγωγε· τὸ ξυρὸν δέ γ’ ἐκ τῆς οἰκίας</l>
 					<l>ἔρριψα πρῶτον, ἵνα δασυνθείην ὅλη</l>
 					<l>καὶ μηδὲν εἴην ἔτι γυναικὶ προσφερής.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἔχετε δὲ τοὺς πώγωνας, οὓς εἴρητ’ ἔχειν</l>
 					<l>πάσαισιν ἡμῖν, ὁπότε συλλεγοίμεθα;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="70">νὴ τὴν Ἑκάτην καλόν γ’ ἔγωγε τουτονί.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>κἄγωγ’ Ἑπικράτους οὐκ ὀλίγῳ καλλίονα.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ὑμεῖς δὲ τί φατε;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">φασί· κατανεύουσι γάρ.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>καὶ μὴν τά γ’ ἄλλ’ ὑμῖν ὁρῶ πεπραγμένα.</l>
 					<l>Λακωνικὰς γὰρ ἔχετε καὶ βακτηρίας</l>
 					<l n="75">καὶ θαἰμάτια τἀνδρεῖα, καθάπερ εἴπομεν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἔγωγέ τοι τὸ σκύταλον ἐξηνεγκάμην</l>
 					<l>τὸ τοῦ Λαμίου τουτὶ καθεύδοντος λάθρᾳ.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>τοῦτ’ ἔστ’ ἐκείνων τῶν σκυτάλων ὧν πέρδεται.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>νὴ τὸν Δία τὸν σωτῆρ’ ἐπιτήδειός γ’ ἂν ἦν</l>
 					<l n="80">τὴν τοῦ πανόπτου διφθέραν ἐνημμένος</l>
@@ -345,27 +345,27 @@ convert to p3
 					<l n="85">ἡμεῖς βαδίζειν, ἐξ ἕω γενήσεται.</l>
 					<milestone ed="p" n="86" unit="card"/>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>νὴ τὸν Δί’ ὥστε δεῖ σε καταλαβεῖν ἕδρας</l>
 					<l>ὑπὸ τῷ λίθῳ τῶν πρυτάνεων καταντικρύ.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>ταυτί γέ τοι νὴ τὸν Δί’ ἐφερόμην, ἵνα</l>
 					<l>πληρουμένης ξαίνοιμι τῆς ἐκκλησίας.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l n="90">πληρουμένης τάλαινα;</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l part="Y">νὴ τὴν Ἄρτεμιν</l>
 					<l>ἔγωγε. τί γὰρ ἂν χεῖρον ἀκροῴμην ἄρα</l>
 					<l>ξαίνουσα; γυμνὰ δ’ ἐστί μου τὰ παιδία.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἰδού γέ σε ξαίνουσαν, ἣν τοῦ σώματος</l>
 					<l>οὐδὲν παραφῆναι τοῖς καθημένοις ἔδει.</l>
@@ -377,13 +377,13 @@ convert to p3
 					<l n="100">ὅταν καθῶμεν ὃν περιδησόμεσθ’ ἐκεῖ,</l>
 					<l>τίς οὐκ ἂν ἡμᾶς ἄνδρας ἡγήσαιθ’ ὁρῶν;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>Ἀγύρριος γοῦν τὸν Προνόμου πώγων’ ἔχων</l>
 					<l>λέληθε· καίτοι πρότερον ἦν οὗτος γυνή·</l>
 					<l>νυνὶ δ’, ὁρᾷς, πράττει τὰ μέγιστ’ ἐν τῇ πόλει.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l n="105">τούτου γε τοίνυν τὴν ἐπιοῦσαν ἡμέραν</l>
 					<l>τόλμημα τολμῶμεν τοσοῦτον οὕνεκα,</l>
@@ -391,102 +391,102 @@ convert to p3
 					<l>δυνώμεθ’, ὥστ’ ἀγαθόν τι πρᾶξαι τὴν πόλιν·</l>
 					<l>νῦν μὲν γὰρ οὔτε θέομεν οὔτ’ ἐλαύνομεν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="110">καὶ πῶς γυναικῶν θηλύφρων ξυνουσία</l>
 					<l>δημηγορήσει;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">πολὺ μὲν οὖν ἄριστά που.</l>
 					<l>λέγουσι γὰρ καὶ τῶν νεανίσκων ὅσοι</l>
 					<l>πλεῖστα σποδοῦνται, δεινοτάτους εἶναι λέγειν·</l>
 					<l>ἡμῖν δ’ ὑπάρχει τοῦτο κατὰ τύχην τινά.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="115">οὐκ οἶδα· δεινὸν δ’ ἐστὶν ἡ μὴ ’μπειρία.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>οὐκοῦν ἐπίτηδες ξυνελέγημεν ἐνθάδε,</l>
 					<l>ὅπως προμελετήσωμεν ἁκεῖ δεῖ λέγειν.</l>
 					<l>οὐκ ἂν φθάνοις τὸ γένειον ἂν περιδουμένη</l>
 					<l>ἄλλαι θ’ ὅσαι λαλεῖν μεμελετήκασί που.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="120">τίς δ’ ὦ μέλ’ ἡμῶν οὐ λαλεῖν ἐπίσταται;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἴθι δὴ σὺ περιδοῦ καὶ ταχέως ἀνὴρ γενοῦ·</l>
 					<l>ἐγὼ δὲ θεῖσα τοὺς στεφάνους περιδήσομαι</l>
 					<l>καὐτὴ μεθ’ ὑμῶν, ἤν τί μοι δόξῃ λέγειν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>δεῦρ’ ὦ γλυκυτάτη Πραξαγόρα, σκέψαι τάλαν</l>
 					<l n="125">ὡς καὶ καταγέλαστον τὸ πρᾶγμα φαίνεται.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>πῶς καταγέλαστον;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">ὥσπερ εἴ τις σηπίαις</l>
 					<l>πώγωνα περιδήσειεν ἐσταθευμέναις.</l>
 					<milestone ed="p" n="128" unit="card"/>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ὁ περιστίαρχος, περιφέρειν χρὴ τὴν γαλῆν.</l>
 					<l>πάριτ’ ἐς τὸ πρόσθεν. Ἀρίφραδες παῦσαι λαλῶν.</l>
 					<l n="130">κάθιζε παριών. τίς ἀγορεύειν βούλεται;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἐγώ.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">περίθου δὴ τὸν στέφανον τύχἀγαθῇ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἰδού.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">λέγοις ἄν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">εἶτα πρὶν πιεῖν λέγω;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἰδοὺ πιεῖν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">τί γὰρ ὦ μέλ’ ἐστεφανωσάμην;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἄπιθ’ ἐκποδών· τοιαῦτ’ ἂν ἡμᾶς ἠργάσω</l>
 					<l n="135">κἀκεῖ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">τί δ’; οὐ πίνουσι κἀν τἠκκλησίᾳ;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἰδού γε σοὶ πίνουσι.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">νὴ τὴν Ἄρτεμιν</l>
 					<l>καὶ ταῦτα γ’ εὔζωρον. τὰ γοῦν βουλεύματα</l>
@@ -497,30 +497,30 @@ convert to p3
 					<l>καὶ λοιδοροῦνταί γ’ ὥσπερ ἐμπεπωκότες,</l>
 					<l>καὶ τὸν παροινοῦντ’ ἐκφέρουσ’ οἱ τοξόται,</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>σὺ μὲν βάδιζε καὶ κάθησ’· οὐδὲν γὰρ εἶ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="145">νὴ τὸν Δί’ ἦ μοι μὴ γενειᾶν κρεῖττον ἦν·</l>
 					<l>δίψῃ γάρ, ὡς ἔοικ’, ἀφαυανθήσομαι.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἔσθ’ ἥτις ἑτέρα βούλεται λέγειν;</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l part="Y">ἐγώ.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἴθι δὴ στεφανοῦ· καὶ γὰρ τὸ χρῆμ’ ἐργάζεται.</l>
 					<l>ἄγε νυν ὅπως ἀνδριστὶ καὶ καλῶς ἐρεῖς</l>
 					<l n="150">διερεισαμένη τὸ σχῆμα τῇ βακτηρίᾳ.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>ἐβουλόμην μὲν ἂν ἕτερον τῶν ἠθάδων</l>
 					<l>λέγειν τὰ βέλτισθ’, ἵν’ ἐκαθήμην ἥσυχος·</l>
@@ -528,46 +528,46 @@ convert to p3
 					<l>ἐν τοῖς καπηλείοισι λάκκους ἐμποιεῖν</l>
 					<l n="155">ὕδατος. ἐμοὶ μὲν οὐ δοκεῖ μὰ τὼ θεώ.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>μὰ τὼ θεώ; τάλαινα ποῦ τὸν νοῦν ἔχεις;</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>τί δ’ ἔστιν; οὐ γὰρ δὴ πιεῖν γ’ ᾔτησά σε.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>μὰ Δί’ ἀλλ’ ἀνὴρ ὢν τὼ θεὼ κατώμοσας,</l>
 					<l>καίτοι τά γ’ ἄλλ’ εἰποῦσα δεξιώτατα.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l n="160">ὢ νὴ τὸν Ἀπόλλω.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">παῦε τοίνυν, ὡς ἐγὼ</l>
 					<l>ἐκκλησιάσουσ’ οὐκ ἂν προβαίην τὸν πόδα</l>
 					<l>τὸν ἕτερον, εἰ μὴ ταῦτ’ ἀκριβωθήσεται.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>φέρε τὸν στέφανον· ἐγὼ γὰρ αὖ λέξω πάλιν.</l>
 					<l>οἶμαι γὰρ ἤδη μεμελετηκέναι καλῶς.</l>
 					<l n="165">ἐμοὶ γὰρ ὦ γυναῖκες αἱ καθήμεναι—</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>γυναῖκας αὖ δύστηνε τοὺς ἄνδρας λέγεις;</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>δῑ Ἐπίγονόν γ’ ἐκεῖνον· ἐπιβλέψασα γὰρ</l>
 					<l>ἐκεῖσε πρὸς γυναῖκας ᾠόμην λέγειν.</l>
 					<milestone ed="p" n="169" unit="card"/>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἄπερρε καὶ σὺ καὶ κάθησ’ ἐντευθενί·</l>
 					<l n="170">αὐτὴ γὰρ ὑμῶν γ’ ἕνεκά μοι λέξειν δοκῶ</l>
@@ -590,20 +590,20 @@ convert to p3
 					<l>ὁ δ’ οὐ λαβὼν εἶναι θανάτου φήσ’ ἀξίους</l>
 					<l>τοὺς μισθοφορεῖν ζητοῦντας ἐν τἠκκλησίᾳ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>νὴ τὴν Ἀφροδίτην εὖ γε ταυταγὶ λέγεις.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l n="190">τάλαιν’ Ἀφροδίτην ὤμοσας; χαρίεντά γ’ ἂν</l>
 					<l>ἔδρασας, εἰ τοῦτ’ εἶπας ἐν τἠκκλησίᾳ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἀλλ’ οὐκ ἂν εἶπον.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">μηδ’ ἐθίζου νῦν λέγειν.</l>
 					<l>τὸ συμμαχικὸν αὖ τοῦθ’, ὅτ’ ἐσκοπούμεθα,</l>
@@ -619,11 +619,11 @@ convert to p3
 					<l>Θρασύβουλος αὐτὸς οὐχὶ παρακαλούμενος.</l>
 					<milestone ed="p" n="204" unit="card"/>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ὡς ξυνετὸς ἁνήρ.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">νῦν καλῶς ἐπῄνεσας.</l>
 					<l n="205">ὑμεῖς γάρ ἐστ’ ὦ δῆμε τούτων αἴτιοι.</l>
@@ -635,15 +635,15 @@ convert to p3
 					<l>ἡμᾶς παραδοῦναι. καὶ γὰρ ἐν ταῖς οἰκίαις</l>
 					<l>ταύταις ἐπιτρόποις καὶ ταμίαισι χρώμεθα.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>εὖ γ’ εὖ γε νὴ Δί’ εὖ γε.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l part="Y">λέγε λέγ’ ὦγαθέ.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ὡς δ’ εἰσὶν ἡμῶν τοὺς τρόπους βελτίονες</l>
 					<l n="215">ἐγὼ διδάξω. πρῶτα μὲν γὰρ τἄρια</l>
@@ -675,17 +675,17 @@ convert to p3
 					<l n="240">εὐδαιμονοῦντες τὸν βίον διάξετε.</l>
 					<milestone ed="p" n="241" unit="card"/>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>εὖ γ’ ὦ γλυκυτάτη Πραξαγόρα καὶ δεξιῶς.</l>
 					<l>πόθεν ὦ τάλαινα ταῦτ’ ἔμαθες οὕτω καλῶς;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ἐν ταῖς φυγαῖς μετὰ τἀνδρὸς ᾤκησ’ ἐν πυκνί·</l>
 					<l>ἔπειτ’ ἀκούουσ’ ἐξέμαθον τῶν ῥητόρων.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="245">οὐκ ἐτὸς ἄρ’ ὦ μέλ’ ἦσθα δεινὴ καὶ σοφή·</l>
 					<l>καί σε στρατηγεῖν αἱ γυναῖκες αὐτόθεν</l>
@@ -693,67 +693,67 @@ convert to p3
 					<l>ἀτὰρ ἢν Κέφαλός σοι λοιδορῆται προσφθαρείς,</l>
 					<l>πῶς ἀντερεῖς πρὸς αὐτὸν ἐν τἠκκλησίᾳ;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l n="250">φήσω παραφρονεῖν αὐτόν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">ἀλλὰ τοῦτό γε</l>
 					<l>ἴσασι πάντες.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">ἀλλὰ καὶ μελαγχολᾶν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>καὶ τοῦτ’ ἴσασιν.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">ἀλλὰ καὶ τὰ τρύβλια</l>
 					<l>κακῶς κεραμεύειν, τὴν δὲ πόλιν εὖ καὶ καλῶς.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>τί δ’ ἢν Νεοκλείδης ὁ γλάμων σε λοιδορῇ;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l n="255">τούτῳ μὲν εἶπον ἐς κυνὸς πυγὴν ὁρᾶν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>τί δ’ ἢν ὑποκρούωσίν σε;</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">προσκινήσομαι</l>
 					<l>ἅτ’ οὐκ ἄπειρος οὖσα πολλῶν κρουμάτων.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἐκεῖνο μόνον ἄσκεπτον, ἤν σ’ οἱ τοξόται</l>
 					<l>ἕλκωσιν, ὅ τι δράσεις ποτ’.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">ἐξαγκωνιῶ</l>
 					<l n="260">ὡδί· μέση γὰρ οὐδέποτε ληφθήσομαι.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>ἡμεῖς δέ γ’, ἢν αἴρωσ’, ἐᾶν κελεύσομεν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ταυτὶ μὲν ἡμῖν ἐντεθύμηται καλῶς</l>
 					<l>ἐκεῖνο δ’ οὐ πεφροντίκαμεν, ὅτῳ τρόπῳ</l>
 					<l>τὰς χεῖρας αἴρειν μνημονεύσομεν τότε.</l>
 					<l n="265">εἰθισμέναι γάρ ἐσμεν αἴρειν τὼ σκέλει.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>χαλεπὸν τὸ πρᾶγμ’· ὅμως δὲ χειροτονητέον</l>
 					<l>ἐξωμισάσαις τὸν ἕτερον βραχίονα.</l>
@@ -770,14 +770,14 @@ convert to p3
 					<l>πρεσβυτικόν τι, τὸν τρόπον μιμούμεναι</l>
 					<l>τὸν τῶν ἀγροίκων.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l part="Y">εὖ λέγεις· ἡμεῖς δέ γε</l>
 					<l n="280">προΐωμεν αὐτῶν. καὶ γὰρ ἑτέρας οἴομαι</l>
 					<l>ἐκ τῶν ἀγρῶν ἐς τὴν πύκν’ ἥξειν ἄντικρυς</l>
 					<l>γυναῖκας.</l>
 				</sp>
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l part="Y">ἀλλὰ σπεύσαθ’ ὡς εἴωθ’ ἐκεῖ</l>
 					<l>τοῖς μὴ παροῦσιν ὀρθρίοις ἐς τὴν πύκνα</l>
@@ -785,7 +785,7 @@ convert to p3
 				</sp>
 			</div1>
 			<div1 type="Exodus">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορὸς</speaker>
 					<l n="285">ὥρα προβαίνειν ὦνδρες ἡμῖν ἐστι· τοῦτο γὰρ χρὴ</l>
 					<l>μεμνημένας ἀεὶ λέγειν, ὡς μήποτ’ ἐξολίσθῃ</l>
@@ -794,7 +794,7 @@ convert to p3
 					<milestone ed="p" n="289" unit="card"/>
 				</sp>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χωρῶμεν εἰς ἐκκλησίαν ὦνδρες· ἠπείλησε γὰρ</l>
 						<l n="290">ὁ θεσμοθέτης, ὃς ἂν</l>
@@ -821,7 +821,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="300">ὅρα δ’ ὅπως ὠθήσομεν τούσδε τοὺς ἐξ ἄστεως</l>
 						<l n="300b">ἥκοντας, ὅσοι πρὸ τοῦ</l>
@@ -965,7 +965,7 @@ convert to p3
 					<l n="370">διαρραγέντα μηδὲ βεβαλανωμένον,</l>
 					<l>ἵνα μὴ γένωμαι σκωραμὶς κωμῳδική.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>οὗτος τί ποιεῖς; οὔτι που χέζεις;</l>
 				</sp>
@@ -974,7 +974,7 @@ convert to p3
 					<l part="Y">ἐγώ;</l>
 					<l>οὐ δῆτ’ ἔτι γε μὰ τὸν Δί’, ἀλλ’ ἀνίσταμαι.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>τὸ τῆς γυναικὸς δ’ ἀμπέχει χιτώνιον;</l>
 				</sp>
@@ -983,7 +983,7 @@ convert to p3
 					<l n="375">ἐν τῷ σκότῳ γὰρ τοῦτ’ ἔτυχον ἔνδον λαβών.</l>
 					<l>ἀτὰρ πόθεν ἥκεις ἐτεόν;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">ἐξ ἐκκλησίας.</l>
 				</sp>
@@ -991,7 +991,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>ἤδη λέλυται γάρ;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">νὴ Δί’ ὄρθριον μὲν οὖν.</l>
 					<l>καὶ δῆτα πολὺν ἡ μίλτος ὦ Ζεῦ φίλτατε</l>
@@ -1001,7 +1001,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l n="380">τὸ τριώβολον δῆτ’ ἔλαβες;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">εἰ γὰρ ὤφελον.</l>
 					<l>ἀλλ’ ὕστερος νῦν ἦλθον, ὥστ’ αἰσχύνομαι</l>
@@ -1011,7 +1011,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>τὸ δ’ αἴτιον τί;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">πλεῖστος ἀνθρώπων ὄχλος,</l>
 					<l>ὅσος οὐδεπώποτ’ ἦλθ’ ἁθρόος ἐς τὴν πύκνα.</l>
@@ -1025,7 +1025,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>οὐδ’ ἄρ’ ἂν ἐγὼ λάβοιμι νῦν ἐλθών;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">πόθεν;</l>
 					<l n="390">οὐδ’ εἰ μὰ Δία τότ’ ἦλθες ὅτε τὸ δεύτερον</l>
@@ -1039,7 +1039,7 @@ convert to p3
 					<l>ἀτὰρ τί τὸ πρᾶγμ’ ἦν, ὅτι τοσοῦτον χρῆμ’ ὄχλου</l>
 					<l n="395">οὕτως ἐν ὥρᾳ ξυνελέγη;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">τί δ’ ἄλλο γ’ ἢ</l>
 					<l>ἔδοξε τοῖς πρυτάνεσι περὶ σωτηρίας</l>
@@ -1059,7 +1059,7 @@ convert to p3
 					<l>σαυτοῦ παραλείφειν τὰ βλέφαρα τῆς ἑσπέρας,’</l>
 					<l>ἔγωγ’ ἂν εἶπον, εἰ παρὼν ἐτύγχανον.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>μετὰ τοῦτον Εὐαίων ὁ δεξιώτατος</l>
 					<l>παρῆλθε γυμνός, ὡς ἐδόκει τοῖς πλείοσιν·</l>
@@ -1084,7 +1084,7 @@ convert to p3
 					<l n="425">δεῖπνον παρέχειν ἅπασιν ἢ κλάειν μακρά,</l>
 					<l>ἵνα τοῦτ’ ἀπέλαυσαν Ναυσικύδους τἀγαθόν.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>μετὰ τοῦτο τοίνυν εὐπρεπὴς νεανίας</l>
 					<l>λευκός τις ἀνεπήδησ’ ὅμοιος Νικίᾳ</l>
@@ -1099,7 +1099,7 @@ convert to p3
 					<l part="Y">νοῦν γὰρ εἶχον νὴ Δία.</l>
 					<milestone ed="p" n="434" unit="card"/>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>ἀλλ’ ἦσαν ἥττους· ὁ δὲ κατεῖχε τῇ βοῇ,</l>
 					<l n="435">τὰς μὲν γυναῖκας πόλλ’ ἀγαθὰ λέγων, σὲ δὲ</l>
@@ -1109,7 +1109,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l part="Y">καὶ τί εἶπε;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">πρῶτον μέν σ’ ἔφη</l>
 					<l>εἶναι πανοῦργον.</l>
@@ -1118,7 +1118,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l part="Y">καὶ σέ;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">μή πω τοῦτ’ ἔρῃ.</l>
 					<l>κἄπειτα κλέπτην.</l>
@@ -1127,7 +1127,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l part="Y">ἐμὲ μόνον;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">καὶ νὴ Δία</l>
 					<l>καὶ συκοφάντην.</l>
@@ -1136,7 +1136,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l part="Y">ἐμὲ μόνον;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">καὶ νὴ Δία</l>
 					<l n="440">τωνδὶ τὸ πλῆθος.</l>
@@ -1145,7 +1145,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l part="Y">τίς δὲ τοῦτ’ ἄλλως λέγει;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορὸς</speaker>
 					<l>γυναῖκα δ’ εἶναι πρᾶγμ’ ἔφη νουβυστικὸν</l>
 					<l>καὶ χρηματοποιόν· κοὔτε τἀπόρρητ’ ἔφη</l>
@@ -1156,7 +1156,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l n="445">καὶ νὴ τὸν Ἑρμῆν τοῦτό γ’ οὐκ ἐψεύσατο.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>ἔπειτα συμβάλλειν πρὸς ἀλλήλας ἔφη</l>
 					<l>ἱμάτια χρυσί’ ἀργύριον ἐκπώματα</l>
@@ -1168,7 +1168,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>νὴ τὸν Ποσειδῶ μαρτύρων γ’ ἐναντίον.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>οὐ συκοφαντεῖν, οὐ διώκειν, οὐδὲ τὸν</l>
 					<l>δῆμον καταλύειν, ἀλλὰ πολλὰ κἀγαθά,</l>
@@ -1178,7 +1178,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l n="455">τί δῆτ’ ἔδοξεν;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">ἐπιτρέπειν γε τὴν πόλιν</l>
 					<l>ταύταις. ἐδόκει γὰρ τοῦτο μόνον ἐν τῇ πόλει</l>
@@ -1188,7 +1188,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l part="Y">καὶ δέδοκται;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">φήμ’ ἐγώ.</l>
 				</sp>
@@ -1197,7 +1197,7 @@ convert to p3
 					<l>ἅπαντά τ’ αὐταῖς ἐστι προστεταγμένα</l>
 					<l>ἃ τοῖσιν ἀστοῖς ἔμελεν;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">οὕτω ταῦτ’ ἔχει.</l>
 				</sp>
@@ -1205,7 +1205,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l n="460">οὐδ’ ἐς δικαστήριον ἄρ’ εἶμ’ ἀλλ’ ἡ γυνή;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>οὐδ’ ἔτι σὺ θρέψεις οὓς ἔχεις ἀλλ’ ἡ γυνή.</l>
 				</sp>
@@ -1213,7 +1213,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>οὐδὲ στένειν τὸν ὄρθρον ἔτι πρᾶγμ’ ἆρά μοι;</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>μὰ Δί’ ἀλλὰ ταῖς γυναιξὶ ταῦτ’ ἤδη μέλει·</l>
 					<l>σὺ δ’ ἀστενακτὶ περδόμενος οἴκοι μενεῖς.</l>
@@ -1224,7 +1224,7 @@ convert to p3
 					<l>μὴ παραλαβοῦσαι τῆς πόλεως τὰς ἡνίας</l>
 					<l>ἔπειτ’ ἀναγκάζωσι πρὸς βίαν—</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">τί δρᾶν;</l>
 				</sp>
@@ -1232,7 +1232,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>κινεῖν ἑαυτάς.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">ἢν δὲ μὴ δυνώμεθα;</l>
 				</sp>
@@ -1240,7 +1240,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>ἄριστον οὐ δώσουσι.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">σὺ δέ γε νὴ Δία</l>
 					<l n="470">δρᾶ ταῦθ’, ἵν’ ἀριστᾷς τε καὶ κινῇς ἅμα.</l>
@@ -1249,7 +1249,7 @@ convert to p3
 					<speaker>Βλέπυρος</speaker>
 					<l>τὸ πρὸς βίαν δεινότατον.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l part="Y">ἀλλ’ εἰ τῇ πόλει</l>
 					<l>τοῦτο ξυνοίσει, ταῦτα χρὴ πάντ’ ἄνδρα δρᾶν.</l>
@@ -1260,7 +1260,7 @@ convert to p3
 					<l>ἀνόηθ’ ὅσ’ ἂν καὶ μῶρα βουλευσώμεθα,</l>
 					<l n="475">ἅπαντ’ ἐπὶ τὸ βέλτιον ἡμῖν ξυμφέρειν.</l>
 				</sp>
-				<sp who="#xremes">
+				<sp who="#chremes">
 					<speaker>Χρέμης</speaker>
 					<l>καὶ ξυμφέροι γ’ ὦ πότνια Παλλὰς καὶ θεοί.</l>
 					<l>ἀλλ’ εἶμι· σὺ δ’ ὑγίαινε.</l>
@@ -1273,7 +1273,7 @@ convert to p3
 			</div1>
 			<div1 type="Parodos">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l>ἔμβα χώρει.</l>
 						<l>ἆρ’ ἔστι τῶν ἀνδρῶν τις ἡμῖν ὅστις ἐπακολουθεῖ;</l>
@@ -1284,7 +1284,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l>ἀλλ’ ὡς μάλιστα τοῖν ποδοῖν ἐπικτυπῶν βάδιζε·</l>
 						<l>ἡμῖν δ’ ἂν αἰσχύνην φέροι</l>
@@ -1301,7 +1301,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l>ὥστ’ εἰκὸς ἡμᾶς μὴ βραδύνειν ἔστ’ ἐπαναμενούσας</l>
 						<l>πώγωνας ἐξηρτημένας,</l>
@@ -1319,7 +1319,7 @@ convert to p3
 				</div2>
 			</div1>
 			<div1 type="Choral">
-				<sp who="#praksagora">
+				<sp who="#praxagora">
 					<speaker>Πραξάγορα</speaker>
 					<l>ταυτὶ μὲν ἡμῖν ὦ γυναῖκες εὐτυχῶς</l>
 					<l n="505">τὰ πράγματ’ ἐκβέβηκεν ἁβουλεύσαμεν.</l>
@@ -1333,13 +1333,13 @@ convert to p3
 					<l>ὅθενπερ ἔλαβον τἄλλα θ’ ἁξηνεγκάμην.</l>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l>κεῖται &lt;καὶ&gt; δὴ πάνθ’ ἅπερ εἶπας, σὸν δ’ ἔργον τἄλλα διδάσκειν,</l>
 						<l n="515">ὅ τί σοι δρῶσαι ξύμφορον ἡμεῖς δόξομεν ὀρθῶς ὑπακούειν.</l>
 						<l>οὐδεμιᾷ γὰρ δεινοτέρᾳ σου ξυμμείξασ’ οἶδα γυναικί.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>περιμείνατέ νυν, ἵνα τῆς ἀρχῆς ἣν ἄρτι κεχιεροτόνημαι,</l>
 						<l>ξυμβούλοισιν πάσαις ὑμῖν χρήσωμαι. καὶ γὰρ ἐκεῖ μοι</l>
@@ -1351,7 +1351,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l n="520">αὕτη πόθεν ἥκεις Πραξαγόρα;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">τί δ’ ὦ μέλε</l>
 						<l>σοὶ τοῦθ’;</l>
@@ -1360,7 +1360,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">ὅ τί μοι τοῦτ’ ἔστιν; ὡς εὐηθικῶς.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>οὔτοι παρὰ τοῦ μοιχοῦ γε φήσεις.</l>
 					</sp>
@@ -1369,7 +1369,7 @@ convert to p3
 						<l part="Y">οὐκ ἴσως</l>
 						<l>ἑνός γε.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">καὶ μὴν βασανίσαι τουτί γέ σοι</l>
 						<l>ἔξεστι.</l>
@@ -1378,7 +1378,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">πῶς;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">εἰ τῆς κεφαλῆς ὄζω μύρου.</l>
 					</sp>
@@ -1386,7 +1386,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l n="525">τί δ’; οὐχὶ βινεῖται γυνὴ κἄνευ μύρου;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>οὐ δῆτα τάλαν ἔγωγε.</l>
 					</sp>
@@ -1395,7 +1395,7 @@ convert to p3
 						<l part="Y">πῶς οὖν ὄρθριον</l>
 						<l>ᾤχου σιωπῇ θοἰμάτιον λαβοῦσά μου;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>γυνή μέ τις νύκτωρ ἑταίρα καὶ φίλη</l>
 						<l>μετεπέμψατ’ ὠδίνουσα.</l>
@@ -1405,7 +1405,7 @@ convert to p3
 						<l part="Y">κᾆτ’ οὐκ ἦν ἐμοὶ</l>
 						<l n="530">φράσασαν ἰέναι;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">τῆς λεχοῦς δ’ οὐ φροντίσαι</l>
 						<l>οὕτως ἐχούσης ὦνερ;</l>
@@ -1415,7 +1415,7 @@ convert to p3
 						<l part="Y">εἰποῦσάν γέ μοι.</l>
 						<l>ἀλλ’ ἔστιν ἐνταῦθά τι κακόν.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">μὰ τὼ θεὼ</l>
 						<l>ἀλλ’ ὥσπερ εἶχον ᾠχόμην· ἐδεῖτο δὲ</l>
@@ -1431,7 +1431,7 @@ convert to p3
 						<l>ᾤχου καταλιποῦσ’ ὡσπερεὶ προκείμενον,</l>
 						<l>μόνον οὐ στεφανώσασ’ οὐδ’ ἐπιθεῖσα λήκυθον.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ψῦχος γὰρ ἦν, ἐγὼ δὲ λεπτὴ κἀσθενής·</l>
 						<l n="540">ἔπειθ’ ἵν’ ἀλεαίνοιμι, τοῦτ’ ἠμπεσχόμην·</l>
@@ -1443,7 +1443,7 @@ convert to p3
 						<l part="Y">αἱ δὲ δὴ Λακωνικαὶ</l>
 						<l>ᾤχοντο μετὰ σοῦ κατὰ τί χἠ βακτηρία;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ἵνα θοἰμάτιον σώσαιμι, μεθυπεδησάμην</l>
 						<l n="545">μιμουμένη σε καὶ κτυποῦσα τοῖν ποδοῖν</l>
@@ -1454,7 +1454,7 @@ convert to p3
 						<l>οἶσθ’ οὖν ἀπολωλεκυῖα πυρῶν ἑκτέα,</l>
 						<l>ὃν χρῆν ἔμ’ ἐξ ἐκκλησίας εἰληφέναι;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>μὴ φροντίσῃς· ἄρρεν γὰρ ἔτεκε παιδίον.</l>
 					</sp>
@@ -1462,7 +1462,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l n="550">ἡκκλησία;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">μὰ Δί’ ἀλλ’ ἐφ’ ἣν ἐγᾠχόμην.</l>
 						<l>ἀτὰρ γεγένηται;</l>
@@ -1472,7 +1472,7 @@ convert to p3
 						<l>ναὶ μὰ Δί’.  οὐκ ᾔδησθά με</l>
 						<l>φράσαντά σοι χθές;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">ἄρτι γ’ ἀναμιμνῄσκομαι.</l>
 					</sp>
@@ -1480,7 +1480,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>οὐδ’ ἄρα τὰ δόξαντ’ οἶσθα;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">μὰ Δί ἐγὼ μὲν οὔ.</l>
 					</sp>
@@ -1489,7 +1489,7 @@ convert to p3
 						<l>κάθησο τοίνυν σηπίας μασωμένη.</l>
 						<l n="555">ὑμῖν δέ φασι παραδεδόσθαι τὴν πόλιν.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>τί δρᾶν; ὑφαίνειν;</l>
 					</sp>
@@ -1497,7 +1497,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">οὐ μὰ Δί’ ἀλλ’ ἄρχειν.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">τίνων;</l>
 					</sp>
@@ -1505,7 +1505,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>ἁπαξαπάντων τῶν κατὰ πόλιν πραγμάτων.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>νὴ τὴν Ἀφροδίτην μακαρία γ’ ἄρ ἡ πόλις</l>
 						<l>ἔσται τὸ λοιπόν.</l>
@@ -1514,7 +1514,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">κατὰ τί;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">πολλῶν οὕνεκα.</l>
 						<l n="560">οὐ γὰρ ἔτι τοῖς τολμῶσιν αὐτὴν αἰσχρὰ δρᾶν</l>
@@ -1530,7 +1530,7 @@ convert to p3
 						<speaker>Ἀνήρ</speaker>
 						<l>ὦ δαιμόνῑ ἀνδρῶν τὴν γυναῖκ’ ἔα λέγειν.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l n="565">μὴ λωποδυτῆσαι, μὴ φθονεῖν τοῖς πλησίον,</l>
 						<l>μὴ γυμνὸν εἶναι μὴ πένητα μηδένα,</l>
@@ -1540,7 +1540,7 @@ convert to p3
 						<speaker>Ἀνήρ</speaker>
 						<l>νὴ τὸν Ποσειδῶ μεγάλα γ’, εἰ μὴ ψεύσεται.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ἀλλ’ ἀποφανῶ τοῦθ’, ὥστε σέ τέ μοι μαρτυρεῖν</l>
 						<l n="570">καὶ τοῦτον αὐτὸν μηδὲν ἀντειπεῖν ἐμοι.</l>
@@ -1550,7 +1550,7 @@ convert to p3
 			</div1>
 			<div1 type="Agon">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l>νῦν δὴ δεῖ σε πυκνὴν φρένα καὶ φιλόσοφον ἐγείρειν</l>
 						<l>φροντίδ’ ἐπισταμένην</l>
@@ -1568,7 +1568,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l>ἀλλ’ οὐ μέλλειν, ἀλλ’ ἅπτεσθαι καὶ δὴ χρῆν ταῖς διανοίαις,</l>
 						<l>ὡς τὸ ταχύνειν χαρίτων μετέχει πλεῖστον παρὰ τοῖσι θεαταῖς.</l>
@@ -1576,7 +1576,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="epirrheme">
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>καὶ μὴν ὅτι μὲν χρηστὰ διδάξω πιστεύω· τοὺς δὲ θεατάς,</l>
 						<l>εἰ καινοτομεῖν ἐθελήσουσιν καὶ μὴ τοῖς ἠθάσι λίαν</l>
@@ -1587,7 +1587,7 @@ convert to p3
 						<l>περὶ μὲν τοίνυν τοῦ καινοτομεῖν μὴ δείσῃς· τοῦτο γὰρ ἡμῖν</l>
 						<l>δρᾶν ἀντ’ ἄλλης ἀρχῆς ἐστιν, τῶν δ’ ἀρχαίων ἀμελῆσαι.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>μή νυν πρότερον μηδεὶς ὑμῶν ἀντείπῃ μηδ’ ὑποκρούσῃ,</l>
 						<l>πρὶν ἐπίστασθαι τὴν ἐπίνοιαν καὶ τοῦ φράζοντος ἀκοῦσαι.</l>
@@ -1601,7 +1601,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l n="595">πῶς οὖν ἔσται κοινὸς ἅπασιν;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">κατέδει πέλεθον πρότερός μου.</l>
 					</sp>
@@ -1609,7 +1609,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>καὶ τῶν πελέθων κοινωνοῦμεν;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">μὰ Δί’ ἀλλ’ ἔφθης μ’ ὑποκρούσας.</l>
 						<l>τοῦτο γὰρ ἤμελλον ἐγὼ λέξειν· τὴν γῆν πρώτιστα ποιήσω</l>
@@ -1622,7 +1622,7 @@ convert to p3
 						<l>πῶς οὖν ὅστις μὴ κέκτηται γῆν ἡμῶν, ἀργύριον δὲ</l>
 						<l>καὶ Δαρεικοὺς ἀφανῆ πλοῦτον;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">τοῦτ’ ἐς τὸ μέσον καταθήσει.</l>
 						<l>καὶ μὴ καταθεὶς ψευδορκήσει.</l>
@@ -1632,7 +1632,7 @@ convert to p3
 						<l part="Y">κἀκτήσατο γὰρ διὰ τοῦτο.</l>
 						<milestone ed="p" n="604" unit="card"/>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ἀλλ’ οὐδέν τοι χρήσιμον ἔσται πάντως αὐτῷ.</l>
 					</sp>
@@ -1640,7 +1640,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">κατὰ δὴ τί;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l n="605">οὐδεὶς οὐδὲν πενίᾳ δράσει· πάντα γὰρ ἕξουσιν ἅπαντες,</l>
 						<l>ἄρτους τεμάχη μάζας χλαίνας οἶνον στεφάνους ἐρεβίνθους.</l>
@@ -1650,7 +1650,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>οὔκουν καὶ νῦν οὗτοι μᾶλλον κλέπτουσ’ οἷς ταῦτα πάρεστιν;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>πρότερόν γ’ ὦταῖρ’ ὅτε τοῖσι νόμοις διεχρώμεθα τοῖς προτέροισιν·</l>
 						<l n="610">νῦν δ’ ἔσται γὰρ βίος ἐκ κοινοῦ, τί τὸ κέρδος μὴ καταθεῖναι;</l>
@@ -1661,7 +1661,7 @@ convert to p3
 						<l>ἕξει τούτων ἀφελὼν δοῦναι, τῶν ἐκ κοινοῦ δὲ μεθέξει</l>
 						<l>ξυγκαταδαρθών.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">ἀλλ’ ἐξέσται προῖκ’ αὐτῷ ξυγκαταδαρθεῖν.</l>
 						<l>καὶ ταύτας γὰρ κοινὰς ποιῶ τοῖς ἀνδράσι συγκατακεῖσθαι</l>
@@ -1672,7 +1672,7 @@ convert to p3
 						<l part="Y">πῶς οὖν οὐ πάντες ἴασιν</l>
 						<l>ἐπὶ τὴν ὡραιοτάτην αὐτῶν καὶ ζητήσουσιν ἐρείδειν;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>αἱ φαυλότεραι καὶ σιμότεραι παρὰ τὰς σεμνὰς καθεδοῦνται·</l>
 						<l>κᾆτ’ ἢν ταύτης ἐπιθυμήσῃ, τὴν αἰσχρὰν πρῶθ’ ὑποκρούσει.</l>
@@ -1682,7 +1682,7 @@ convert to p3
 						<l>καὶ πῶς ἡμᾶς τοὺς πρεσβύτας, ἢν ταῖς αἰσχραῖσι συνῶμεν,</l>
 						<l n="620">οὐκ ἐπιλείψει τὸ πέος πρότερον πρὶν ἐκεῖσ’ οἷ φὴ|ς ἀφικέσθαι;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>οὐχὶ μαχοῦνται· περὶ σοῦ θάρρει· μὴ δείσῃς· οὐχὶ μαχοῦνται.</l>
 					</sp>
@@ -1690,7 +1690,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>περὶ τοῦ;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">τοῦ μὴ ξυγκαταδαρθεῖν. καὶ σοὶ τοιοῦτον ὑπάρχει.</l>
 					</sp>
@@ -1700,7 +1700,7 @@ convert to p3
 						<l>μηδεμιᾶς ᾖ τρύπημα κενόν· τὸ δὲ τῶν ἀνδρῶν τί ποιήσει;</l>
 						<l n="625">φεύξονται γὰρ τοὺς αἰσχίους, ἐπὶ τοὺς δὲ καλοὺς βαδιοῦνται.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ἀλλὰ φυλάξουσ’ οἱ φαυλότεροι τοὺς καλλίους ἀπιόντας</l>
 						<l>ἀπὸ τοῦ δείπνου καὶ τηρήσουσ’ ἐπὶ τοῖσιν δημοσίοισιν·</l>
@@ -1711,7 +1711,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l n="630">ἡ Λυσικράτους ἄρα νυνὶ ῥὶς ἴσα τοῖσι καλοῖσι φρονήσει.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>νὴ τὸν Ἀπόλλω καὶ δημοτική γ’ ἡ γνώμη καὶ καταχήνη</l>
 						<l>τῶν σεμνοτέρων ἔσται πολλὴ καὶ τῶν σφραγῖδας ἐχόντων,</l>
@@ -1724,7 +1724,7 @@ convert to p3
 						<l n="635">πῶς οὖν οὕτω ζώντων ἡμῶν τοὺς αὑτοῦ παῖδας ἕκαστος</l>
 						<l>ἔσται δυνατὸς διαγιγνώσκειν;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">τί δὲ δεῖ; πατέρας &lt;γὰρ&gt; ἅπαντας</l>
 						<l>τοὺς πρεσβυτέρους αὑτῶν εἶναι τοῖσι χρόνοισιν νομιοῦσιν.</l>
@@ -1735,7 +1735,7 @@ convert to p3
 						<l>διὰ τὴν ἄγνοιαν, ἐπεὶ καὶ νῦν γιγνώσκοντες πατέρ’ ὄντα</l>
 						<l n="640">ἄγχουσι. τί δῆθ’ ὅταν ἀγνὼς ᾖ; πῶς οὐ τότε κἀπιχεσοῦνται;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ἀλλ’ ὁ παρεστὼς οὐκ ἐπιτρέψει· τότε δ’ αὐτοῖς οὐκ ἔμελ’ οὐδὲν</l>
 						<l>τῶν ἀλλοτρίων ὅστις τύπτοι· νῦν δ’ ἢν πληγέντος ἀκούσῃ,</l>
@@ -1746,7 +1746,7 @@ convert to p3
 						<l>τὰ μὲν ἄλλα λέγεις οὐδὲν σκαιῶς· εἰ δὲ προσελθὼν Ἐπίκουρος</l>
 						<l n="645">ἢ Λευκολόφας πάππαν με καλεῖ, τοῦτ’ ἤδη δεινὸν ἀκοῦσαι.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>πολὺ μέντοι δεινότερον τούτου τοῦ πράγματός ἐστι,</l>
 					</sp>
@@ -1754,7 +1754,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">τὸ ποῖον;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>εἴ σε φιλήσειεν Ἀρίστυλλος φάσκων αὑτοῦ πατέρ’ εἶναι.</l>
 					</sp>
@@ -1762,7 +1762,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>οἰμώζοι γ’ ἂν καὶ κωκύοι.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">σὺ δέ γ’ ὄζοις ἂν καλαμίνθης,</l>
 						<l>ἀλλ’ οὗτος μὲν πρότερον γέγονεν πρὶν τὸ ψήφισμα γενέσθαι,</l>
@@ -1773,7 +1773,7 @@ convert to p3
 						<l part="Y">δεινὸν μέντἂν ἐπεπόνθη.</l>
 						<l>τὴν γῆν δὲ τίς ἔσθ’ ὁ γεωργήσων;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">οἱ δοῦλοι. σοὶ δὲ μελήσει,</l>
 						<l>ὅταν ᾖ δεκάπουν τὸ στοιχεῖον, λιπαρὸν χωρεῖν ἐπὶ δεῖπνον.</l>
@@ -1782,7 +1782,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>περὶ δ’ ἱματίων τίς πόρος ἔσται; καὶ γὰρ τοῦτ’ ἔστιν ἐρέσθαι.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>τὰ μὲν ὄνθ’ ὑμῖν πρῶτον ὑπάρξει, τὰ δὲ λοίφ’ ἡμεῖς ὑφανοῦμεν.</l>
 					</sp>
@@ -1791,7 +1791,7 @@ convert to p3
 						<l n="655">ἓν ἔτι ζητῶ· πῶς ἤν τις ὄφλῃ παρὰ τοῖς ἄρχουσι δίκην τῳ,</l>
 						<l>πόθεν ἐκτείσει ταύτην; οὐ γὰρ τῶν κοινῶν γ’ ἐστὶ δίκαιον.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ἀλλ’ οὐδὲ δίκαι πρῶτον ἔσονται.</l>
 					</sp>
@@ -1799,7 +1799,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">τουτὶ τοὔπος σ’ ἐπιτρίψει.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>κἀγὼ ταύτην γνώμην ἐθέμην· τοῦ γὰρ τάλαν οὕνεκ’ ἔσονται;</l>
 					</sp>
@@ -1808,7 +1808,7 @@ convert to p3
 						<l>πολλῶν οὕνεκα νὴ τὸν Ἀπόλλω· πρῶτον δ’ ἑνὸς οὕνεκα δήπου,</l>
 						<l n="660">ἤν τις ὀφείλων ἐξαρνῆται.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">πόθεν οὖν ἐδάνεισ’ ὁ δανείσας</l>
 						<l>ἐν τῷ κοινῷ πάντων ὄντων; κλέπτων δήποῡ στ’ ἐπίδηλος.</l>
@@ -1819,7 +1819,7 @@ convert to p3
 						<l>τῆς αἰκείας οἱ τύπτοντες πόθεν ἐκτείσουσιν, ἐπειδὰν</l>
 						<l>εὐωχηθέντες ὑβρίζωσιν; τοῦτο γὰρ οἶμαί σ’ ἀπορήσειν.</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l n="665">ἀπὸ τῆς μάζης ἧς σιτεῖται· ταύτης γὰρ ὅταν τις ἀφαιρῇ,</l>
 						<l>οὐχ ὑβριεῖται φαύλως οὕτως αὖθις τῇ γαστρὶ κολασθείς.</l>
@@ -1829,7 +1829,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>οὐδ’ αὖ κλέπτης οὐδεὶς ἔσται;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">πῶς γὰρ κλέψει μετὸν αὐτῷ;</l>
 					</sp>
@@ -1837,7 +1837,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>οὐδ’ ἀποδύσουσ’ ἄρα τῶν νυκτῶν;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">οὐκ ἢν οἴκοι γε καθεύδῃς,</l>
 						<l>οὐδ’ ἤν γε θύραζ’ ὥσπερ πρότερον· βίοτος γὰρ πᾶσιν ὑπάρξει.</l>
@@ -1848,7 +1848,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>οὐδὲ κυβεύσουσ’ ἆρ’ ἄνθρωποι;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">περὶ τοῦ γὰρ τοῦτο ποιήσει;</l>
 					</sp>
@@ -1856,7 +1856,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>τὴν δὲ δίαιταν τίνα ποιήσεις;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">κοινὴν πᾶσιν. τὸ γὰρ ἄστυ</l>
 						<l>μίαν οἴκησίν φημι ποιήσειν συρρήξασ’ εἰς ἓν ἅπαντα,</l>
@@ -1866,7 +1866,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">τὸ δὲ δεῖπνον ποῦ παραθήσεις;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>τὰ δικαστήρια καὶ τὰς στοιὰς ἀνδρῶνας πάντα ποιήσω.</l>
 					</sp>
@@ -1874,7 +1874,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>τὸ δὲ βῆμα τί σοι χρήσιμον ἔσται;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">τοὺς κρατῆρας καταθήσω</l>
 						<l>καὶ τὰς ὑδρίας, καὶ ῥαψῳδεῖν ἔσται τοῖς παιδαρίοισιν</l>
@@ -1886,7 +1886,7 @@ convert to p3
 						<l part="Y">νὴ τὸν Ἀπόλλω χάριέν γε.</l>
 						<l>τὰ δὲ κληρωτήρια ποῖ τρέψεις;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">εἰς τὴν ἀγορὰν καταθήσω·</l>
 						<l>κᾆτα στήσασα παρ’ Ἁρμοδίῳ κληρώσω πάντας, ἕως ἂν</l>
@@ -1899,7 +1899,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>ἵνα κάπτωσιν;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">μὰ Δί’ ἀλλ’ ἵν’ ἐκεῖ δειπνῶσιν.</l>
 					</sp>
@@ -1910,7 +1910,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 met="anapets" type="pnigos">
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>ἀλλ’ οὐκ ἔσται τοῦτο παρ’ ἡμῖν·</l>
 						<l n="690">πᾶσι γὰρ ἄφθονα πάντα παρέξομεν,</l>
@@ -1943,7 +1943,7 @@ convert to p3
 						<l part="Y">πάνυ.</l>
 						<milestone ed="p" n="711" unit="card"/>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l>βαδιστέον τἄρ’ ἐστὶν εἰς ἀγορὰν ἐμοί,</l>
 						<l>ἵν’ ἀποδέχωμαι τὰ προσιόντα χρήματα,</l>
@@ -1956,7 +1956,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l>ἤδη γὰρ εὐωχησόμεσθα;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">φήμ’ ἐγώ.</l>
 						<l>ἔπειτα τὰς πόρνας καταπαῦσαι βούλομαι</l>
@@ -1966,7 +1966,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">ἵνα τί;</l>
 					</sp>
-					<sp who="#praksagora">
+					<sp who="#praxagora">
 						<speaker>Πραξάγορα</speaker>
 						<l part="Y">δῆλον τουτογί·</l>
 						<l n="720">ἵνα τῶν νέων ἔχωσιν αὗται τὰς ἀκμάς.</l>
@@ -1981,7 +1981,7 @@ convert to p3
 						<l>ἵν’ ἀποβλέπωμαι καὶ λέγωσί μοι ταδί,</l>
 						<l>τὸν τῆς στρατηγοῦ τοῦτον οὐ θαυμάζετε;</l>
 					</sp>
-					<sp who="#anera">
+					<sp who="#aner_a">
 						<speaker>Ἀνὴρ Α</speaker>
 						<l>ἐγὼ δ’ ἵν’ εἰς ἀγοράν γε τὰ σκεύη φέρω,</l>
 						<l>προχειριοῦμαι κἀξετάσω τὴν οὐσίαν.</l>
@@ -1990,7 +1990,7 @@ convert to p3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="730">χώρει σὺ δεῦρο κιναχύρα καλὴ καλῶς</l>
 					<l>τῶν χρημάτων θύραζε πρώτη τῶν ἐμῶν,</l>
@@ -2010,7 +2010,7 @@ convert to p3
 					<l n="745">τὰ χυτρίδῑ ἤδη καὶ τὸν ὄχλον ἀφίετε.</l>
 					<milestone ed="p" n="746" unit="card"/>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ἐγὼ καταθήσω τἀμά; κακοδαίμων ἄρα</l>
 					<l>ἀνὴρ ἔσομαι καὶ νοῦν ὀλίγον κεκτημένος.</l>
@@ -2023,130 +2023,130 @@ convert to p3
 					<l>πότερον μετοικιζόμενος ἐξενήνοχας</l>
 					<l n="755">αὔτ’ ἢ φέρεις ἐνέχυρα θήσων;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">οὐδαμῶς.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>τί δῆτ’ ἐπὶ στοίχου ’στὶν οὕτως; οὔτι μὴ</l>
 					<l>Ἱέρωνι τῷ κήρυκι πομπὴν πέμπετε;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>μὰ Δί’ ἀλλ’ ἀποφέρειν αὐτὰ μέλλω τῇ πόλει</l>
 					<l>ἐς τὴν ἀγορὰν κατὰ τοὺς δεδογμένους νόμους.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l n="760">μέλλεις ἀποφέρειν;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">πάνυ γε.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">κακοδαίμων ἄρ’ εἶ</l>
 					<l>νὴ τὸν Δία τὸν σωτῆρα.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">πῶς;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">πῶς; ῥᾳδίως.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>τί δ’; οὐχὶ πειθαρχεῖν με τοῖς νόμοισι δεῖ;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ποίοισιν ὦ δύστηνε;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">τοῖς δεδογμένοις.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>δεδογμένοισιν; ὡς ἀνόητος ἦσθ’ ἄρα.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="765">ἀνόητος;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">οὐ γάρ; ἠλιθιώτατος μὲν οὖν</l>
 					<l>ἁπαξαπάντων.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">ὅτι τὸ ταττόμενον ποιῶ;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>τὸ ταττόμενον γὰρ δεῖ ποιεῖν τὸν σώφρονα;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>μάλιστα πάντων.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">τὸν μὲν οὖν ἀβέλτερον.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>σὺ δ’ οὐ καταθεῖναι διανοεῖ;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">φυλάξομαι,</l>
 					<l n="770">πρὶν ἄν γ’ ἴδω τὸ πλῆθος ὅ τι βουλεύεται.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>τί γὰρ ἄλλο γ’ ἢ φέρειν παρεσκευασμένοι</l>
 					<l>τὰ χρήματ’ εἰσίν;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἀλλ’ ἰδὼν ἐπειθόμην.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>λέγουσι γοῦν ἐν ταῖς ὁδοῖς.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">λέξουσι γάρ.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>καί φασιν οἴσειν ἀράμενοι.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">φήσουσι γάρ.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="775">ἀπολεῖς ἀπιστῶν πάντ’.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἀπιστήσουσι γάρ.</l>
 					<milestone ed="p" n="776" unit="card"/>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>ὁ Ζεύς σέ γ’ ἐπιτρίψειεν.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἐπιτρίψουσι γάρ.</l>
 					<l>οἴσειν δοκεῖς τιν’ ὅστις αὐτῶν νοῦν ἔχει;</l>
@@ -2157,160 +2157,160 @@ convert to p3
 					<l>ἕστηκεν ἐκτείνοντα τὴν χεῖρ’ ὑπτίαν</l>
 					<l>οὐχ ὥς τι δώσοντ’ ἀλλ’ ὅπως τι λήψεται.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>ὦ δαιμόνῑ ἀνδρῶν ἔα με τῶν προὔργου τι δρᾶν.</l>
 					<l n="785">ταυτὶ γάρ ἐστι συνδετέα. ποῦ μοὔσθ’ ἱμάς;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ὄντως γὰρ οἴσεις;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">ναὶ μὰ Δία, καὶ δὴ μὲν οὖν</l>
 					<l>τωδὶ ξυνάπτω τὼ τρίποδε.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">τῆς μωρίας,</l>
 					<l>τὸ μηδὲ περιμείναντα τοὺς ἄλλους ὅ τι</l>
 					<l>δράσουσιν εἶτα τηνικαῦτ’ ἤδη—</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">τί δρᾶν;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l n="790">ἐπαναμένειν, ἔπειτα διατρίβειν ἔτι.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>ἵνα δὴ τί;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">σεισμὸς εἰ γένοιτο πολλάκις</l>
 					<l>ἢ πῦρ ἀπότροπον, ἢ διᾴξειεν γαλῆ,</l>
 					<l>παύσαιντ’ ἂν ἐσφέροντες ὦμβρόντητε σύ.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>χαρίεντα γοῦν πάθοιμ’ ἄν, εἰ μὴ ’χοιμ’ ὅποι</l>
 					<l n="795">ταῦτα καταθείμην.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">μὴ γὰρ οὐ λάβῃς ὅποι·</l>
 					<l>θάρρει, καταθήσεις, κἂν ἔνης ἔλθῃς.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">τιή;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ἐγᾦδα τούτους χειροτονοῦντας μὲν ταχύ,</l>
 					<l>ἅττ’ ἂν δὲ δόξῃ ταῦτα πάλιν ἀρνουμένους.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>οἴσουσιν ὦ τᾶν.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἢν δὲ μὴ κομίσωσι, τί;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="800">ἀμέλει κομιοῦσιν.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἢν δὲ μὴ κομίσωσι, τί;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>μαχούμεθ’ αὐτοῖς.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἢν δὲ κρείττους ὦσι, τί;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>ἄπειμ’ ἐάσας.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἢν δὲ πωλῶσ’ αὐτά, τί;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>διαρραγείης.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἢν διαρραγῶ δέ, τί;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>καλῶς ποιήσεις.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">σὺ δ’ ἐπιθυμήσεις φέρειν;</l>
 					<milestone ed="p" n="805" unit="card"/>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="805">ἔγωγε· καὶ γὰρ τοὺς ἐμαυτοῦ γείτονας</l>
 					<l>ὁρῶ φέροντας.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">πάνυ γ’ ἂν οὖν Ἀντισθένης</l>
 					<l>αὔτ’ εἰσενέγκοι· πολὺ γὰρ ἐμμελέστερον</l>
 					<l>πρότερον χέσαι πλεῖν ἢ τριάκονθ’ ἡμέρας.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>οἴμωζε.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">Καλλίμαχος δ’ ὁ χοροδιδάσκαλος</l>
 					<l n="810">αὐτοῖσιν εἰσοίσει τι;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">πλείω Καλλίου.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ἅνθρωπος οὗτος ἀποβαλεῖ τὴν οὐσίαν.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>δεινά γε λέγεις.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">τί δεινόν; ὥσπερ οὐχ ὁρῶν</l>
 					<l>ἀεὶ τοιαῦτα γιγνόμενα ψηφίσματα.</l>
 					<l>οὐκ οἶσθ’ ἐκεῖν’ οὕδοξε τὸ περὶ τῶν ἁλῶν;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="815">ἔγωγε.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">τοὺς χαλκοῦς δ’ ἐκείνους ἡνίκα</l>
 					<l>ἐψηφισάμεθ’, οὐκ οἶσθα;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">καὶ κακόν γέ μοι</l>
 					<l>τὸ κόμμ’ ἐγένετ’ ἐκεῖνο. πωλῶν γὰρ βότρυς</l>
@@ -2320,7 +2320,7 @@ convert to p3
 					<l>ἀνέκραγ’ ὁ κῆρυξ μὴ δέχεσθαι μηδένα</l>
 					<l>χαλκοῦν τὸ λοιπόν· ‘ἀργύρῳ γὰρ χρώμεθα.’</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>τὸ δ’ ἔναγχος οὐχ ἅπαντες ἡμεῖς ὤμνυμεν</l>
 					<l>τάλαντ’ ἔσεσθαι πεντακόσια τῇ πόλει</l>
@@ -2330,17 +2330,17 @@ convert to p3
 					<l>ὁ Διὸς Κόρινθος καὶ τὸ πρᾶγμ’ οὐκ ἤρκεσεν,</l>
 					<l>πάλιν κατεπίττου πᾶς ἀνὴρ Εὐριπίδην.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="830">οὐ ταὐτὸν ὦ τᾶν. τότε μὲν ἡμεῖς ἤρχομεν,</l>
 					<l>νῦν δ’ αἱ γυναῖκες.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἃς ἐγὼ φυλάξομαι</l>
 					<l>νὴ τὸν Ποσειδῶ μὴ κατουρήσωσί μου.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>οὐκ οἶδ’ ὅ τι ληρεῖς. φέρε σὺ τἀνάφορον ὁ παῖς.</l>
 					<milestone ed="p" n="834" unit="card"/>
@@ -2367,102 +2367,102 @@ convert to p3
 					<l>πρὸς ταῦτα χωρεῖθ’, ὡς ὁ τὴν μᾶζαν φέρων</l>
 					<l>ἕστηκεν· ἀλλὰ τὰς γνάθους διοίγνυτε.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>οὐκοῦν βαδιοῦμαι δῆτα. τί γὰρ ἕστηκ’ ἔχων</l>
 					<l>ἐνταῦθ’, ἐπειδὴ ταῦτα τῇ πόλει δοκεῖ;</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="855">καὶ ποῖ βαδιεῖ σὺ μὴ καταθεὶς τὴν οὐσίαν;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ἐπὶ δεῖπνον.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">οὐ δῆτ’, ἤν γ’ ἐκείναις νοῦς ἐνῇ,</l>
 					<l>πρίν γ’ ἂν ἀπενέγκῃς.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">ἀλλ’ ἀποίσω.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">πηνίκα;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>οὐ τοὐμὸν ὦ τᾶν ἐμποδὼν ἔσται.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">τί δή;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ἑτέρους ἀποίσειν φήμ’ ἔθ’ ὑστέρους ἐμοῦ.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l n="860">βαδιεῖ δὲ δειπνήσων ὅμως;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l part="Y">τί γὰρ πάθω;</l>
 					<l>τὰ δυνατὰ γὰρ δεῖ τῇ πόλει ξυλλαμβάνειν</l>
 					<l>τοὺς εὖ φρονοῦντας.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">ἢν δὲ κωλύσωσι, τί;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>ὁμόσ’ εἶμι κύψας.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">ἢν δὲ μαστιγῶσι, τί;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>καλούμεθ’ αὐτάς.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">ἢν δὲ καταγελῶσι, τί;</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l n="865">ἐπὶ ταῖς θύραις ἑστώς—</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">τί δράσεις; εἰπέ μοι.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>τῶν ἐσφερόντων ἁρπάσομαι τὰ σιτία.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l>βάδιζε τοίνυν ὕστερος· σὺ δ’ ὦ Σίκων</l>
 					<l>καὶ Παρμένων αἴρεσθε τὴν παμπησίαν.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>φέρε νυν ἐγώ σοι ξυμφέρω.</l>
 				</sp>
-				<sp who="#anera">
+				<sp who="#aner_a">
 					<speaker>Ἀνὴρ Α</speaker>
 					<l part="Y">μὴ μηδαμῶς.</l>
 					<l n="870">δέδοικα γὰρ μὴ καὶ παρὰ τῇ στρατηγίδι,</l>
 					<l>ὅταν κατατιθῶ, προσποιῇ τῶν χρημάτων.</l>
 				</sp>
-				<sp who="#anerb">
+				<sp who="#aner_b">
 					<speaker>Ἀνὴρ Β</speaker>
 					<l>νὴ τὸν Δία δεῖ γοῦν μηχανήματός τινος,</l>
 					<l>ὅπως τὰ μὲν ὄντα χρήμαθ’ ἕξω, τοισδεδὶ</l>
@@ -2474,7 +2474,7 @@ convert to p3
 				<stage>Χοροῦ</stage>
 			</div1>
 			<div1 type="Lyric-Scene">
-				<sp who="#graysa">
+				<sp who="#graus_a">
 					<speaker>Γραῦς Α</speaker>
 					<l>τί ποθ’ ἅνδρες οὐχ ἥκουσιν; ὥρα δ’ ἦν πάλαι·</l>
 					<l>ἐγὼ δὲ καταπεπλασμένη ψιμυθίῳ</l>
@@ -2494,7 +2494,7 @@ convert to p3
 					<l>κεἰ γὰρ δῑ ὄχλου τοῦτ’ ἐστὶ τοῖς θεωμένοις,</l>
 					<l>ὅμως ἔχει τερπνόν τι καὶ κωμῳδικόν.</l>
 				</sp>
-				<sp who="#graysa">
+				<sp who="#graus_a">
 					<speaker>Γραῦς Α</speaker>
 					<l n="890">τούτῳ διαλέγου κἀποχώρησον· σὺ δὲ</l>
 					<l>φιλοττάριον αὐλητὰ τοὺς αὐλοὺς λαβὼν</l>
@@ -2525,7 +2525,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>ἐκπέσοι σου τὸ τρῆμα</l>
 						<l>τό τ’ ἐπίκλιντρον ἀποβάλοιο</l>
@@ -2551,7 +2551,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>ἤδη τὸν ἀπ’ Ἰωνίας</l>
 						<l>τρόπον τάλαινα κνησιᾷς·</l>
@@ -2569,7 +2569,7 @@ convert to p3
 						<l>ᾆδ’ ὁπόσα βούλει καὶ παράκυφθ’ ὥσπερ γαλῆ·</l>
 						<l n="925">οὐδεὶς γὰρ ὡς σὲ πρότερον εἴσεισ’ ἀντ’ ἐμοῦ.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>οὔκουν ἐπ’ ἐκφοράν γε.</l>
 					</sp>
@@ -2577,7 +2577,7 @@ convert to p3
 						<speaker>Νεᾶνις</speaker>
 						<l part="Y">καινόν γ’ ὦ σαπρά.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>οὐ δῆτα.</l>
 					</sp>
@@ -2585,7 +2585,7 @@ convert to p3
 						<speaker>Νεᾶνις</speaker>
 						<l part="Y">τί γὰρ ἂν γραῒ καινά τις λέγοι;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>οὐ τοὐμὸν ὀδυνήσει σε γῆρας.</l>
 					</sp>
@@ -2594,7 +2594,7 @@ convert to p3
 						<l part="Y">ἀλλὰ τί;</l>
 						<l>ἥγχουσα μᾶλλον καὶ τὸ σὸν ψιμύθιον;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l n="930">τί μοι διαλέγει;</l>
 					</sp>
@@ -2602,7 +2602,7 @@ convert to p3
 						<speaker>Νεᾶνις</speaker>
 						<l part="Y">σὺ δὲ τί διακύπτεις;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">ἐγώ;</l>
 						<l>ᾄδω πρὸς ἐμαυτὴν Ἐπιγένει τὠμῷ φίλῳ.</l>
@@ -2611,7 +2611,7 @@ convert to p3
 						<speaker>Νεᾶνις</speaker>
 						<l>σοὶ γὰρ φίλος τίς ἐστιν ἄλλος ἢ Γέρης;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>δείξει γε καὶ σοί. τάχα γὰρ εἶσιν ὡς ἐμέ.</l>
 					</sp>
@@ -2619,7 +2619,7 @@ convert to p3
 						<speaker>Νεᾶνις</speaker>
 						<l>ὁδὶ γὰρ αὐτός ἐστιν.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">οὐ σοῦ γ’ ὦλεθρε</l>
 						<l n="935">δεόμενος οὐδέν.</l>
@@ -2629,7 +2629,7 @@ convert to p3
 						<l part="Y">νὴ Δί’ ὦ φθίνυλλα σὺ</l>
 						<l>δείξει τάχ’ αὐτός, ὡς ἔγωγ’ ἀπέρχομαι.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>κἄγωγ’, ἵνα γνῷς ὡς πολύ σου μεῖζον φρονῶ.</l>
 					</sp>
@@ -2644,7 +2644,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>οἰμώζων ἄρα νὴ Δία σποδήσεις.</l>
 						<l>οὐ γὰρ τἀπὶ Χαριξένης τάδ’ ἐστίν.</l>
@@ -2720,7 +2720,7 @@ convert to p3
 						<l n="975">διά τοι σὲ πόνους ἔχω.</l>
 						<milestone ed="p" n="976" unit="card"/>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>οὗτος τί κόπτεις; μῶν ἐμὲ ζητεῖς;</l>
 					</sp>
@@ -2728,7 +2728,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l part="Y">πόθεν;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>καὶ τὴν θύραν γ’ ἤραττες.</l>
 					</sp>
@@ -2736,7 +2736,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l part="Y">ἀποθάνοιμ’ ἄρα.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>τοῦ δαὶ δεόμενος δᾷδ’ ἔχων ἐλήλυθας;</l>
 					</sp>
@@ -2744,7 +2744,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>Ἀναφλύστιον ζητῶν τιν’ ἄνθρωπον.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">τίνα;</l>
 					</sp>
@@ -2752,7 +2752,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l n="980">οὐ τὸν Σεβῖνον, ὃν σὺ προσδοκᾷς ἴσως.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>νὴ τὴν Ἀφροδίτην, ἤν τε βούλῃ γ’ ἤν τε μή.</l>
 					</sp>
@@ -2762,7 +2762,7 @@ convert to p3
 						<l>εἰσάγομεν, ἀλλ’ εἰσαῦθις ἀναβεβλήμεθα.</l>
 						<l>τὰς ἐντὸς εἴκοσιν γὰρ ἐκδικάζομεν.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l n="985">ἐπὶ τῆς προτέρας ἀρχῆς γε ταῦτ’ ἦν ὦ γλύκων·</l>
 						<l>νυνὶ δὲ πρῶτον εἰσάγειν ἡμᾶς δοκεῖ.</l>
@@ -2771,7 +2771,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>τῷ βουλομένῳ γε κατὰ τὸν ἐν πεττοῖς νόμον.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>ἀλλ’ οὐδὲ δειπνεῖς κατὰ τὸν ἐν πεττοῖς νόμον.</l>
 					</sp>
@@ -2779,7 +2779,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>οὐκ οἶδ’ ὅ τι λέγεις· τηνδεδί μοι κρουστέον.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l n="990">ὅταν γε κρούσῃς τὴν ἐμὴν πρῶτον θύραν.</l>
 					</sp>
@@ -2787,7 +2787,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>ἀλλ’ οὐχὶ νυνὶ κρησέραν αἰτούμεθα.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>οἶδ’ ὅτι φιλοῦμαι· νῦν δὲ θαυμάζεις ὅτι</l>
 						<l>θύρασί μ’ ηὗρες· ἀλλὰ πρόσαγε τὸ στόμα.</l>
@@ -2796,7 +2796,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>ἀλλ’ ὦ μέλ’ ὀρρωδῶ τὸν ἐραστήν σου.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">τίνα;</l>
 					</sp>
@@ -2804,7 +2804,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l n="995">τὸν τῶν γραφέων ἄριστον.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">οὗτος δ’ ἔστι τίς;</l>
 					</sp>
@@ -2813,7 +2813,7 @@ convert to p3
 						<l>ὃς τοῖς νεκροῖσι ζωγραφεῖ τὰς ληκύθους.</l>
 						<l>ἀλλ’ ἄπιθ’, ὅπως μή σ’ ἐπὶ θύραισιν ὄψεται.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>οἶδ’ οἶδ’ ὅ τι βούλει.</l>
 					</sp>
@@ -2821,7 +2821,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l part="Y">καὶ γὰρ ἐγώ σε νὴ Δία.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>μὰ τὴν Ἀφροδίτην ἥ μ’ ἔλαχε κληρουμένη,</l>
 						<l n="1000">μὴ ’γώ σ’ ἀφήσω.</l>
@@ -2830,7 +2830,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l part="Y">παραφρονεῖς ὦ γρᾴδιον.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>ληρεῖς· ἐγὼ δ’ ἄξω σ’ ἐπὶ τἀμὰ στρώματα.</l>
 					</sp>
@@ -2840,7 +2840,7 @@ convert to p3
 						<l>ἐξὸν καθέντα γρᾴδιον τοιουτονὶ</l>
 						<l>ἐκ τῶν φρεάτων τοὺς κάδους ξυλλαμβάνειν;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l n="1005">μὴ σκῶπτέ μ’ ὦ τάλαν ἀλλ’ ἕπου δεῦρ’ ὡς ἐμέ.</l>
 					</sp>
@@ -2849,7 +2849,7 @@ convert to p3
 						<l>ἀλλ’ οὐκ ἀνάγκη μοὐστίν, εἰ μὴ τῶν ἐμῶν</l>
 						<l>τὴν πεντακοσιοστὴν κατέθηκας τῇ πόλει.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>νὴ τὴν Ἀφροδίτην δεῖ γε μέντοι &lt;σ’&gt;. ὡς ἐγὼ</l>
 						<l>
@@ -2862,7 +2862,7 @@ convert to p3
 						<l n="1010">ἐγὼ δὲ ταῖς γε τηλικαύταις ἄχθομαι,</l>
 						<l>κοὐκ ἂν πιθοίμην οὐδέποτ’.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">ἀλλὰ νὴ Δία</l>
 						<l>ἀναγκάσει τουτί σε.</l>
@@ -2871,7 +2871,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l part="Y">τοῦτο δ’ ἔστι τί;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>ψήφισμα, καθ’ ὅ σε δεῖ βαδίζειν ὡς ἐμέ.</l>
 					</sp>
@@ -2879,7 +2879,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>λέγ’ αὐτὸ τί ποτε κἄστι.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">καὶ δή σοι λέγω.</l>
 						<l n="1015">ἔδοξε ταῖς γυναιξίν, ἢν ἀνὴρ νέος</l>
@@ -2893,7 +2893,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>οἴμοι Προκρούστης τήμερον γενήσομαι.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>τοῖς γὰρ νόμοις τοῖς ἡμετέροισι πειστέον.</l>
 					</sp>
@@ -2902,7 +2902,7 @@ convert to p3
 						<l>τί δ’ ἢν ἀφαιρῆταί μ’ ἀνὴρ τῶν δημοτῶν</l>
 						<l>ἢ τῶν φίλων ἐλθών τις;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">ἀλλ’ οὐ κύριος</l>
 						<l n="1025">ὑπὲρ μέδιμνόν ἐστ’ ἀνὴρ οὐδεὶς ἔτι.</l>
@@ -2911,7 +2911,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>ἐξωμοσία δ’ οὐκ ἔστιν;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">οὐ γὰρ δεῖ στροφῆς.</l>
 					</sp>
@@ -2919,7 +2919,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>ἀλλ’ ἔμπορος εἶναι σκήψομαι.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">κλάων γε σύ.</l>
 					</sp>
@@ -2927,7 +2927,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>τί δῆτα χρὴ δρᾶν;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">δεῦρ’ ἀκολουθεῖν ὡς ἐμέ.</l>
 					</sp>
@@ -2935,7 +2935,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>καὶ ταῦτ’ ἀνάγκη μοὐστί;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">Διομήδειά γε.</l>
 					</sp>
@@ -2946,7 +2946,7 @@ convert to p3
 						<l>καὶ ταινίωσαι καὶ παράθου τὰς ληκύθους,</l>
 						<l>ὕδατός τε κατάθου τοὔστρακον πρὸ τῆς θύρας.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>ἦ μὴν ἔτ’ ὠνήσει σὺ καὶ στεφάνην ἐμοί.</l>
 					</sp>
@@ -2959,7 +2959,7 @@ convert to p3
 						<speaker>Νεᾶνις</speaker>
 						<l>ποῖ τοῦτον ἕλκεις;</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l part="Y">τὸν ἐμὸν αὐτῆς εἰσάγω.</l>
 					</sp>
@@ -2971,7 +2971,7 @@ convert to p3
 						<l>ὥστ’ εἰ καταστήσεσθε τοῦτον τὸν νόμον,</l>
 						<l>τὴν γῆν ἅπασαν Οἰδιπόδων ἐμπλήσετε.</l>
 					</sp>
-					<sp who="#graysa">
+					<sp who="#graus_a">
 						<speaker>Γραῦς Α</speaker>
 						<l>ὦ παμβδελυρὰ φθονοῦσα τόνδε τὸν λόγον</l>
 						<l>ἐξηῦρες· ἀλλ’ ἐγώ σε τιμωρήσομαι.</l>
@@ -2984,7 +2984,7 @@ convert to p3
 						<l>μεγάλην ἀποδώσω καὶ παχεῖάν σοι χάριν.</l>
 						<milestone ed="p" n="1049" unit="card"/>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l>αὕτη σὺ ποῖ τονδὶ παραβᾶσα τὸν νόμον</l>
 						<l n="1050">ἕλκεις, παρ’ ἐμοὶ τῶν γραμμάτων εἰρηκότων</l>
@@ -2996,7 +2996,7 @@ convert to p3
 						<l>πόθεν ἐξέκυψας ὦ κάκιστ’ ἀπολουμένη;</l>
 						<l>τοῦτο γὰρ ἐκείνου τὸ κακὸν ἐξωλέστερον.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l>βάδιζε δεῦρο.</l>
 					</sp>
@@ -3005,7 +3005,7 @@ convert to p3
 						<l part="Y">μηδαμῶς με περιίδῃς</l>
 						<l n="1055">ἑλκόμενον ὑπὸ τῆσδ’ ἀντιβολῶ σ’.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l part="Y">ἀλλ’ οὐκ ἐγώ,</l>
 						<l>ἀλλ’ ὁ νόμος ἕλκει σ’.</l>
@@ -3015,7 +3015,7 @@ convert to p3
 						<l part="Y">οὐκ ἐμέ γ’, ἀλλ’ ἔμπουσά τις</l>
 						<l>ἐξ αἵματος φλύκταιναν ἠμφιεσμένη.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l>ἕπου μαλακίων δεῦρ’ ἀνύσας καὶ μὴ λάλει.</l>
 					</sp>
@@ -3026,7 +3026,7 @@ convert to p3
 						<l>αὐτοῦ τι δρῶντα πυρρὸν ὄψει μ’ αὐτίκα</l>
 						<l>ὑπὸ τοῦ δέους.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l part="Y">θάρρει, βάδιζ’· ἔνδον χεσεῖ.</l>
 					</sp>
@@ -3036,11 +3036,11 @@ convert to p3
 						<l>ἀλλ’ ἐγγυητάς σοι καταστήσω δύο</l>
 						<l>ἀξιόχρεως.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l part="Y">μή μοι καθίστη.</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l n="1065">ποῖ σὺ ποῖ</l>
 						<l>χωρεῖς μετὰ ταύτης;</l>
@@ -3056,19 +3056,19 @@ convert to p3
 						<l>πότερον πίθηκος ἀνάπλεως ψιμυθίου,</l>
 						<l>ἢ γραῦς ἀνεστηκυῖα παρὰ τῶν πλειόνων;</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l>μὴ σκῶπτέ μ’ ἀλλὰ δεῦρ’ ἕπου.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l part="Y">δευρὶ μὲν οὖν.</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l n="1075">ὡς οὐκ ἀφήσω σ’ οὐδέποτ’.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l part="Y">οὐδὲ μὴν ἐγώ.</l>
 					</sp>
@@ -3076,11 +3076,11 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>διασπάσεσθέ μ’ ὦ κακῶς ἀπολούμεναι.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l>ἐμοὶ γὰρ ἀκολουθεῖν σ’ ἔδει κατὰ τὸν νόμον.</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l>οὐκ ἢν ἑτέρα γε γραῦς ἔτ’ αἰσχίων φανῇ.</l>
 						<milestone ed="p" n="1079" unit="card"/>
@@ -3090,7 +3090,7 @@ convert to p3
 						<l>ἢν οὖν ὑφ’ ὑμῶν πρῶτον ἀπόλωμαι κακῶς,</l>
 						<l n="1080">φέρε πῶς ἐπ’ ἐκείνην τὴν καλὴν ἀφίξομαι;</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l>αὐτὸς σκόπει σύ· τάδε δέ σοι ποιητέον.</l>
 					</sp>
@@ -3098,7 +3098,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>ποτέρας προτέρας οὖν κατελάσας ἀπαλλαγῶ;</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l>οὐκ οἶσθα; βαδιεῖ δεῦρ’.</l>
 					</sp>
@@ -3106,7 +3106,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l part="Y">ἀφέτω νύν μ’ αὑτηί.</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l>δευρὶ μὲν οὖν ἴθ’ ὡς ἔμ’.</l>
 					</sp>
@@ -3114,11 +3114,11 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l part="Y">ἢν ἡδί μ’ ἀφῇ.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l n="1085">ἀλλ’ οὐκ ἀφήσω μὰ Δία σ’.</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l part="Y">οὐδὲ μὴν ἐγώ.</l>
 					</sp>
@@ -3126,7 +3126,7 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>χαλεπαί γ’ ἂν ἦστε γενόμεναι πορθμῆς.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l part="Y">τιή;</l>
 					</sp>
@@ -3134,11 +3134,11 @@ convert to p3
 						<speaker>Νεανίας</speaker>
 						<l>ἕλκοντε τοὺς πλωτῆρας ἂν ἀπεκναίετε.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l>σιγῇ βάδιζε δεῦρο.</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l part="Y">μὰ Δί’ ἀλλ’ ὡς ἐμέ.</l>
 					</sp>
@@ -3148,7 +3148,7 @@ convert to p3
 						<l n="1090">ψήφισμα, βινεῖν δεῖ με διαλελημμένον.</l>
 						<l>πῶς οὖν δικωπεῖν ἀμφοτέρας δυνήσομαι;</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l>καλῶς, ἐπειδὰν καταφάγῃς βολβῶν χύτραν.</l>
 					</sp>
@@ -3157,7 +3157,7 @@ convert to p3
 						<l>οἴμοι κακοδαίμων ἐγγὺς ἤδη τῆς θύρας</l>
 						<l>ἑλκόμενός εἰμ’.</l>
 					</sp>
-					<sp who="#graysb">
+					<sp who="#graus_b">
 						<speaker>Γραῦς Β</speaker>
 						<l part="Y">ἀλλ’ οὐδὲν ἔσται σοι πλέον.</l>
 						<l n="1095">ξυνεσπεσοῦμαι γὰρ μετὰ σοῦ.</l>
@@ -3167,7 +3167,7 @@ convert to p3
 						<l part="Y">μὴ πρὸς θεῶν·</l>
 						<l>ἑνὶ γὰρ ξυνέχεσθαι κρεῖττον ἢ δυοῖν κακοῖν.</l>
 					</sp>
-					<sp who="#graysg">
+					<sp who="#graus_g">
 						<speaker>Γραῦς Γ</speaker>
 						<l>νὴ τὴν Ἑκάτην ἐάν τε βούλῃ γ’ ἤν τέ μή.</l>
 					</sp>
@@ -3210,7 +3210,7 @@ convert to p3
 					<l n="1125">ἀλλ’ ὦ γυναῖκες φράσατέ μοι τὸν δεσπότην,</l>
 					<l>τὸν ἄνδρ’, ὅπου ’στί, τῆς ἐμῆς κεκτημένης.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορὸς</speaker>
 					<l>αὐτοῦ μένουσ’ ἡμῖν γ’ ἂν ἐξευρεῖν δοκεῖς.</l>
 				</sp>
@@ -3230,7 +3230,7 @@ convert to p3
 					<l>ὅστις πολιτῶν πλεῖον ἢ τρισμυρίων</l>
 					<l>ὄντων τὸ πλῆθος οὐ δεδείπνηκας μόνος;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορὸς</speaker>
 					<l>εὐδαιμονικόν γ’ ἄνθρωπον εἴρηκας σαφῶς.</l>
 				</sp>
@@ -3263,7 +3263,7 @@ convert to p3
 					<l>ἐγὼ δὲ πρὸς τὸ δεῖπνον ἤδη ’πείξομαι·</l>
 					<l n="1150">ἔχω δέ τοι καὶ δᾷδα ταυτηνὶ καλῶς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορὸς</speaker>
 					<l>τί δῆτα διατρίβεις ἔχων, ἀλλ’ οὐκ ἄγεις</l>
 					<l>τασδὶ λαβών; ἐν ὅσῳ δὲ καταβαίνεις, ἐγὼ</l>
@@ -3274,7 +3274,7 @@ convert to p3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l n="1155">τοῖς σοφοῖς μὲν τῶν σοφῶν μεμνημένοις κρίνειν ἐμέ,</l>
 						<l>τοῖς γελῶσι δ’ ἡδέως διὰ τὸν γέλων κρίνειν ἐμέ·</l>
@@ -3290,7 +3290,7 @@ convert to p3
 			</div1>
 			<div1 type="Exodus">
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l>ὦ ὦ ὥρα δή,</l>
 						<l>&lt;ὦ&gt; φίλαι γυναῖκες, εἴπερ μέλλομεν τὸ χρῆμα δρᾶν,</l>
@@ -3301,7 +3301,7 @@ convert to p3
 						<speaker>Βλέπυρος</speaker>
 						<l part="Y">τοῦτο δρῶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορὸς</speaker>
 						<l part="Y">καὶ τάσδε νῦν . . . .</l>
 						<l>

--- a/tei/aristophanes-frogs.xml
+++ b/tei/aristophanes-frogs.xml
@@ -55,31 +55,31 @@
 					<person xml:id="therapaina" sex="FEMALE">
 						<persName>Θεράπαινα</persName>
 					</person>
-					<person xml:id="eyripides" sex="MALE">
+					<person xml:id="euripides" sex="MALE">
 						<persName>Εὐριπίδης</persName>
 					</person>
 					<person xml:id="aiakos" sex="MALE">
 						<persName>Ἄιακος</persName>
 					</person>
-					<person xml:id="pandokeytria" sex="FEMALE">
+					<person xml:id="pandokeutria" sex="FEMALE">
 						<persName>Πανδοκευτρία</persName>
 					</person>
-					<person xml:id="ksanthias" sex="MALE">
+					<person xml:id="xanthias" sex="MALE">
 						<persName>Ξανθίας</persName>
 					</person>
-					<person xml:id="aisxylos" sex="MALE">
+					<person xml:id="aischylos" sex="MALE">
 						<persName>Αἰσχύλος</persName>
 					</person>
 					<person xml:id="plathane" sex="FEMALE">
 						<persName>Πλαθάνη</persName>
 					</person>
-					<person xml:id="erakles" sex="MALE">
+					<person xml:id="herakles" sex="MALE">
 						<persName>Ἡρακλῆς</persName>
 					</person>
 					<person xml:id="dionysos" sex="MALE">
 						<persName>Διόνυσος</persName>
 					</person>
-					<person xml:id="xaron" sex="MALE">
+					<person xml:id="charon" sex="MALE">
 						<persName>Χάρων</persName>
 					</person>
 					<person xml:id="nekros" sex="MALE">
@@ -91,10 +91,10 @@
 					<person xml:id="dis" sex="MALE">
 						<persName>Δις.</persName>
 					</person>
-					<person xml:id="ployton" sex="MALE">
+					<person xml:id="plouton" sex="MALE">
 						<persName>Πλούτων</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="UNKNOWN">
+					<personGrp xml:id="choros" sex="UNKNOWN">
 						<name>Χορός</name>
 					</personGrp>
 				</listPerson>
@@ -176,7 +176,7 @@ convert to p3
 		<body>
 			<div1 type="Prologue">
 				<milestone n="1" unit="card"/>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>Εἴπω τι τῶν εἰωθότων ὦ δέσποτα,</l>
 					<l>ἐφ’ οἷς ἀεὶ γελῶσιν οἱ θεώμενοι;</l>
@@ -186,7 +186,7 @@ convert to p3
 					<l>νὴ τὸν Δί’ ὅ τι Βούλει γε, πλὴν ‘πιέζομαι,’</l>
 					<l>τοῦτο δὲ φύλαξαι· πάνυ γάρ ἐστ’ ἤδη χολή.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>μηδ’ ἕτερον ἀστεῖόν τι;</l>
 				</sp>
@@ -194,7 +194,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">πλήν γ’ ‘ὡς θλίβομαι.’</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="6">τί δαί; τὸ πάνυ γέλοιον εἴπω;</l>
 				</sp>
@@ -203,7 +203,7 @@ convert to p3
 					<l part="Y">νὴ Δία</l>
 					<l>θαρρῶν γε· μόνον ἐκεῖν’ ὅπως μὴ ’ρεῖς,</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">τὸ τί;</l>
 				</sp>
@@ -211,7 +211,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>μεταβαλλόμενος τἀνάφορον ὅτι ‘χεζητιᾷς.’</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>μηδ’ ὅτι τοσοῦτον ἄχθος ἐπ’ ἐμαυτῷ φέρων,</l>
 					<l n="10">εἰ μὴ καθαιρήσει τις, ἀποπαρδήσομαι;</l>
@@ -220,7 +220,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>μὴ δῆθ’, ἱκετεύω, πλήν γ’ ὅταν μέλλω ’ξεμεῖν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δῆτ’ ἔδει με ταῦτα τὰ σκεύη φέρειν,</l>
 					<l>εἴπερ ποιήσω μηδὲν ὧνπερ Φρύνιχος</l>
@@ -232,7 +232,7 @@ convert to p3
 					<l>ὅταν τι τούτων τῶν σοφισμάτων ἴδω,</l>
 					<l>πλεῖν ἢ ’νιαυτῷ πρεσβύτερος ἀπέρχομαι.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ὢ τρισκακοδαίμων ἄρ’ ὁ τράχηλος οὑτοσί,</l>
 					<l n="20">ὅτι θλίβεται μέν, τὸ δὲ γέλοιον οὐκ ἐρεῖ.</l>
@@ -244,7 +244,7 @@ convert to p3
 					<l>αὐτὸς βαδίζω καὶ πονῶ, τοῦτον δ’ ὀχῶ,</l>
 					<l n="24">ἵνα μὴ ταλαιπωροῖτο μηδ’ ἄχθος φέροι;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οὐ γὰρ φέρω ’γώ;</l>
 				</sp>
@@ -252,7 +252,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">πῶς φέρεις γὰρ ὅς γ’ ὀχεῖ;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>φέρων γε ταυτί.</l>
 				</sp>
@@ -260,7 +260,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">τίνα τρόπον;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">Βαρέως πάνυ.</l>
 				</sp>
@@ -268,7 +268,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>οὔκουν τὸ Βάρος τοῦθ’ ὃ σὺ φέρεις ὄνος φέρει;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οὐ δῆθ’ ὅ γ’ ἔχω ’γὼ καὶ φέρω μὰ τὸν Δί’ οὔ.</l>
 				</sp>
@@ -276,7 +276,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>πῶς γὰρ φέρεις, ὅς γ’ αὐτὸς ὑφ’ ἑτέρου φέρει;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="30">οὐκ οἶδ’· ὁ δ’ ὦμος οὑτοσὶ πιέζεται.</l>
 				</sp>
@@ -285,7 +285,7 @@ convert to p3
 					<l>σὺ δ’ οὖν ἐπειδὴ τὸν ὄνον οὐ φῄς σ’ ὠφελεῖν,</l>
 					<l>ἐν τῷ μέρει σὺ τὸν ὄνον ἀράμενος φέρε.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οἴμοι κακοδαίμων· τί γὰρ ἐγὼ οὐκ ἐναυμάχουν;</l>
 					<l>ἦ τἄν σε κωκύειν ἂν ἐκέλευον μακρά.</l>
@@ -297,7 +297,7 @@ convert to p3
 					<l>ἔδει τραπέσθαι. παιδίον, παῖ, ἠμί, παῖ.</l>
 					<milestone ed="p" n="38" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>τίς τὴν θύραν ἐπάταξεν; ὡς κενταυρικῶς</l>
 					<l>ἐνήλαθ’ ὅστις· εἰπέ μοι τουτὶ τί ἦν;</l>
@@ -306,7 +306,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="40">ὁ παῖς.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">τί ἔστιν;</l>
 				</sp>
@@ -314,7 +314,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">οὐκ ἐνεθυμήθης;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">τὸ τί;</l>
 				</sp>
@@ -322,11 +322,11 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>ὡς σφόδρα μ’ ἔδεισε.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">νὴ Δία μὴ μαίνοιό γε.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οὔ τοι μὰ τὴν Δήμητρα δύναμαι μὴ γελᾶν·</l>
 					<l>καίτοι δάκνω γ’ ἐμαυτόν· ἀλλ’ ὅμως γελῶ.</l>
@@ -335,7 +335,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>ὦ δαιμόνιε πρόσελθε· δέομαι γάρ τί σου.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="45">ἀλλ’ οὐχ οἷός τ’ εἴμ’ ἀποσοβῆσαι τὸν γέλων</l>
 					<l>ὁρῶν λεοντῆν ἐπὶ κροκωτῷ κειμένην.</l>
@@ -346,7 +346,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἐπεβάτευον Κλεισθένει‐</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>κἀναυμάχησας;</l>
 				</sp>
@@ -355,7 +355,7 @@ convert to p3
 					<l part="Y">καὶ κατεδύσαμέν γε ναῦς</l>
 					<l n="50">τῶν πολεμίων ἢ δώδεκ’ ἢ τρεῖς καὶ δέκα.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>σφώ;</l>
 				</sp>
@@ -363,7 +363,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">νὴ τὸν Ἀπόλλω.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">κᾆτ’ ἔγωγ’ ἐξηγρόμην.</l>
 				</sp>
@@ -373,7 +373,7 @@ convert to p3
 					<l>τὴν Ἀνδρομέδαν πρὸς ἐμαυτὸν ἐξαίφνης πόθος</l>
 					<l>τὴν καρδίαν ἐπάταξε πῶς οἴει σφόδρα.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="55">πόθος; πόσος τις;</l>
 				</sp>
@@ -381,7 +381,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">μικρὸς ἡλίκος Μόλων.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>γυναικός;</l>
 				</sp>
@@ -389,7 +389,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">οὐ δῆτ’.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">ἀλλὰ παιδός;</l>
 				</sp>
@@ -397,7 +397,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">οὐδαμῶς.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἀλλ’ ἀνδρός;</l>
 				</sp>
@@ -405,7 +405,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἀπαπαί.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">ξυνεγένου τῷ Κλεισθένει;</l>
 				</sp>
@@ -415,7 +415,7 @@ convert to p3
 					<l>τοιοῦτος ἵμερός με διαλυμαίνεται.</l>
 					<milestone ed="p" n="60" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="60">ποῖός τις ὦδελφίδιον;</l>
 				</sp>
@@ -425,7 +425,7 @@ convert to p3
 					<l>ὅμως γε μέντοι σοι δῑ αἰνιγμῶν ἐρῶ.</l>
 					<l>ἤδη ποτ’ ἐπεθύμησας ἐξαίφνης ἔτνους;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἔτνους; βαβαιάξ, μυριάκις γ’ ἐν τῷ βίῳ.</l>
 				</sp>
@@ -433,7 +433,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>ἆρ’ ἐκδιδάσκω τὸ σαφὲς ἢ ’τέρᾳ φράσω;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="65">μὴ δῆτα περὶ ἔτνους γε· πάνυ γὰρ μανθάνω.</l>
 				</sp>
@@ -442,7 +442,7 @@ convert to p3
 					<l>τοιουτοσὶ τοίνυν με δαρδάπτει πόθος</l>
 					<l>Εὐριπίδου.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">καὶ ταῦτα τοῦ τεθνηκότος;</l>
 				</sp>
@@ -451,7 +451,7 @@ convert to p3
 					<l>κοὐδείς γέ μ’ ἂν πείσειεν ἀνθρώπων τὸ μὴ οὐκ</l>
 					<l>ἐλθεῖν ἐπ’ ἐκεῖνον.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">πότερον εἰς Ἅιδου κάτω;</l>
 				</sp>
@@ -459,7 +459,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="70">καὶ νὴ Δί’ εἴ τί γ’ ἔστιν ἔτι κατωτέρω.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>τί βουλόμενος;</l>
 				</sp>
@@ -468,7 +468,7 @@ convert to p3
 					<l part="Y">δέομαι ποιητοῦ δεξιοῦ.</l>
 					<l>οἱ μὲν γὰρ οὐκέτ’ εἰσίν, οἱ δ’ ὄντες κακοί.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>τί δ’; οὐκ Ἰοφῶν ζῇ;</l>
 				</sp>
@@ -478,7 +478,7 @@ convert to p3
 					<l>ἔτ’ ἐστὶ λοιπὸν ἀγαθόν, εἰ καὶ τοῦτ’ ἄρα·</l>
 					<l n="75">οὐ γὰρ σάφ’ οἶδ’ οὐδ’ αὐτὸ τοῦθ’ ὅπως ἔχει.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>εἶτ’ οὐχὶ Σοφοκλέα πρότερον Εὐριπίδου</l>
 					<l>μέλλεις ἀναγαγεῖν, εἴπερ ἐκεῖθεν δεῖ σ’ ἄγειν;</l>
@@ -491,7 +491,7 @@ convert to p3
 					<l>κἂν ξυναποδρᾶναι δεῦρ’ ἐπιχειρήσειέ μοι·</l>
 					<l>ὁ δ’ εὔκολος μὲν ἐνθάδ’ εὔκολος δ’ ἐκεῖ.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>Ἀγάθων δὲ ποῦ ’στιν;</l>
 				</sp>
@@ -500,7 +500,7 @@ convert to p3
 					<l part="Y">ἀπολιπών μ’ ἀποίχεται,</l>
 					<l>ἀγαθὸς ποιητὴς καὶ ποθεινὸς τοῖς φίλοις.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="85">ποῖ γῆς ὁ τλήμων;</l>
 				</sp>
@@ -508,7 +508,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἐς Μακάρων εὐωχίαν.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ὁ δὲ Σενοκλέης;</l>
 				</sp>
@@ -516,17 +516,17 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἐξόλοιτο νὴ Δία.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>Πυθάγγελος δέ;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">περὶ ἐμοῦ δ’ οὐδεὶς λόγος</l>
 					<l>ἐπιτριβομένου τὸν ὦμον οὑτωσὶ σφόδρα.</l>
 					<milestone ed="p" n="89" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οὔκουν ἕτερ’ ἔστ’ ἐνταῦθα μειρακύλλια</l>
 					<l n="90">τραγῳδίας ποιοῦντα πλεῖν ἢ μύρια,</l>
@@ -541,7 +541,7 @@ convert to p3
 					<l>γόνιμον δὲ ποιητὴν ἂν οὐχ εὕροις ἔτι</l>
 					<l>ζητῶν ἄν, ὅστις ῥῆμα γενναῖον λάκοι.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>πῶς γόνιμον;</l>
 				</sp>
@@ -553,7 +553,7 @@ convert to p3
 					<l>ἢ φρένα μὲν οὐκ ἐθέλουσαν ὀμόσαι καθ’ ἱερῶν,</l>
 					<l>γλῶτταν δ’ ἐπιορκήσασαν ἰδίᾳ τῆς φρενός.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>σὲ δὲ ταῦτ’ ἀρέσκει;</l>
 				</sp>
@@ -561,7 +561,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">μἀλλὰ πλεῖν ἢ μαίνομαι.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἦ μὴν κόβαλά γ’ ἐστίν, ὡς καὶ σοὶ δοκεῖ.</l>
 				</sp>
@@ -569,7 +569,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="105">μὴ τὸν ἐμὸν οἴκει νοῦν· ἔχεις γὰρ οἰκίαν.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>καὶ μὴν ἀτεχνῶς γε παμπόνηρα φαίνεται.</l>
 				</sp>
@@ -577,7 +577,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>δειπνεῖν με δίδασκε.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">περὶ ἐμοῦ δ’ οὐδεὶς λόγος.</l>
 				</sp>
@@ -592,12 +592,12 @@ convert to p3
 					<l>πόλεις διαίτας πανδοκευτρίας, ὅπου</l>
 					<l>κόρεις ὀλίγιστοι.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">περὶ ἐμοῦ δ’ οὐδεὶς λόγος.</l>
 					<milestone ed="p" n="116" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="116">ὦ σχέτλιε τολμήσεις γὰρ ἰέναι καὶ σύ γε;</l>
 				</sp>
@@ -607,7 +607,7 @@ convert to p3
 					<l>ὅπῃ τάχιστ’ ἀφιζόμεθ’ εἰς Ἅιδου κάτω·</l>
 					<l>καὶ μήτε θερμὴν μήτ’ ἄγαν ψυχρὰν φράσῃς.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="120">φέρε δὴ τίν’ αὐτῶν σοι φράσω πρώτην; τίνα;</l>
 					<l>μία μὲν γὰρ ἔστιν ἀπὸ κάλω καὶ θρανίου,</l>
@@ -617,7 +617,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">παῦε, πνιγηρὰν λέγεις.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἀλλ’ ἔστιν ἀτραπὸς ξύντομος τετριμμένη</l>
 					<l>ἡ διὰ θυείας.</l>
@@ -626,7 +626,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἆρα κώνειον λέγεις;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="125">μάλιστά γε.</l>
 				</sp>
@@ -635,7 +635,7 @@ convert to p3
 					<l part="Y">ψυχράν γε καὶ δυσχείμερον·</l>
 					<l>εὐθὺς γὰρ ἀποπήγνυσι τἀντικνήμια.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>βούλει κατάντη καὶ ταχεῖαν σοι φράσω;</l>
 				</sp>
@@ -643,7 +643,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>νὴ τὸν Δί’ ὡς ὄντος γε μὴ βαδιστικοῦ.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>καθέρπυσόν νυν ἐς Κεραμεικόν.</l>
 				</sp>
@@ -651,7 +651,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">κᾆτα τί;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἀναβὰς ἐπὶ τὸν πύργον τὸν ὑψηλόν—</l>
 				</sp>
@@ -659,7 +659,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">τί δρῶ;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="131">ἀφιεμένην τὴν λαμπάδ’ ἐντεῦθεν θεῶ,</l>
 					<l>κἄπειτ’ ἐπειδὰν θῶσιν οἱ θεώμενοι</l>
@@ -669,7 +669,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ποῖ</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">κάτω.</l>
 				</sp>
@@ -678,7 +678,7 @@ convert to p3
 					<l n="134">ἀλλ’ ἀπολέσαιμ’ ἂν ἐγκεφάλου θρίω δύο.</l>
 					<l>οὐκ ἂν βαδίσαιμι τὴν ὁδὸν ταύτην.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">τί δαί;</l>
 				</sp>
@@ -686,7 +686,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>ἥνπερ σὺ τότε κατῆλθες.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">ἀλλ’ ὁ πλοῦς πολύς.</l>
 					<l>εὐθὺς γὰρ ἐπὶ λίμνην μεγάλην ἥξεις πάνυ</l>
@@ -696,7 +696,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">εἶτα πῶς περαιωθήσομαι;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἐν πλοιαρίῳ τυννουτῳί σ’ ἀνὴρ γέρων</l>
 					<l n="140">ναύτης διάξει δύ’ ὀβολὼ μισθὸν λαβών.</l>
@@ -707,7 +707,7 @@ convert to p3
 					<l>ὡς μέγα δύνασθον πανταχοῦ τὼ δύ’ ὀβολώ.</l>
 					<l>πῶς ἠλθέτην κἀκεῖσε;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">Θησεὺς ἤγαγεν.</l>
 					<l>μετὰ ταῦτ’ ὄφεις καὶ θηρί’ ὄψει μυρία</l>
@@ -718,7 +718,7 @@ convert to p3
 					<l part="Y">μή μ’ ἔκπληττε μηδὲ δειμάτου·</l>
 					<l>οὐ γάρ μ’ ἀποτρέψεις.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">εἶτα βόρβορον πολὺν</l>
 					<l n="146">καὶ σκῶρ ἀείνων· ἐν δὲ τούτῳ κειμένους,</l>
@@ -734,7 +734,7 @@ convert to p3
 					<l>νὴ τοὺς θεοὺς ἐχρῆν γε πρὸς τούτοισι κεἰ</l>
 					<l>τὴν πυρρίχην τις ἔμαθε τὴν Κινησίου.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἐντεῦθεν αὐλῶν τίς σε περίεισιν πνοή,</l>
 					<l n="155">ὄψει τε φῶς κάλλιστον ὥσπερ ἐνθάδε,</l>
@@ -745,16 +745,16 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>οὗτοι δὲ δὴ τίνες εἰσίν;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l part="Y">οἱ μεμυημένοι—</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>νὴ τὸν Δί’ ἐγὼ γοῦν ὄνος ἄγω μυστήρια.</l>
 					<l n="160">ἀτὰρ οὐ καθέξω ταῦτα τὸν πλείω χρόνον.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οἵ σοι φράσουσ’ ἁπαξάπανθ’ ὧν ἂν δέῃ.</l>
 					<l>οὗτοι γὰρ ἐγγύτατα παρ’ αὐτὴν τὴν ὁδὸν</l>
@@ -766,7 +766,7 @@ convert to p3
 					<l part="Y">νὴ Δία καὶ σύ γε</l>
 					<l n="165">ὑγίαινε. σὺ δὲ τὰ στρώματ’ αὖθις λάμβανε.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>πρὶν καὶ καταθέσθαι;</l>
 				</sp>
@@ -774,7 +774,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">καὶ ταχέως μέντοι πάνυ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>μὴ δῆθ’, ἱκετεύω σ’, ἀλλὰ μίσθωσαί τινα</l>
 					<l>τῶν ἐκφερομένων, ὅστις ἐπὶ τοῦτ’ ἔρχεται.</l>
@@ -783,7 +783,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>ἐὰν δὲ μὴ εὕρω;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">τότε μ’ ἄγειν.</l>
 				</sp>
@@ -830,7 +830,7 @@ convert to p3
 					<speaker>Νέκρος</speaker>
 					<l part="Y">ἀναβιοίην νυν πάλιν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ὡς σεμνὸς ὁ κατάρατος· οὐκ οἰμώξεται;</l>
 					<l>ἐγὼ βαδιοῦμαι.</l>
@@ -840,11 +840,11 @@ convert to p3
 					<l part="Y">χρηστὸς εἶ καὶ γεννάδας.</l>
 					<l n="180">χωρῶμεν ἐπὶ τὸ πλοῖον.</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l part="Y">ὠὸπ παραβαλοῦ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τουτὶ τί ἔστι;</l>
 				</sp>
@@ -853,7 +853,7 @@ convert to p3
 					<l part="Y">τοῦτο; λίμνη νὴ Δία</l>
 					<l>αὕτη ’στὶν ἣν ἔφραζε, καὶ πλοῖόν γ’ ὁρῶ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>νὴ τὸν Ποσειδῶ κἄστι γ’ ὁ Χάρων οὑτοσί.</l>
 				</sp>
@@ -862,7 +862,7 @@ convert to p3
 					<l>χαῖρ’ ὦ Χάρων, χαῖρ’ ὦ Χάρων, χαῖρ’ ὦ Χάρων.</l>
 					<milestone ed="p" n="185" unit="card"/>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l n="185">τίς εἰς ἀναπαύλας ἐκ κακῶν καὶ πραγμάτων;</l>
 					<l>τίς ἐς τὸ Λήθης πεδίον, ἢ σ’ Ὄνου πόκας,</l>
@@ -872,7 +872,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>ἐγώ.</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l part="Y">ταχέως ἔμβαινε.</l>
 				</sp>
@@ -881,7 +881,7 @@ convert to p3
 					<l part="Y">ποῖ σχήσειν δοκεῖς;</l>
 					<l>ἐς κόρακας ὄντως;</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l part="Y">ναὶ μὰ Δία σοῦ γ’ οὕνεκα.</l>
 					<l n="190">ἔσβαινε δή.</l>
@@ -890,24 +890,24 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">παῖ δεῦρο.</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l part="Y">δοῦλον οὐκ ἄγω,</l>
 					<l>εἰ μὴ νεναυμάχηκε τὴν περὶ τῶν κρεῶν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>μὰ τὸν Δί’ οὐ γὰρ ἀλλ’ ἔτυχον ὀφθαλμιῶν.</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l>οὔκουν περιθρέξει δῆτα τὴν λίμνην κύκλῳ;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ποῦ δῆτ’ ἀναμενῶ;</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l part="Y">παρὰ τὸν Αὑαίνου λίθον</l>
 					<l n="195">ἐπὶ ταῖς ἀναπαύλαις.</l>
@@ -916,12 +916,12 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">μανθάνεις;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">πάνυ μανθάνω.</l>
 					<l>οἴμοι κακοδαίμων, τῷ ξυνέτυχον ἐξιών;</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l>κάθιζ’ ἐπὶ κώπην. εἴ τις ἔτι πλεῖ, σπευδέτω.</l>
 					<l>οὗτος τί ποιεῖς;</l>
@@ -931,7 +931,7 @@ convert to p3
 					<l part="Y">ὅ τι ποιῶ; τί δ’ ἄλλο γ’ ἢ</l>
 					<l n="199">ἵζω ’πὶ κώπην, οὗπερ ἐκέλευές με σύ;</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l>οὔκουν καθεδεῖ δῆτ’ ἐνθαδὶ γάστρων;</l>
 				</sp>
@@ -939,7 +939,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἰδού.</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l>οὔκουν προβαλεῖ τὼ χεῖρε κἀκτενεῖς;</l>
 				</sp>
@@ -947,7 +947,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἰδού.</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l>οὐ μὴ φλυαρήσεις ἔχων ἀλλ’ ἀντιβὰς</l>
 					<l>ἐλᾷς προθύμως;</l>
@@ -958,7 +958,7 @@ convert to p3
 					<l n="204">ἄπειρος ἀθαλάττωτος ἀσαλαμίνιος</l>
 					<l>ὢν εἶτ’ ἐλαύνειν;</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l part="Y">ῥᾷστ’· ἀκούσει γὰρ μέλη</l>
 					<l>κάλλιστ’, ἐπειδὰν ἐμβάλῃς ἅπαξ,</l>
@@ -967,7 +967,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">τίνων;</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l>βατράχων κύκνων θαυμαστά.</l>
 				</sp>
@@ -975,7 +975,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">κατακέλευε δή.</l>
 				</sp>
-				<sp who="#xaron">
+				<sp who="#charon">
 					<speaker>Χάρων</speaker>
 					<l>ὦ ὀπὸπ ὦ ὀπόπ.</l>
 					<milestone ed="p" n="209" unit="card"/>
@@ -1104,7 +1104,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ἔμελλον ἄρα παύσειν ποθ’ ὑμᾶς τοῦ κοάξ.</l>
 					</sp>
-					<sp who="#xaron">
+					<sp who="#charon">
 						<speaker>Χάρων</speaker>
 						<l>ὢ παῦε παῦε, παραβαλοῦ τὼ κωπίω,</l>
 						<l n="270">ἔκβαιν’, ἀπόδος τὸν ναῦλον.</l>
@@ -1114,7 +1114,7 @@ convert to p3
 						<l part="Y">ἔχε δὴ τὠβολώ.</l>
 						<l>ὁ Ξανθίας. ποῦ Ξανθίας; ἦ Ξανθία.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>ἰαῦ.</l>
 					</sp>
@@ -1122,7 +1122,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">βάδιζε δεῦρο.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">χαῖρ’ ὦ δέσποτα.</l>
 					</sp>
@@ -1130,7 +1130,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>τί ἔστι τἀνταυθοῖ;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">σκότος καὶ βόρβορος.</l>
 					</sp>
@@ -1139,7 +1139,7 @@ convert to p3
 						<l>κατεῖδες οὖν που τοὺς πατραλοίας αὐτόθι</l>
 						<l n="275">καὶ τοὺς ἐπιόρκους, οὓς ἔλεγεν ἡμῖν;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">σὺ δ’ οὔ;</l>
 					</sp>
@@ -1148,7 +1148,7 @@ convert to p3
 						<l>νὴ τὸν Ποσειδῶ ’γωγε, καὶ νυνί γ’ ὁρῶ.</l>
 						<l>ἄγε δὴ τί δρῶμεν;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">προϊέναι βέλτιστα νῷν,</l>
 						<l>ὡς οὗτος ὁ τόπος ἐστὶν οὗ τὰ θηρία</l>
@@ -1163,7 +1163,7 @@ convert to p3
 						<l>ἐγὼ δέ γ’ εὐξαίμην ἂν ἐντυχεῖν τινι</l>
 						<l>λαβεῖν τ’ ἀγώνισμ’ ἄξιόν τι τῆς ὁδοῦ.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="285">νὴ τὸν Δία καὶ μὴν αἰσθάνομαι ψόφου τινός.</l>
 					</sp>
@@ -1171,7 +1171,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ποῦ ποῦ ’στιν;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">ἐξόπισθεν.</l>
 					</sp>
@@ -1179,7 +1179,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">ἐξόπισθ’ ἴθι.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>ἀλλ’ ἐστὶν ἐν τῷ πρόσθε.</l>
 					</sp>
@@ -1187,7 +1187,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">πρόσθε νυν ἴθι.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>καὶ μὴν ὁρῶ νὴ τὸν Δία θηρίον μέγα.</l>
 					</sp>
@@ -1195,7 +1195,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ποῖόν τι;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">δεινόν· παντοδαπὸν γοῦν γίγνεται</l>
 						<l n="290">τοτὲ μέν γε βοῦς, νυνὶ δ’ ὀρεύς, τοτὲ δ’ αὖ γυνὴ</l>
@@ -1205,7 +1205,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">ποῦ ’στι; φέρ’ ἐπ’ αὐτὴν ἴω.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>ἀλλ’ οὐκέτ’ αὖ γυνή ’στιν, ἀλλ’ ἤδη κύων.</l>
 					</sp>
@@ -1213,7 +1213,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>Ἔμπουσα τοίνυν ἐστί.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">πυρὶ γοῦν λάμπεται</l>
 						<l>ἅπαν τὸ πρόσωπον.</l>
@@ -1222,7 +1222,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">καὶ σκέλος χαλκοῦν ἔχει;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="295">νὴ τὸν Ποσειδῶ, καὶ βολίτινον θάτερον,</l>
 						<l>σάφ’ ἴσθι.</l>
@@ -1231,7 +1231,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">ποῖ δῆτ’ ἂν τραποίμην;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">ποῖ δ’ ἐγώ;</l>
 					</sp>
@@ -1239,7 +1239,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ἱερεῦ διαφύλαξόν μ’, ἵν’ ὦ σοι ξυμπότης.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>ἀπολούμεθ’ ὦναξ Ἡράκλεις.</l>
 					</sp>
@@ -1248,7 +1248,7 @@ convert to p3
 						<l part="Y">οὐ μὴ καλεῖς μ’</l>
 						<l>ὦνθρωφ’, ἱκετεύω, μηδὲ κατερεῖς τοὔνομα.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="300">Διόνυσε τοίνυν.</l>
 					</sp>
@@ -1257,7 +1257,7 @@ convert to p3
 						<l part="Y">τοῦτό γ’ ἧττον θατέρου.</l>
 						<l>ἴθ’ ᾗπερ ἔρχει.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">δεῦρο δεῦρ’ ὦ δέσποτα.</l>
 					</sp>
@@ -1265,7 +1265,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>τί δ’ ἔστι;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">θάρρει· πάντ’ ἀγαθὰ πεπράγαμεν,</l>
 						<l>ἔξεστί θ’ ὥσπερ Ἡγέλοχος ἡμῖν λέγειν,</l>
@@ -1276,7 +1276,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">κατόμοσον.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">νὴ τὸν Δία.</l>
 					</sp>
@@ -1284,7 +1284,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>καὖθις κατόμοσον.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">νὴ Δί’.</l>
 					</sp>
@@ -1292,7 +1292,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">ὄμοσον.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">νὴ Δία.</l>
 					</sp>
@@ -1300,7 +1300,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>οἴμοι τάλας, ὡς ὠχρίασ’ αὐτὴν ἰδών.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>ὁδὶ δὲ δείσας ὑπερεπυρρίασέ σου.</l>
 					</sp>
@@ -1309,7 +1309,7 @@ convert to p3
 						<l>οἴμοι, πόθεν μοι τὰ κακὰ ταυτὶ προσέπεσεν;</l>
 						<l n="310">τίν’ αἰτιάσομαι θεῶν μ’ ἀπολλύναι;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>αἰθέρα Διὸς δωμάτιον ἢ χρόνου πόδα;</l>
 					</sp>
@@ -1318,7 +1318,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>οὗτος.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">τί ἔστιν;</l>
 					</sp>
@@ -1326,7 +1326,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">οὐ κατήκουσας;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">τίνος;</l>
 					</sp>
@@ -1334,7 +1334,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>αὐλῶν πνοῆς.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">ἔγωγε, καὶ δᾴδων γέ με</l>
 						<l>αὔρα τις εἰσέπνευσε μυστικωτάτη.</l>
@@ -1348,12 +1348,12 @@ convert to p3
 			</div1>
 			<div1 type="Parodos">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἴακχ’ ὦ Ἴακχε.</l>
 						<l>Ἴακχ’ ὦ Ἴακχε.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>τοῦτ’ ἔστ’ ἐκεῖν’ ὦ δέσποθ’· οἱ μεμυημένοι</l>
 						<l>ἐνταῦθά που παίζουσιν, οὓς ἔφραζε νῷν.</l>
@@ -1367,7 +1367,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἴακχ’ ὦ πολυτίμητ’ ἐν ἕδραις ἐνθάδε ναίων,</l>
 						<l n="325">Ἴακχ’ ὦ Ἴακχε,</l>
@@ -1382,7 +1382,7 @@ convert to p3
 						<l>ὁσίοις μύσταις χορείαν.</l>
 						<milestone ed="p" n="337" unit="card"/>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>ὦ πότνια πολυτίμητε Δήμητρος κόρη,</l>
 						<l>ὡς ἡδύ μοι προσέπνευσε χοιρείων κρεῶν.</l>
@@ -1394,7 +1394,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>†ἔγειρε φλογέας λαμπάδας ἐν χερσὶ γὰρ ἥκει τινάσσων†,</l>
 						<l n="341">Ἴακχ’ ὦ Ἴακχε,</l>
@@ -1411,7 +1411,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐφημεῖν χρὴ κἀξίστασθαι τοῖς ἡμετέροισι χοροῖσιν,</l>
 						<l n="355">ὅστις ἄπειρος τοιῶνδε λόγων ἢ γνώμῃ μὴ καθαρεύει,</l>
@@ -1435,7 +1435,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χώρει νυν πᾶς ἀνδρείως</l>
 						<l>ἐς τοὺς εὐανθεῖς κόλπους</l>
@@ -1447,7 +1447,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἔμβα χὤπως ἀρεῖς</l>
 						<l>τὴν Σώτειραν γενναίως</l>
@@ -1459,7 +1459,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγε νυν ἑτέραν ὕμνων ἰδέαν τὴν καρποφόρον βασίλειαν</l>
 						<l>Δήμητρα θεὰν ἐπικοσμοῦντες ζαθέαις μολπαῖς κελαδεῖτε.</l>
@@ -1467,7 +1467,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Δήμητερ ἁγνῶν ὀργίων</l>
 						<l n="387">ἄνασσα συμπαραστάτει,</l>
@@ -1478,7 +1478,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ πολλὰ μὲν γέλοιά μ’ εἰ‐</l>
 						<l>πεῖν, πολλὰ δὲ σπουδαῖα, καὶ</l>
@@ -1489,7 +1489,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγ’ εἶα</l>
 						<l>νῦν καὶ τὸν ὡραῖον θεὸν παρακαλεῖτε δεῦρο</l>
@@ -1498,7 +1498,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἴακχε πολυτίμητε, μέλος ἑορτῆς</l>
 						<l n="400">ἥδιστον εὑρών, δεῦρο συνακολούθει</l>
@@ -1510,7 +1510,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὺ γὰρ κατεσχίσω μὲν ἐπὶ γέλωτι</l>
 						<l n="406">κἀπ’ εὐτελείᾳ τόδε τὸ σανδαλίσκον</l>
@@ -1522,7 +1522,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ γὰρ παραβλέψας τι μειρακίσκης</l>
 						<l>νῦν δὴ κατεῖδον καὶ μάλ’ εὐπροσώπου</l>
@@ -1542,14 +1542,14 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">κἄγωγε πρός.</l>
 						<milestone ed="p" n="420" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βούλεσθε δῆτα κοινῇ</l>
 						<l n="421">σκώψωμεν Ἀρχέδημον;</l>
@@ -1558,7 +1558,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νυνὶ δὲ δημαγωγεῖ</l>
 						<l>ἐν τοῖς ἄνω νεκροῖσι,</l>
@@ -1567,7 +1567,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="426">τὸν Κλεισθένους δ’ ἀκούω</l>
 						<l>ἐν ταῖς ταφαῖσι πρωκτὸν</l>
@@ -1576,7 +1576,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κἀκόπτετ’ ἐγκεκυφώς,</l>
 						<l n="430">κἄκλαε κἀκεκράγει</l>
@@ -1585,7 +1585,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="5" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="432">καὶ Καλλίαν γέ φασι</l>
 						<l>τοῦτον τὸν Ἱπποβίνου</l>
@@ -1603,7 +1603,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="7" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδὲν μακρὰν ἀπέλθῃς,</l>
 						<l>μηδ’ αὖθις ἐπανέρῃ με,</l>
@@ -1617,12 +1617,12 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>τουτὶ τί ἦν τὸ πρᾶγμα;</l>
 						<l>ἀλλ’ ἢ Διὸς Κόρινθος ἐν τοῖς στρώμασιν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χωρεῖτε</l>
 						<l n="445">νῦν ἱερὸν ἀνὰ κύκλον θεᾶς, ἀνθοφόρον ἀν’ ἄλσος</l>
@@ -1633,7 +1633,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χωρῶμεν ἐς πολυρρόδους</l>
 						<l n="450">λειμῶνας ἀνθεμώδεις,</l>
@@ -1645,7 +1645,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="455">μόνοις γὰρ ἡμῖν ἥλιος</l>
 						<l>καὶ φέγγος ἱλαρόν ἐστιν,</l>
@@ -1663,7 +1663,7 @@ convert to p3
 					<l n="460">ἄγε δὴ τίνα τρόπον τὴν θύραν κόψω; τίνα;</l>
 					<l>πῶς ἐνθάδ’ ἄρα κόπτουσιν οὑπιχώριοι;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οὐ μὴ διατρίψεις, ἀλλὰ γεύσει τῆς θύρας,</l>
 					<l>καθ’ Ἡρακλέα τὸ σχῆμα καὶ τὸ λῆμ’ ἔχων.</l>
@@ -1697,7 +1697,7 @@ convert to p3
 					<l>διασπάσονται Γοργόνες Τειθράσιαι,</l>
 					<l>ἐφ’ ἃς ἐγὼ δρομαῖον ὁρμήσω πόδα.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οὗτος τί δέδρακας;</l>
 				</sp>
@@ -1705,7 +1705,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἐγκέχοδα· κάλει θεόν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="480">ὦ καταγέλαστ’ οὔκουν ἀναστήσει ταχὺ</l>
 					<l>πρίν τινά σ’ ἰδεῖν ἀλλότριον;</l>
@@ -1715,7 +1715,7 @@ convert to p3
 					<l part="Y">ἀλλ’ ὡρακιῶ.</l>
 					<l>ἀλλ’ οἶσε πρὸς τὴν καρδίαν μου σφογγιάν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἰδοὺ λαβέ, προσθοῦ.</l>
 				</sp>
@@ -1723,7 +1723,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ποῦ ’στιν;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">ὦ χρυσοῖ θεοὶ</l>
 					<l>ἐνταῦθ’ ἔχεις τὴν καρδίαν;</l>
@@ -1733,7 +1733,7 @@ convert to p3
 					<l part="Y">δείσασα γὰρ</l>
 					<l n="485">ἐς τὴν κάτω μου κοιλίαν καθείρπυσεν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ὦ δειλότατε θεῶν σὺ κἀνθρώπων.</l>
 				</sp>
@@ -1743,7 +1743,7 @@ convert to p3
 					<l>πῶς δειλὸς ὅστις σφογγιὰν ᾔτησά σε;</l>
 					<l>οὐκ ἂν ἕτερός γ’ αὔτ’ ἠργάσατ’ ἀνήρ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">ἀλλὰ τί;</l>
 				</sp>
@@ -1752,7 +1752,7 @@ convert to p3
 					<l>κατέκειτ’ ἂν ὀσφραινόμενος, εἴπερ δειλὸς ἦν·</l>
 					<l n="490">ἐγὼ δ’ ἀνέστην καὶ προσέτ’ ἀπεψησάμην.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἀνδρεῖά γ’ ὦ Πόσειδον.</l>
 				</sp>
@@ -1762,7 +1762,7 @@ convert to p3
 					<l>σὺ δ’ οὐκ ἔδεισας τὸν ψόφον τῶν ῥημάτων</l>
 					<l>καὶ τὰς ἀπειλάς;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">οὐ μὰ Δί’ οὐδ’ ἐφρόντισα.</l>
 				</sp>
@@ -1773,7 +1773,7 @@ convert to p3
 					<l>καὶ τὴν λεοντῆν, εἴπερ ἀφοβόσπλαγχνος εἶ·</l>
 					<l>ἐγὼ δ’ ἔσομαί σοι σκευοφόρος ἐν τῷ μέρει.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>φέρε δὴ ταχέως αὔτ’· οὐ γὰρ ἀλλὰ πειστέον·</l>
 					<l>καὶ βλέψον ἐς τὸν Ἡρακλειοξανθίαν,</l>
@@ -1793,7 +1793,7 @@ convert to p3
 					<l>ἔτνους δύ’ ἢ τρεῖς, βοῦν ἀπηνθράκιζ’ ὅλον,</l>
 					<l>πλακοῦντας ὤπτα κολλάβους. ἀλλ’ εἴσιθι.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>κάλλιστ’, ἐπαινῶ.</l>
 				</sp>
@@ -1805,7 +1805,7 @@ convert to p3
 					<l>ἔφρυγε, κᾦνον ἀνεκεράννυ γλυκύτατον.</l>
 					<l>ἀλλ’ εἴσιθ’ ἅμ’ ἐμοί.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">πάνυ καλῶς.</l>
 				</sp>
@@ -1816,7 +1816,7 @@ convert to p3
 					<l>ἥδ’ ἔνδον ἔσθ’ ὡραιοτάτη κὠρχηστρίδες</l>
 					<l n="515">ἕτεραι δύ’ ἢ τρεῖς.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">πῶς λέγεις; ὀρχηστρίδες;</l>
 				</sp>
@@ -1826,7 +1826,7 @@ convert to p3
 					<l>ἀλλ’ εἴσιθ’, ὡς ὁ μάγειρος ἤδη τὰ τεμάχη</l>
 					<l>ἔμελλ’ ἀφαιρεῖν χἠ τράπεζ’ εἰσῄρετο.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἴθι νυν φράσον πρώτιστα ταῖς ὀρχηστρίσιν</l>
 					<l n="520">ταῖς ἔνδον οὔσαις αὐτὸς ὅτι εἰσέρχομαι.</l>
@@ -1839,7 +1839,7 @@ convert to p3
 					<l>οὐ μὴ φλυαρήσεις ἔχων ὦ Ξανθία,</l>
 					<l n="525">ἀλλ’ ἀράμενος οἴσεις πάλιν τὰ στρώματα.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δ’ ἔστιν; οὔ τι πού μ’ ἀφελέσθαι διανοεῖ</l>
 					<l>ἅδωκας αὐτός;</l>
@@ -1849,7 +1849,7 @@ convert to p3
 					<l part="Y">οὐ τάχ’, ἀλλ’ ἤδη ποιῶ.</l>
 					<l>κατάθου τὸ δέρμα.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">ταῦτ’ ἐγὼ μαρτύρομαι</l>
 					<l>καὶ τοῖς θεοῖσιν ἐπιτρέπω.</l>
@@ -1860,14 +1860,14 @@ convert to p3
 					<l n="530">τὸ δὲ προσδοκῆσαί σ’ οὐκ ἀνόητον καὶ κενὸν</l>
 					<l>ὡς δοῦλος ὢν καὶ θνητὸς Ἀλκμήνης ἔσει;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἀμέλει καλῶς· ἔχ’ αὔτ’. ἴσως γάρ τοί ποτε</l>
 					<l>ἐμοῦ δεηθείης ἄν, εἰ θεὸς θέλοι.</l>
 					<milestone ed="p" n="534" unit="card"/>
 				</sp>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ταῦτα μὲν πρὸς ἀνδρός ἐστι</l>
 						<l>νοῦν ἔχοντος καὶ φρένας καὶ</l>
@@ -1898,7 +1898,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l>Πλαθάνη Πλαθάνη δεῦρ’ ἔλθ’, ὁ πανοῦργος οὑτοσί,</l>
 						<l n="550">ὃς ἐς τὸ πανδοκεῖον εἰσελθών ποτε</l>
@@ -1909,20 +1909,20 @@ convert to p3
 						<l part="Y">νὴ Δία</l>
 						<l>ἐκεῖνος αὐτὸς δῆτα.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">κακὸν ἥκει τινί.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l>καὶ κρέα γε πρὸς τούτοισιν ἀνάβραστ’ εἴκοσιν</l>
 						<l>ἀν’ ἡμιωβολιαῖα.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">δώσει τις δίκην.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l n="555">καὶ τὰ σκόροδα τὰ πολλά.</l>
 					</sp>
@@ -1931,7 +1931,7 @@ convert to p3
 						<l part="Y">ληρεῖς ὦ γύναι</l>
 						<l>κοὐκ οἶσθ’ ὅ τι λέγεις.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l part="Y">οὐ μὲν οὖν με προσεδόκας,</l>
 						<l>ὁτιὴ κοθόρνους εἶχες, ἂν γνῶναί σ’ ἔτι;</l>
@@ -1942,16 +1942,16 @@ convert to p3
 						<l>μὰ Δί’ οὐδὲ τὸν τυρόν γε τὸν χλωρὸν τάλαν,</l>
 						<l n="560">ὃν οὗτος αὐτοῖς τοῖς ταλάροις κατήσθιεν</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l>κἄπειτ’ ἐπειδὴ τἀργύριον ἐπραττόμην,</l>
 						<l>ἔβλεψεν ἔς με δριμὺ κἀμυκᾶτό γε.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>τούτου πάνυ τοὔργον· οὗτος ὁ τρόπος πανταχοῦ.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l>καὶ τὸ ξίφος γ’ ἐσπᾶτο μαίνεσθαι δοκῶν.</l>
 					</sp>
@@ -1959,13 +1959,13 @@ convert to p3
 						<speaker>Πλαθάνη</speaker>
 						<l n="565">νὴ Δία τάλαινα.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l part="Y">νὼ δὲ δεισάσα γέ που</l>
 						<l>ἐπὶ τὴν κατήλιφ’ εὐθὺς ἀνεπηδήσαμεν·</l>
 						<l>ὁ δ’ ᾤχετ’ ἐξᾴξας γε τὰς ψιάθους λαβών.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>καὶ τοῦτο τούτου τοὔργον.</l>
 					</sp>
@@ -1973,7 +1973,7 @@ convert to p3
 						<speaker>Πλαθάνη</speaker>
 						<l part="Y">ἀλλ’ ἐχρῆν τι δρᾶν.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l>ἴθι δὴ κάλεσον τὸν προστάτην Κλέωνά μοι.</l>
 					</sp>
@@ -1982,7 +1982,7 @@ convert to p3
 						<l n="570">σὺ δ’ ἔμοιγ’ ἐάνπερ ἐπιτύχῃς Ὑπέρβολον,</l>
 						<l>ἵν’ αὐτὸν ἐπιτρίψωμεν.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l part="Y">ὦ μιαρὰ φάρυξ,</l>
 						<l>ὡς ἡδέως ἄν σου λίθῳ τοὺς γομφίους</l>
@@ -1992,7 +1992,7 @@ convert to p3
 						<speaker>Πλαθάνη</speaker>
 						<l>ἐγὼ δέ γ’ ἐς τὸ βάραθρον ἐμβάλοιμί σε.</l>
 					</sp>
-					<sp who="#pandokeytria">
+					<sp who="#pandokeutria">
 						<speaker>Πανδοκευτρία</speaker>
 						<l n="575">ἐγὼ δὲ τὸν λάρυγγ’ ἂν ἐκτέμοιμί σου</l>
 						<l>δρέπανον λαβοῦσ’, ᾧ τὰς χόλικας κατέσπασας.</l>
@@ -2006,7 +2006,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>κάκιστ’ ἀπολοίμην, Ξανθίαν εἰ μὴ φιλῶ.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="580">οἶδ’ οἶδα τὸν νοῦν· παῦε παῦε τοῦ λόγου.</l>
 						<l>οὐκ ἂν γενοίμην Ἡρακλῆς ἄν.</l>
@@ -2016,7 +2016,7 @@ convert to p3
 						<l part="Y">μηδαμῶς</l>
 						<l>ὦ Ξανθίδιον.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">καὶ πῶς ἂν Ἀλκμήνης ἐγὼ</l>
 						<l>υἱὸς γενοίμην δοῦλος ἅμα καὶ θνητὸς ὤν;</l>
@@ -2029,14 +2029,14 @@ convert to p3
 						<l>πρόρριζος αὐτός, ἡ γυνή, τὰ παιδία,</l>
 						<l>κάκιστ’ ἀπολοίμην, κἀρχέδημος ὁ γλάμων.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>δέχομαι τὸν ὅρκον κἀπὶ τούτοις λαμβάνω.</l>
 						<milestone ed="p" n="590" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="590">νῦν σὸν ἔργον ἔστ’, ἐπειδὴ</l>
 						<l>τὴν στολὴν εἴληφας ἥνπερ</l>
@@ -2050,7 +2050,7 @@ convert to p3
 						<l>αὖθις αἴρεσθαί σ’ ἀνάγκη</l>
 						<l>’σται πάλιν τὰ στρώματα.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>οὐ κακῶς ὦνδρες παραινεῖτ’,</l>
 						<l>ἀλλὰ καὐτὸς τυγχάνω ταῦτ’</l>
@@ -2076,7 +2076,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">ἥκει τῳ κακόν.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>οὐκ ἐς κόρακας; μὴ πρόσιτον.</l>
 					</sp>
@@ -2099,7 +2099,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>σχέτλια μὲν οὖν καὶ δεινά.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">καὶ μὴν νὴ Δία</l>
 						<l>εἰ πώποτ’ ἦλθον δεῦρ’, ἐθέλω τεθνηκέναι,</l>
@@ -2112,7 +2112,7 @@ convert to p3
 						<speaker>Ἄιακος</speaker>
 						<l>καὶ πῶς βασανίσω;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">πάντα τρόπον, ἐν κλίμακι</l>
 						<l>δήσας κρεμάσας ὑστριχίδι μαστιγῶν, δέρων,</l>
@@ -2125,7 +2125,7 @@ convert to p3
 						<l>δίκαιος ὁ λόγος· κἄν τι πηρώσω γέ σου</l>
 						<l>τὸν παῖδα τύπτων, τἀργύριόν σοι κείσεται.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="625">μὴ δῆτ’ ἔμοιγ’. οὕτω δὲ βασάνιζ’ ἀπαγαγών.</l>
 					</sp>
@@ -2154,7 +2154,7 @@ convert to p3
 						<speaker>Ἄιακος</speaker>
 						<l part="Y">ταῦτ’ ἀκούεις;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">φήμ’ ἐγώ.</l>
 						<l>καὶ πολύ γε μᾶλλόν ἐστι μαστιγωτέος·</l>
@@ -2165,7 +2165,7 @@ convert to p3
 						<l n="635">τί δῆτ’, ἐπειδὴ καὶ σὺ φὴ|ς εἶναι θεός,</l>
 						<l>οὐ καὶ σὺ τύπτει τὰς ἴσας πληγὰς ἐμοί;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>δίκαιος ὁ λόγος· χὠπότερόν γ’ ἂν νῷν ἴδῃς</l>
 						<l>κλαύσαντα πρότερον ἢ προτιμήσαντά τι</l>
@@ -2176,7 +2176,7 @@ convert to p3
 						<l n="640">οὐκ ἔσθ’ ὅπως οὐκ εἶ σὺ γεννάδας ἀνήρ·</l>
 						<l>χωρεῖς γὰρ ἐς τὸ δίκαιον. ἀποδύεσθε δή.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>πῶς οὖν βασανιεῖς νὼ δικαίως;</l>
 					</sp>
@@ -2185,7 +2185,7 @@ convert to p3
 						<l part="Y">ῥᾳδίως·</l>
 						<l>πληγὴν παρὰ πληγὴν ἑκάτερον.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">καλῶς λέγεις.</l>
 					</sp>
@@ -2193,7 +2193,7 @@ convert to p3
 						<speaker>Ἄιακος</speaker>
 						<l>ἰδού.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">σκόπει νυν ἤν μ’ ὑποκινήσαντ’ ἴδῃς.</l>
 					</sp>
@@ -2201,7 +2201,7 @@ convert to p3
 						<speaker>Ἄιακος</speaker>
 						<l n="645">ἤδη ’πάταξά σ’.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">οὐ μὰ Δί’.</l>
 					</sp>
@@ -2226,7 +2226,7 @@ convert to p3
 						<speaker>Ἄιακος</speaker>
 						<l>οὐκ οἶδα· τουδὶ δ’ αὖθις ἀποπειράσομαι.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>οὔκουν ἀνύσεις τι; ἀτταταῖ.</l>
 					</sp>
@@ -2235,7 +2235,7 @@ convert to p3
 						<l part="Y">τί τἀτταταῖ;</l>
 						<l n="650">μῶν ὠδυνήθης;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">οὐ μὰ Δί’ ἀλλ’ ἐφρόντισα</l>
 						<l>ὁπόθ’ Ἡράκλεια τἀν Διομείοις γίγνεται.</l>
@@ -2276,7 +2276,7 @@ convert to p3
 						<speaker>Ἄιακος</speaker>
 						<l>βαδιστέον τἄρ’ ἐστὶν ἐπὶ τονδὶ πάλιν.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>οἴμοι.</l>
 					</sp>
@@ -2284,7 +2284,7 @@ convert to p3
 						<speaker>Ἄιακος</speaker>
 						<l part="Y">τί ἔστι;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">τὴν ἄκανθαν ἐξελε.</l>
 					</sp>
@@ -2296,7 +2296,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>Ἄπολλον—ὅς που Δῆλον ἢ Πυθῶν’ ἔχεις.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="660">ἤλγησεν· οὐκ ἤκουσας;</l>
 					</sp>
@@ -2305,7 +2305,7 @@ convert to p3
 						<l part="Y">οὐκ ἔγωγ’, ἐπεὶ</l>
 						<l>ἴαμβον Ἱππώνακτος ἀνεμιμνῃσκόμην.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>οὐδὲν ποιεῖς γάρ· ἀλλὰ τὰς λαγόνας σπόδει.</l>
 					</sp>
@@ -2317,7 +2317,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>Πόσειδον</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">ἤλγησέν τις.</l>
 					</sp>
@@ -2342,7 +2342,7 @@ convert to p3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="675">Μοῦσα χορῶν ἱερῶν· ἐπίβηθι καὶ ἔλθ’ ἐπὶ τέρψιν ἀοιδᾶς ἐμᾶς,</l>
 						<l>τὸν πολὺν ὀψομένη λαῶν· ὄχλον, οὗ σοφίαι</l>
@@ -2357,7 +2357,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν ἱερὸν χορὸν δίκαιόν ἐστι χρηστὰ τῇ πόλει</l>
 						<l>ξυμπαραινεῖν καὶ διδάσκειν. πρῶτον οὖν ἡμῖν δοκεῖ</l>
@@ -2383,7 +2383,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δ’ ἐγὼ ὀρθὸς ἰδεῖν βίον ἀνέρος ἢ τρόπον ὅστις ἔτ’</l>
 						<l>οἰμώξεται,</l>
@@ -2399,7 +2399,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλάκις γ’ ἡμῖν ἔδοξεν ἡ πόλις πεπονθέναι</l>
 						<l>ταὐτὸν ἔς τε τῶν πολιτῶν τοὺς καλούς τε κἀγαθοὺς</l>
@@ -2431,7 +2431,7 @@ convert to p3
 					<l>νὴ τὸν Δία τὸν σωτῆρα γεννάδας ἀνὴρ</l>
 					<l>ὁ δεσπότης σου.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">πῶς γὰρ οὐχὶ γεννάδας,</l>
 					<l n="740">ὅστις γε πίνειν οἶδε καὶ βινεῖν μόνον;</l>
@@ -2441,7 +2441,7 @@ convert to p3
 					<l>τὸ δὲ μὴ πατάξαι σ’ ἐξελεγχθέντ’ ἄντικρυς,</l>
 					<l>ὅτι δοῦλος ὢν ἔφασκες εἶναι δεσπότης.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ᾤμωξε μέντἄν.</l>
 				</sp>
@@ -2450,7 +2450,7 @@ convert to p3
 					<l part="Y">τοῦτο μέντοι δουλικὸν</l>
 					<l>εὐθὺς πεποίηκας, ὅπερ ἐγὼ χαίρω ποιῶν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="745">χαίρεις, ἱκετεύω;</l>
 				</sp>
@@ -2459,7 +2459,7 @@ convert to p3
 					<l part="Y">μἀλλ’ ἐποπτεύειν δοκῶ,</l>
 					<l>ὅταν καταράσωμαι λάθρᾳ τῷ δεσπότῃ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δὲ τονθορύζων, ἡνίκ’ ἂν πληγὰς λαβὼν</l>
 					<l>πολλὰς ἀπίῃς θύραζε;</l>
@@ -2468,7 +2468,7 @@ convert to p3
 					<speaker>Ἄιακος</speaker>
 					<l part="Y">καὶ τοῦθ’ ἥδομαι.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δὲ πολλὰ πράττων;</l>
 				</sp>
@@ -2476,7 +2476,7 @@ convert to p3
 					<speaker>Ἄιακος</speaker>
 					<l part="Y">ὡς μὰ Δί’ οὐδὲν οἶδ’ ἐγώ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="750">ὁμόγνιε Ζεῦ· καὶ παρακούων δεσποτῶν</l>
 					<l>ἅττ’ ἂν λαλῶσι;</l>
@@ -2485,7 +2485,7 @@ convert to p3
 					<speaker>Ἄιακος</speaker>
 					<l part="Y">μἀλλὰ πλεῖν ἢ μαίνομαι.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δὲ τοῖς θύραζε ταῦτα καταλαλῶν;</l>
 				</sp>
@@ -2494,7 +2494,7 @@ convert to p3
 					<l part="Y">ἐγώ;</l>
 					<l>μὰ Δί’ ἀλλ’ ὅταν δρῶ τοῦτο, κἀκμιαίνομαι.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ὦ Φοῖβ’ Ἄπολλον ἔμβαλέ μοι τὴν δεξιάν,</l>
 					<l n="755">καὶ δὸς κύσαι καὐτὸς κύσον, καί μοι φράσον</l>
@@ -2506,7 +2506,7 @@ convert to p3
 					<speaker>Ἄιακος</speaker>
 					<l part="Y">Αἰσχύλου κεὐριπίδου.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἆ.</l>
 				</sp>
@@ -2515,7 +2515,7 @@ convert to p3
 					<l part="Y">πρᾶγμα πρᾶγμα μέγα κεκίνηται μέγα</l>
 					<l n="760">ἐν τοῖς νεκροῖσι καὶ στάσις πολλὴ πάνυ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἐκ τοῦ;</l>
 				</sp>
@@ -2527,7 +2527,7 @@ convert to p3
 					<l>σίτησιν αὐτὸν ἐν πρυτανείῳ λαμβάνειν</l>
 					<l n="765">θρόνον τε τοῦ Πλούτωνος ἑξῆς—</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">μανθάνω.</l>
 				</sp>
@@ -2536,7 +2536,7 @@ convert to p3
 					<l>ἕως ἀφίκοιτο τὴν τέχνην σοφώτερος</l>
 					<l>ἕτερός τις αὐτοῦ· τότε δὲ παραχωρεῖν ἔδει.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δῆτα τουτὶ τεθορύβηκεν Αἰσχύλον;</l>
 				</sp>
@@ -2545,7 +2545,7 @@ convert to p3
 					<l>ἐκεῖνος εἶχε τὸν τραγῳδικὸν θρόνον,</l>
 					<l n="770">ὡς ὢν κράτιστος τὴν τέχνην.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">νυνὶ δὲ τίς;</l>
 				</sp>
@@ -2560,7 +2560,7 @@ convert to p3
 					<l>κἄπειτ’ ἐπαρθεὶς ἀντελάβετο τοῦ θρόνου,</l>
 					<l>ἵν’ Αἰσχύλος καθῆστο.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">κοὐκ ἐβάλλετο;</l>
 				</sp>
@@ -2569,7 +2569,7 @@ convert to p3
 					<l>μὰ Δί’ ἀλλ’ ὁ δῆμος ἀνεβόα κρίσιν ποιεῖν</l>
 					<l n="780">ὁπότερος εἴη τὴν τέχνην σοφώτερος.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ὁ τῶν πανούργων;</l>
 				</sp>
@@ -2577,7 +2577,7 @@ convert to p3
 					<speaker>Ἄιακος</speaker>
 					<l part="Y">νὴ Δί’ οὐράνιόν γ’ ὅσον.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>μετ’ Αἰσχύλου δ’ οὐκ ἦσαν ἕτεροι σύμμαχοι;</l>
 				</sp>
@@ -2585,7 +2585,7 @@ convert to p3
 					<speaker>Ἄιακος</speaker>
 					<l>ὀλίγον τὸ χρηστόν ἐστιν, ὥσπερ ἐνθάδε.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δῆθ’ ὁ Πλούτων δρᾶν παρασκευάζεται;</l>
 				</sp>
@@ -2594,7 +2594,7 @@ convert to p3
 					<l n="785">ἀγῶνα ποιεῖν αὐτίκα μάλα καὶ κρίσιν</l>
 					<l>κἄλεγχον αὐτῶν τῆς τέχνης.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">κἄπειτα πῶς</l>
 					<l>οὐ καὶ Σοφοκλέης ἀντελάβετο τοῦ θρόνου;</l>
@@ -2610,7 +2610,7 @@ convert to p3
 					<l>ἕξειν κατὰ χώραν· εἰ δὲ μή, περὶ τῆς τέχνης</l>
 					<l>διαγωνιεῖσθ’ ἔφασκε πρός γ’ Εὐριπίδην.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="795">τὸ χρῆμ’ ἄρ’ ἔσται;</l>
 				</sp>
@@ -2620,7 +2620,7 @@ convert to p3
 					<l>κἀνταῦθα δὴ τὰ δεινὰ κινηθήσεται.</l>
 					<l>καὶ γὰρ ταλάντῳ μουσικὴ σταθμήσεται—</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>τί δέ; μειαγωγήσουσι τὴν τραγῳδίαν;</l>
 				</sp>
@@ -2629,7 +2629,7 @@ convert to p3
 					<l>καὶ κανόνας ἐξοίσουσι καὶ πήχεις ἐπῶν</l>
 					<l n="800">καὶ πλαίσια ξύμπτυκτα—</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">πλινθεύσουσι γάρ;</l>
 				</sp>
@@ -2638,7 +2638,7 @@ convert to p3
 					<l>καὶ διαμέτρους καὶ σφῆνας. ὁ γὰρ Εὐριπίδης</l>
 					<l>κατ’ ἔπος βασανιεῖν φησι τὰς τραγῳδίας.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἦ που βαρέως οἶμαι τὸν Αἰσχύλον φέρειν.</l>
 				</sp>
@@ -2646,7 +2646,7 @@ convert to p3
 					<speaker>Ἄιακος</speaker>
 					<l>ἔβλεψε γοῦν ταυρηδὸν ἐγκύψας κάτω.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="805">κρινεῖ δὲ δὴ τίς ταῦτα;</l>
 				</sp>
@@ -2656,7 +2656,7 @@ convert to p3
 					<l>σοφῶν γὰρ ἀνδρῶν ἀπορίαν ηὑρισκέτην.</l>
 					<l>οὔτε γὰρ Ἀθηναίοισι συνέβαιν’ Αἰσχύλος—</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>πολλοὺς ἴσως ἐνόμιζε τοὺς τοιχωρύχους.</l>
 				</sp>
@@ -2672,7 +2672,7 @@ convert to p3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ που δεινὸν ἐριβρεμέτας χόλον ἔνδοθεν ἕξει,</l>
 						<l n="815">ἡνίκ’ ἂν ὀξύλαλον παρίδῃ θήγοντος ὀδόντα</l>
@@ -2682,7 +2682,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔσται δ’ ἱππολόφων τε λόγων κορυθαίολα νείκη</l>
 						<l>σχινδαλάμων τε παραξόνια σμιλεύματά τ’ ἔργων,</l>
@@ -2692,7 +2692,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φρίξας δ’ αὐτοκόμου λοφιᾶς λασιαύχενα χαίταν,</l>
 						<l>δεινὸν ἐπισκύνιον ξυνάγων βρυχώμενος ἥσει</l>
@@ -2702,7 +2702,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔνθεν δὴ στοματουργὸς ἐπῶν βασανίστρια λίσφη</l>
 						<l>γλῶσσ’ ἀνελισσομένη φθονεροὺς κινοῦσα χαλινοὺς</l>
@@ -2713,7 +2713,7 @@ convert to p3
 				</div2>
 			</div1>
 			<div1 type="Lyric-Scene">
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="830">οὐκ ἂν μεθείμην τοῦ θρόνου, μὴ νουθέτει.</l>
 					<l>κρείττων γὰρ εἶναί φημι τούτου τὴν τέχνην.</l>
@@ -2722,7 +2722,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>Αἰσχύλε τί σιγᾷς; αἰσθάνει γὰρ τοῦ λόγου.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἀποσεμνυνεῖται πρῶτον, ἅπερ ἑκάστοτε</l>
 					<l>ἐν ταῖς τραγῳδίαισιν ἐτερατεύετο.</l>
@@ -2731,14 +2731,14 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="835">ὦ δαιμόνῑ ἀνδρῶν μὴ μεγάλα λίαν λέγε.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἐγᾦδα τοῦτον καὶ διέσκεμμαι πάλαι,</l>
 					<l>ἄνθρωπον ἀγριοποιὸν αὐθαδόστομον,</l>
 					<l>ἔχοντ’ ἀχάλινον ἀκρατὲς ἀπύλωτον στόμα,</l>
 					<l>ἀπεριλάλητον κομποφακελορρήμονα.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l n="840">ἄληθες ὦ παῖ τῆς ἀρουραίας θεοῦ;</l>
 					<l>σὺ δή με ταῦτ’ ὦ στωμυλιοσυλλεκτάδη</l>
@@ -2750,7 +2750,7 @@ convert to p3
 					<l part="Y">παῦ’ Αἰσχύλε,</l>
 					<l>καὶ μὴ πρὸς ὀργὴν σπλάγχνα θερμήνῃς κότῳ.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l n="845">οὐ δῆτα πρίν γ’ ἂν τοῦτον ἀποφήνω σαφῶς</l>
 					<l>τὸν χωλοποιὸν οἷος ὢν θρασύνεται.</l>
@@ -2760,7 +2760,7 @@ convert to p3
 					<l>ἄρν’ ἄρνα μέλανα παῖδες ἐξενέγκατε·</l>
 					<l>τυφὼς γὰρ ἐκβαίνειν παρασκευάζεται.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>ὦ Κρητικὰς μὲν συλλέγων μονῳδίας,</l>
 					<l n="850">γάμους δ’ ἀνοσίους ἐσφέρων ἐς τὴν τέχνην.</l>
@@ -2778,7 +2778,7 @@ convert to p3
 					<l>σὺ δ’ εὐθὺς ὥσπερ πρῖνος ἐμπρησθεὶς βοᾷς.</l>
 					<milestone ed="p" n="860" unit="card"/>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="860">ἕτοιμός εἰμ’ ἔγωγε, κοὐκ ἀναδύομαι,</l>
 					<l>δάκνειν δάκνεσθαι πρότερος, εἰ τούτῳ δοκεῖ,</l>
@@ -2790,7 +2790,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="865">τί δαὶ σὺ βουλεύει ποιεῖν; λέγ’ Αἰσχύλε.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>ἐβουλόμην μὲν οὐκ ἐρίζειν ἐνθάδε·</l>
 					<l>οὐκ ἐξ ἴσου γάρ ἐστιν ἁγὼν νῷν.</l>
@@ -2799,7 +2799,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">τί δαί;</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>ὅτι ἡ ποίησις οὐχὶ συντέθνηκέ μοι,</l>
 					<l>τούτῳ δὲ συντέθνηκεν, ὥσθ’ ἕξει λέγειν.</l>
@@ -2813,7 +2813,7 @@ convert to p3
 					<l>ὑμεῖς δὲ ταῖς Μούσαις τι μέλος ὑπᾴσατε.</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="875">ὦ Διὸς ἐννέα παρθένοι ἁγναὶ</l>
 						<l>Μοῦσαι, λεπτολόγους ξυνετὰς φρένας αἳ καθορᾶτε</l>
@@ -2828,7 +2828,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l n="885">εὔχεσθε δὴ καὶ σφώ τι πρὶν τἄπη λέγειν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>Δήμητερ ἡ θρέψασα τὴν ἐμὴν φρένα,</l>
 						<l>εἶναί με τῶν σῶν ἄξιον μυστηρίων.</l>
@@ -2837,7 +2837,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ἐπίθες λαβὼν δὴ καὶ σὺ λιβανωτόν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">καλῶς·</l>
 						<l>ἕτεροι γάρ εἰσιν οἷσιν εὔχομαι θεοῖς.</l>
@@ -2846,7 +2846,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l n="890">ἴδιοί τινές σοι, κόμμα καινόν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">καὶ μάλα.</l>
 					</sp>
@@ -2854,7 +2854,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ἴθι δὴ προσεύχου τοῖσιν ἰδιώταις θεοῖς.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>αἰθὴρ ἐμὸν βόσκημα καὶ γλώσσης στρόφιγξ</l>
 						<l>καὶ ξύνεσι καὶ μυκτῆρες ὀσφραντήριοι,</l>
@@ -2865,7 +2865,7 @@ convert to p3
 			</div1>
 			<div1 type="Agon">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ἡμεῖς ἐπιθυμοῦμεν</l>
 						<l>παρὰ σοφοῖν ἀνδροῖν ἀκοῦσαι</l>
@@ -2893,7 +2893,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="Epirrheme">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>καὶ μὴν ἐμαυτὸν μέν γε τὴν ποίησιν οἷός εἰμι,</l>
 						<l>ἐν τοῖσιν ὑστάτοις φράσω, τοῦτον δὲ πρῶτ’ ἐλέγξω,</l>
@@ -2907,7 +2907,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>μὰ τὸν Δί’ οὐ δῆθ’.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ὁ δὲ χορός γ’ ἤρειδεν ὁρμαθοὺς ἂν</l>
 						<l n="915">μελῶν ἐφεξῆς τέτταρας ξυνεχῶς ἄν οἱ δ’ ἐσίγων.</l>
@@ -2917,7 +2917,7 @@ convert to p3
 						<l>ἐγὼ δ’ ἔχαιρον τῇ σιωπῇ, καί με τοῦτ’ ἔτερπεν</l>
 						<l>οὐχ ἧττον ἢ νῦν οἱ λαλοῦντες.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ἠλίθιος γὰρ ἦσθα,</l>
 						<l>σάφ’ ἴσθι.</l>
@@ -2926,7 +2926,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">κἀμαυτῷ δοκῶ. τί δὲ ταῦτ’ ἔδρασ’ ὁ δεῖνα;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὑπ’ ἀλαζονείας, ἵν’ ὁ θεατὴς προσδοκῶν καθοῖτο,</l>
 						<l n="920">ὁπόθ’ ἡ Νιόβη τι φθέγξεται· τὸ δρᾶμα δ’ ἂν διῄει.</l>
@@ -2936,7 +2936,7 @@ convert to p3
 						<l>ὢ παμπόνηρος, οἷ’ ἄρ’ ἐφενακιζόμην ὑπ’ αὐτοῦ.</l>
 						<l>τί σκορδινᾷ καὶ δυσφορεῖς;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ὅτι αὐτὸν ἐξελέγχω.</l>
 						<l>κἄπειτ’ ἐπειδὴ ταῦτα ληρήσειε καὶ τὸ δρᾶμα</l>
@@ -2944,7 +2944,7 @@ convert to p3
 						<l n="925">ὀφρῦς ἔχοντα καὶ λόφους, δείν’ ἄττα μορμορωπά,</l>
 						<l>ἄγνωτα τοῖς θεωμένοις.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">οἴμοι τάλας.</l>
 					</sp>
@@ -2952,7 +2952,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">σιώπα.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>σαφὲς δ’ ἂν εἶπεν οὐδὲ ἕν—</l>
 					</sp>
@@ -2960,7 +2960,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">μὴ πρῖε τοὺς ὀδόντας.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀλλ’ ἢ Σκαμάνδρους ἢ τάφρους ἢ ’π’ ἀσπίδων ἐπόντας</l>
 						<l>γρυπαιέτους χαλκηλάτους καὶ ῥήμαθ’ ἱππόκρημνα,</l>
@@ -2972,7 +2972,7 @@ convert to p3
 						<l>ἤδη ποτ’ ἐν μακρῷ χρόνῳ νυκτὸς διηγρύπνησα</l>
 						<l>τὸν ξουθὸν ἱππαλεκτρυόνα ζητῶν τίς ἐστιν ὄρνις.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>σημεῖον ἐν ταῖς ναυσὶν ὦμαθέστατ’ ἐνεγέγραπτο.</l>
 					</sp>
@@ -2980,16 +2980,16 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ἐγὼ δὲ τὸν Φιλοξένου γ’ ᾤμην Ἔρυξιν εἶναι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="935">εἶτ’ ἐν τραγῳδίαις ἐχρῆν κἀλεκτρυόνα ποιῆσαι;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>σὺ δ’ ὦ θεοῖσιν ἐχθρὲ ποῖ’ ἄττ’ ἐστὶν ἅττ’ ἐποίεις;</l>
 						<milestone ed="p" n="937" unit="card"/>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>οὐχ ἱππαλεκτρυόνας μὰ Δί’ οὐδὲ τραγελάφους, ἅπερ σύ,</l>
 						<l>ἃν τοῖσι παραπετάσμασιν τοῖς Μηδικοῖς γράφουσιν·</l>
@@ -3004,7 +3004,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">Κηφισοφῶντα μιγνύς.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="945">εἶτ’ οὐκ ἐλήρουν ὅ τι τύχοιμ’ οὐδ’ ἐμπεσὼν ἔφυρον,</l>
 						<l>ἀλλ’ οὑξιὼν πρώτιστα μέν μοι τὸ γένος εἶπ’ ἂν εὐθὺς</l>
@@ -3014,18 +3014,18 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">κρεῖττον γὰρ ἦν σοι νὴ Δί’ ἢ τὸ σαυτοῦ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἔπειτ’ ἀπὸ τῶν πρώτων ἐπῶν οὐδὲν παρῆκ’ ἂν ἀργόν,</l>
 						<l>ἀλλ’ ἔλεγεν ἡ γυνή τέ μοι χὠ δοῦλος οὐδὲν ἧττον,</l>
 						<l n="950">χὠ δεσπότης χἠ παρθένος χἠ γραῦς ἄν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">εἶτα δῆτα</l>
 						<l>οὐκ ἀποθανεῖν σε ταῦτ’ ἐχρῆν τολμῶντα;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">μὰ τὸν Ἀπόλλω·</l>
 						<l>δημοκρατικὸν γὰρ αὔτ’ ἔδρων.</l>
@@ -3035,26 +3035,26 @@ convert to p3
 						<l part="Y">τοῦτο μὲν ἔασον ὦ τᾶν.</l>
 						<l>οὐ σοὶ γάρ ἐστι περίπατος κάλλιστα περί γε τούτου.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἔπειτα τουτουσὶ λαλεῖν ἐδίδαξα—</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">φημὶ κἀγώ.</l>
 						<l n="955">ὡς πρὶν διδάξαι γ’ ὤφελες μέσος διαρραγῆναι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>λεπτῶν τε κανόνων ἐσβολὰς ἐπῶν τε γωνιασμούς,</l>
 						<l>νοεῖν ὁρᾶν ξυνιέναι στρέφειν ἐρᾶν τεχνάζειν,</l>
 						<l>κάχ’ ὑποτοπεῖσθαι, περινοεῖν ἅπαντα—</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">φημὶ κἀγώ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>οἰκεῖα πράγματ’ εἰσάγων, οἷς χρώμεθ’, οἷς ξύνεσμεν,</l>
 						<l n="960">ἐξ ὧν γ’ ἂν ἐξηλεγχόμην· ξυνειδότες γὰρ οὗτοι</l>
@@ -3075,7 +3075,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="Pnigos">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τοιαῦτα μέντοὐγὼ φρονεῖν</l>
 						<l>τούτοισιν εἰσηγησάμην,</l>
@@ -3105,7 +3105,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάδε μὲν λεύσσεις φαίδιμ’ Ἀχιλλεῦ·</l>
 						<l>σὺ δὲ τί φέρε πρὸς ταῦτα λέξεις;</l>
@@ -3133,18 +3133,18 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="Antepirrheme">
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l n="1006">θυμοῦμαι μὲν τῇ ξυντυχίᾳ, καὶ μου τὰ σπλάγχν’ ἀγανακτεῖ,</l>
 						<l>εἰ πρὸς τοῦτον δεῖ μ’ ἀντιλέγειν· ἵνα μὴ φάσκῃ δ’ ἀπορεῖν με,</l>
 						<l>ἀπόκριναί μοι, τίνος οὕνεκα χρὴ θαυμάζειν ἄνδρα ποιητήν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>δεξιότητος καὶ νουθεσίας, ὅτι βελτίους τε ποιοῦμεν</l>
 						<l n="1010">τοὺς ἀνθρώπους ἐν ταῖς πόλεσιν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">τοῦτ’ οὖν εἰ μὴ πεποίηκας,</l>
 						<l>ἀλλ’ ἐκ χρηστῶν καὶ γενναίων μοχθηροτάτους ἀπέδειξας,</l>
@@ -3154,7 +3154,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">τεθνάναι· μὴ τοῦτον ἐρώτα.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>σκέψαι τοίνυν οἵους αὐτοὺς παρ’ ἐμοῦ παρεδέξατο πρῶτον,</l>
 						<l>εἰ γενναίους καὶ τετραπήχεις, καὶ μὴ διαδρασιπολίτας,</l>
@@ -3166,7 +3166,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>καὶ δὴ χωρεῖ τουτὶ τὸ κακόν· κρανοποιῶν αὖ μ’ ἐπιτρίψει.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>καὶ τί σὺ δράσας οὕτως αὐτοὺς γενναίους ἐξεδίδαξας;</l>
 					</sp>
@@ -3174,7 +3174,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l n="1020">Αἰσχύλε λέξον, μηδ’ αὐθάδως σεμνυνόμενος χαλέπαινε.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>δρᾶμα ποιήσας Ἄρεως μεστόν.</l>
 					</sp>
@@ -3182,7 +3182,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">ποῖον;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">τοὺς ἕπτ’ ἐπὶ Θήβας·</l>
 						<l>ὃ θεασάμενος πᾶς ἄν τις ἀνὴρ ἠράσθη δάιος εἶναι.</l>
@@ -3192,7 +3192,7 @@ convert to p3
 						<l>τουτὶ μέν σοι κακὸν εἴργασται· Θηβαίους γὰρ πεποίηκας</l>
 						<l>ἀνδρειοτέρους ἐς τὸν πόλεμον, καὶ τούτου γ’ οὕνεκα τύπτου.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l n="1025">ἀλλ’ ὑμῖν αὔτ’ ἐξῆν ἀσκεῖν, ἀλλ’ οὐκ ἐπὶ τοῦτ’ ἐτράπεσθε.</l>
 						<l>εἶτα διδάξας Πέρσας μετὰ τοῦτ’ ἐπιθυμεῖν ἐξεδίδαξα</l>
@@ -3203,7 +3203,7 @@ convert to p3
 						<l>ἐχάρην γοῦν, †ἡνίκ’ ἤκουσα περὶ Δαρείου τεθνεῶτος,†</l>
 						<l>ὁ χορὸς δ’ εὐθὺς τὼ χεῖρ’ ὡδὶ συγκρούσας εἶπεν ‘ἰαυοῖ.’</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l n="1030">ταῦτα γὰρ ἄνδρας χρὴ ποιητὰς ἀσκεῖν. σκέψαι γὰρ ἀπ’ ἀρχῆς</l>
 						<l>ὡς ὠφέλιμοι τῶν ποιητῶν οἱ γενναῖοι γεγένηνται.</l>
@@ -3219,7 +3219,7 @@ convert to p3
 						<l>ἐδίδαξεν ὅμως τὸν σκαιότατον· πρώην γοῦν, ἡνίκ’ ἔπεμπεν,</l>
 						<l>τὸ κράνος πρῶτον περιδησάμενος τὸν λόφον ἤμελλ’ ἐπιδήσειν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>ἀλλ’ ἄλλους τοι πολλοὺς ἀγαθούς, ὧν ἦν καὶ Λάμαχος ἥρως·</l>
 						<l n="1040">ὅθεν ἡμὴ φρὴν ἀπομαξαμένη πολλὰς ἀρετὰς ἐποίησεν,</l>
@@ -3229,11 +3229,11 @@ convert to p3
 						<l>οὐδ’ οἶδ’ οὐδεὶς ἥντιν’ ἐρῶσαν πώποτ’ ἐποίησα γυναῖκα.</l>
 						<milestone ed="p" n="1045" unit="card"/>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1045">μὰ Δί’ οὐ γὰρ ἐπῆν τῆς Ἀφροδίτης οὐδέν σοι.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">μηδέ γ’ ἐπείη.</l>
 						<l>ἀλλ’ ἐπί τοι σοὶ καὶ τοῖς σοῖσιν πολλὴ πολλοῦ ’πικαθῆτο,</l>
@@ -3244,33 +3244,33 @@ convert to p3
 						<l part="Y">νὴ τὸν Δία τοῦτό γέ τοι δή.</l>
 						<l>ἃ γὰρ ἐς τὰς ἀλλοτρίας ἐποίεις, αὐτὸς τούτοισιν ἐπλήγης.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>καὶ τί βλάπτουσ’ ὦ σχέτλῑ ἀνδρῶν τὴν πόλιν ἁμαὶ Σθενέβοιαι;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l n="1050">ὅτι γενναίας καὶ γενναίων ἀνδρῶν ἀλόχους ἀνέπεισας</l>
 						<l>κώνεια πιεῖν αἰσχυνθείσας διὰ τοὺς σοὺς Βελλεροφόντας.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>πότερον δ’ οὐκ ὄντα λόγον τοῦτον περὶ τῆς Φαίδρας ξυνέθηκα;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>μὰ Δί’ ἀλλ’ ὄντ’· ἀλλ’ ἀποκρύπτειν χρὴ τὸ πονηρὸν τόν γε ποιητήν,</l>
 						<l>καὶ μὴ παράγειν μηδὲ διδάσκειν. τοῖς μὲν γὰρ παιδαρίοισιν</l>
 						<l n="1055">ἔστι διδάσκαλος ὅστις φράζει, τοῖσιν δ’ ἡβῶσι ποιηταί.</l>
 						<l>πάνυ δὴ δεῖ χρηστὰ λέγειν ἡμᾶς.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ἢν οὖν σὺ λέγῃς Λυκαβηττοὺς</l>
 						<l>καὶ Παρνασσῶν ἡμῖν μεγέθη, τοῦτ’ ἐστὶ τὸ χρηστὰ διδάσκειν,</l>
 						<l>ὃν χρῆν φράζειν ἀνθρωπείως;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">ἀλλ’ ὦ κακόδαιμον ἀνάγκη</l>
 						<l>μεγάλων γνωμῶν καὶ διανοιῶν ἴσα καὶ τὰ ῥήματα τίκτειν.</l>
@@ -3278,20 +3278,20 @@ convert to p3
 						<l>καὶ γὰρ τοῖς ἱματίοις ἡμῶν χρῶνται πολὺ σεμνοτέροισιν.</l>
 						<l>ἁμοῦ χρηστῶς καταδείξαντος διελυμήνω σύ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τί δράσας;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>πρῶτον μὲν τοὺς βασιλεύοντας ῥάκῑ ἀμπισχών, ἵν’ ἐλεινοὶ</l>
 						<l>τοῖς ἀνθρώποις φαίνοιντ’ εἶναι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τοῦτ’ οὖν ἔβλαψά τι δράσας;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l n="1065">οὔκουν ἐθέλει γε τριηραρχεῖν πλουτῶν οὐδεὶς διὰ ταῦτα,</l>
 						<l>ἀλλὰ ῥακίοις περιειλάμενος κλάει καὶ φησὶ πένεσθαι.</l>
@@ -3301,7 +3301,7 @@ convert to p3
 						<l>νὴ τὴν Δήμητρα χιτῶνά γ’ ἔχων οὔλων ἐρίων ὑπένερθεν.</l>
 						<l>κἂν ταῦτα λέγων ἐξαπατήσῃ, παρὰ τοὺς ἰχθῦς ἀνέκυψεν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>εἶτ’ αὖ λαλιὰν ἐπιτηδεῦσαι καὶ στωμυλίαν ἐδίδαξας,</l>
 						<l n="1070">ἣ ’ξεκένωσεν τάς τε παλαίστρας καὶ τὰς πυγὰς ἐνέτριψεν</l>
@@ -3318,7 +3318,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="Antipnigos">
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>ποίων δὲ κακῶν οὐκ αἴτιός ἐστ’;</l>
 						<l>οὐ προαγωγοὺς κατέδειξ’ οὗτος,</l>
@@ -3350,7 +3350,7 @@ convert to p3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μέγα τὸ πρᾶγμα, πολὺ τὸ νεῖκος, ἁδρὸς ὁ πόλεμος ἔρχεται.</l>
 						<l n="1100">χαλεπὸν οὖν ἔργον διαιρεῖν,</l>
@@ -3366,7 +3366,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δὲ τοῦτο καταφοβεῖσθον, μή τις ἀμαθία προσῇ</l>
 						<l n="1110">τοῖς θεωμένοισιν, ὡς τὰ</l>
@@ -3383,7 +3383,7 @@ convert to p3
 				</div2>
 			</div1>
 			<div1 type="Lyric-Scene">
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>καὶ μὴν ἐπ’ αὐτοὺς τοὺς προλόγους σου τρέψομαι,</l>
 					<l n="1120">ὅπως τὸ πρῶτον τῆς τραγῳδίας μέρος</l>
@@ -3394,7 +3394,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>καὶ ποῖον αὐτοῦ βασανιεῖς;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">πολλοὺς πάνυ.</l>
 					<l>πρῶτον δέ μοι τὸν ἐξ Ὀρεστείας λέγε.</l>
@@ -3403,7 +3403,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="1125">ἄγε δὴ σιώπα πᾶς ἀνήρ. λέγ’ Αἰσχύλε.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>‘Ἑρμῆ χθόνιε πατρῷ’ ἐποπτεύων κράτη,</l>
 					<l>σωτὴρ γενοῦ μοι σύμμαχός τ’ αἰτουμένῳ.</l>
@@ -3413,7 +3413,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>τούτων ἔχεις ψέγειν τι;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">πλεῖν ἢ δώδεκα.</l>
 				</sp>
@@ -3421,7 +3421,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="1130">ἀλλ’ οὐδὲ πάντα ταῦτά γ’ ἔστ’ ἀλλ’ ἢ τρία.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἔχει δ’ ἕκαστον εἴκοσίν γ’ ἁμαρτίας.</l>
 				</sp>
@@ -3430,7 +3430,7 @@ convert to p3
 					<l>Αἰσχύλε παραινῶ σοι σιωπᾶν· εἰ δὲ μή,</l>
 					<l>πρὸς τρισὶν ἰαμβείοισι προσοφείλων φανεῖ.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>ἐγὼ σιωπῶ τῷδ’;</l>
 				</sp>
@@ -3438,11 +3438,11 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἐὰν πείθῃ γ’ ἐμοί.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1135">εὐθὺς γὰρ ἡμάρτηκεν οὐράνιόν γ’ ὅσον.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>ὁρᾷς ὅτι ληρεῖς;</l>
 				</sp>
@@ -3450,40 +3450,40 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἀλλ’ ὀλίγον γέ μοι μέλει.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>πῶς φῄς μ’ ἁμαρτεῖν;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">αὖθις ἐξ ἀρχῆς λέγε.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>‘Ἑρμῆ χθόνιε πατρῷ’ ἐποπτεύων κράτη.’</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>οὔκουν Ὀρέστης τοῦτ’ ἐπὶ τῷ τύμβῳ λέγει</l>
 					<l n="1140">τῷ τοῦ πατρὸς τεθνεῶτος;</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">οὐκ ἄλλως λέγω.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>πότερ’ οὖν τὸν Ἑρμῆν, ὡς ὁ πατὴρ ἀπώλετο</l>
 					<l>αὐτοῦ βιαίως ἐκ γυναικείας χερὸς</l>
 					<l>δόλοις λαθραίοις, ταῦτ’ ‘ἐποπτεύειν’ ἔφη;</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>οὐ δῆτ’ ἐκεῖνον, ἀλλὰ τὸν Ἐριούνιον</l>
 					<l n="1145">Ἑρμῆν χθόνιον προσεῖπε, κἀδήλου λέγων</l>
 					<l>ὁτιὴ πατρῷον τοῦτο κέκτηται γέρας—</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἔτι μεῖζον ἐξήμαρτες ἢ ’γὼ ’βουλόμην·</l>
 					<l>εἰ γὰρ πατρῷον τὸ χθόνιον ἔχει γέρας—</l>
@@ -3492,7 +3492,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>οὕτω γ’ ἂν εἴη πρὸς πατρὸς τυμβωρύχος.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l n="1150">Διόνυσε πίνεις οἶνον οὐκ ἀνθοσμίαν.</l>
 				</sp>
@@ -3500,12 +3500,12 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>λέγ’ ἕτερον αὐτῷ· σὺ δ’ ἐπιτήρει τὸ βλάβος.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>‘σωτὴρ γενοῦ μοι σύμμαχός τ’ αἰτουμένῳ.</l>
 					<l>ἥκω γὰρ ἐς γῆν τήνδε καὶ κατέρχομαι—’</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>δὶς ταὐτὸν ἡμῖν εἶπεν ὁ σοφὸς Αἰσχύλος.</l>
 				</sp>
@@ -3513,7 +3513,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="1155">πῶς δίς;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">σκόπει τὸ ῥῆμ’· ἐγὼ δέ σοι φράσω.</l>
 					<l>‘ἥκω γὰρ ἐς γῆν,’ φησί, ‘καὶ κατέρχομαι·’</l>
@@ -3525,16 +3525,16 @@ convert to p3
 					<l>νὴ τὸν Δί’ ὥσπερ γ’ εἴ τις εἴποι γείτονι,</l>
 					<l>‘χρῆσον σὺ μάκτραν, εἰ δὲ βούλει, κάρδοπον.’</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l n="1160">οὐ δῆτα τοῦτό γ’ ὦ κατεστωμυλμένε</l>
 					<l>ἄνθρωπε ταὔτ’ ἔστ’, ἀλλ’ ἄριστ’ ἐπῶν ἔχον.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>πῶς δή; δίδαξον γάρ με καθ’ ὅ τι δὴ λέγεις;</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>‘ἐλθεῖν’ μὲν ἐς γῆν ἔσθ’ ὅτῳ μετῇ πάτρας·</l>
 					<l>χωρὶς γὰρ ἄλλης συμφορᾶς ἐλήλυθεν·</l>
@@ -3544,7 +3544,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>εὖ νὴ τὸν Ἀπόλλω. τί σὺ λέγεις Εὐριπίδη;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>οὐ φημὶ τὸν Ὀρέστην κατελθεῖν οἴκαδε·</l>
 					<l>λάθρᾳ γὰρ ἦλθεν οὐ πιθὼν τοὺς κυρίους.</l>
@@ -3553,7 +3553,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>εὖ νὴ τὸν Ἑρμῆν· ὅ τι λέγεις δ’ οὐ μανθάνω.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1170">πέραινε τοίνυν ἕτερον.</l>
 				</sp>
@@ -3562,12 +3562,12 @@ convert to p3
 					<l part="Y">ἴθι πέραινε σὺ</l>
 					<l>Αἰσχύλ’ ἀνύσας· σὺ δ’ ἐς τὸ κακὸν ἀπόβλεπε.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>‘τύμβου δ’ ἐπ’ ὄχθῳ τῷδε κηρύσσω πατρὶ</l>
 					<l>κλύειν ἀκοῦσαι.’</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">τοῦθ’ ἕτερον αὖθις λέγει,</l>
 					<l>‘κλύειν ἀκοῦσαι,’ ταὐτὸν ὂν σαφέστατα.</l>
@@ -3577,11 +3577,11 @@ convert to p3
 					<l n="1175">τεθνηκόσιν γὰρ ἔλεγεν ὦ μόχθηρε σύ,</l>
 					<l>οἷς οὐδὲ τρὶς λέγοντες ἐξικνούμεθα.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>σὺ δὲ πῶς ἐποίεις τοὺς προλόγους;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">ἐγὼ φράσω.</l>
 					<l>κἄν που δὶς εἴπω ταὐτόν, ἢ στοιβὴν ἴδῃς</l>
@@ -3592,22 +3592,22 @@ convert to p3
 					<l n="1180">ἴθι δὴ λέγ’· οὐ γάρ μοὔστιν ἀλλ’ ἀκουστέα</l>
 					<l>τῶν σῶν προλόγων τῆς ὀρθότητος τῶν ἐπῶν.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>‘ἦν Οἰδίπους τὸ πρῶτον εὐδαίμων ἀνήρ’—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>μὰ τὸν Δί’ οὐ δῆτ’, ἀλλὰ κακοδαίμων φύσει,</l>
 					<l>ὅντινά γε πρὶν φῦναι μὲν Ἁπόλλων ἔφη</l>
 					<l n="1185">ἀποκτενεῖν τὸν πατέρα, πρὶν καὶ γεγονέναι·</l>
 					<l>πῶς οὗτος ἦν τὸ πρῶτον εὐδαίμων ἀνήρ;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>‘εἶτ’ ἐγένετ’ αὖθις ἀθλιώτατος βροτῶν.’</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>μὰ τὸν Δί’ οὐ δῆτ’, οὐ μὲν οὖν ἐπαύσατο.</l>
 					<l>πῶς γάρ; ὅτε δὴ πρῶτον μὲν αὐτὸν γενόμενον</l>
@@ -3623,32 +3623,32 @@ convert to p3
 					<l part="Y">εὐδαίμων ἄρ’ ἦν,</l>
 					<l>εἰ κἀστρατήγησέν γε μετ’ Ἐρασινίδου.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ληρεῖς· ἐγὼ δὲ τοὺς προλόγους καλοὺς ποιῶ.</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l>καὶ μὴν μὰ τὸν Δί’ οὐ κατ’ ἔπος γέ σου κνίσω</l>
 					<l>τὸ ῥῆμ’ ἕκαστον, ἀλλὰ σὺν τοῖσιν θεοῖς</l>
 					<l n="1200">ἀπὸ ληκυθίου σου τοὺς προλόγους διαφθερῶ.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἀπὸ ληκυθίου σὺ τοὺς ἐμούς;</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ἑνὸς μόνου.</l>
 					<l>ποιεῖς γὰρ οὕτως ὥστ’ ἐναρμόττειν ἅπαν,</l>
 					<l>καὶ κῳδάριον καὶ ληκύθιον καὶ θύλακον,</l>
 					<l>ἐν τοῖς ἰαμβείοισι. δείξω δ’ αὐτίκα.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1205">ἰδού, σὺ δείξεις;</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">φημί.</l>
 				</sp>
@@ -3657,13 +3657,13 @@ convert to p3
 					<l part="Y">καὶ δὴ χρὴ λέγειν.</l>
 					<milestone ed="p" n="1206" unit="card"/>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>‘Αἴγυπτος, ὡς ὁ πλεῖστος ἔσπαρται λόγος,</l>
 					<l>ξὺν παισὶ πεντήκοντα ναυτίλῳ πλάτῃ</l>
 					<l>Ἄργος κατασχών—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ληκύθιον ἀπώλεσεν.</l>
 				</sp>
@@ -3672,13 +3672,13 @@ convert to p3
 					<l>τουτὶ τί ἦν τὸ ληκύθιον; οὐ κλαύσεται;</l>
 					<l n="1210">λέγ’ ἕτερον αὐτῷ πρόλογον, ἵνα καὶ γνῶ πάλιν.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>‘Διόνυσος, ὃς θύρσοισι καὶ νεβρῶν δοραῖς</l>
 					<l>καθαπτὸς ἐν πεύκαισι Παρνασσὸν κάτα</l>
 					<l>πηδᾷ χορεύων’—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ληκύθιον ἀπώλεσεν.</l>
 				</sp>
@@ -3686,7 +3686,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>οἴμοι πεπλήγμεθ’ αὖθις ὑπὸ τῆς ληκύθου.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1215">ἀλλ’ οὐδὲν ἔσται πρᾶγμα· πρὸς γὰρ τουτονὶ</l>
 					<l>τὸν πρόλογον οὐχ ἕξει προσάψαι λήκυθον.</l>
@@ -3694,7 +3694,7 @@ convert to p3
 					<l>ἢ γὰρ πεφυκὼς ἐσθλὸς οὐκ ἔχει βίον,</l>
 					<l>ἢ δυσγενὴς ὤν’—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ληκύθιον ἀπώλεσεν.</l>
 				</sp>
@@ -3702,7 +3702,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l n="1220">Εὐριπίδη—</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">τί ἔσθ’;</l>
 				</sp>
@@ -3711,7 +3711,7 @@ convert to p3
 					<l part="Y">ὑφέσθαι μοι δοκεῖ·</l>
 					<l>τὸ ληκύθιον γὰρ τοῦτο πνευσεῖται πολύ.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>οὐδ’ ἂν μὰ τὴν Δήμητρα φροντίσαιμί γε·</l>
 					<l>νυνὶ γὰρ αὐτοῦ τοῦτό γ’ ἐκκεκόψεται.</l>
@@ -3720,12 +3720,12 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>ἴθι δὴ λέγ’ ἕτερον κἀπέχου τῆς ληκύθου.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1225">‘Σιδώνιόν ποτ’ ἄστυ Κάδμος ἐκλιπὼν</l>
 					<l>Ἀγήνορος παῖσ’—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ληκύθιον ἀπώλεσεν.</l>
 				</sp>
@@ -3734,7 +3734,7 @@ convert to p3
 					<l>ὦ δαιμόνῑ ἀνδρῶν ἀποπρίω τὴν λήκυθον,</l>
 					<l>ἵνα μὴ διακναίσῃ τοὺς προλόγους ἡμῶν.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">τὸ τί;</l>
 					<l>ἐγὼ πρίωμαι τῷδ’;</l>
@@ -3743,14 +3743,14 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l part="Y">ἐὰν πείθῃ γ’ ἐμοί.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1230">οὐ δῆτ’, ἐπεὶ πολλοὺς προλόγους ἕξω λέγειν</l>
 					<l>ἵν’ οὗτος οὐχ ἕξει προσάψαι ληκύθιον.</l>
 					<l>‘Πέλοψ ὁ Ταντάλειος ἐς Πῖσαν μολὼν</l>
 					<l>θοαῖσιν ἵπποισ’—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ληκύθιον ἀπώλεσεν.</l>
 				</sp>
@@ -3760,22 +3760,22 @@ convert to p3
 					<l n="1235">ἀλλ’ ὦγάθ’ ἔτι καὶ νῦν ἀπόδος πάσῃ τέχνῃ·</l>
 					<l>λήψει γὰρ ὀβολοῦ πάνυ καλήν τε κἀγαθήν.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>μὰ τὸν Δί’ οὔπω γ’· ἔτι γὰρ εἰσί μοι συχνοί.</l>
 					<l>‘Οἰνεύς ποτ’ ἐκ γῆσ’—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ληκύθιον ἀπώλεσεν.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἔασον εἰπεῖν πρῶθ’ ὅλον με τὸν στίχον.</l>
 					<l n="1240">‘Οἰνεύς ποτ’ ἐκ γῆς πολύμετρον λαβὼν στάχυν</l>
 					<l>θύων ἀπαρχάσ’—</l>
 				</sp>
-				<sp who="#aisxylos">
+				<sp who="#aischylos">
 					<speaker>Αἰσχύλος</speaker>
 					<l part="Y">ληκύθιον ἀπώλεσεν.</l>
 				</sp>
@@ -3783,7 +3783,7 @@ convert to p3
 					<speaker>Διόνυσος</speaker>
 					<l>μεταξὺ θύων; καὶ τίς αὔθ’ ὑφείλετο;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἔα αὐτὸν ὦ τᾶν· πρὸς τοδὶ γὰρ εἰπάτω.</l>
 					<l>‘Ζεύς, ὡς λέλεκται τῆς ἀληθείας ὕπο’—</l>
@@ -3795,14 +3795,14 @@ convert to p3
 					<l>ὥσπερ τὰ σῦκ’ ἐπὶ τοῖσιν ὀφθαλμοῖς ἔφυ.</l>
 					<l>ἀλλ’ ἐς τὰ μέλη πρὸς τῶν θεῶν αὐτοῦ τραποῦ.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>καὶ μὴν ἔχω γ’ οἷς αὐτὸν ἀποδείξω κακὸν</l>
 					<l n="1250">μελοποιὸν ὄντα καὶ ποιοῦντα ταὔτ’ ἀεί.</l>
 					<milestone ed="p" n="1251" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί ποτε πρᾶγμα γενήσεται;</l>
 						<l>φροντίζειν γὰρ ἔγωγ’ ἔχω,</l>
@@ -3815,7 +3815,7 @@ convert to p3
 						<l>τὸν Βακχεῖον ἄνακτα,</l>
 						<l n="1260">καὶ δέδοιχ’ ὑπὲρ αὐτοῦ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>πάνυ γε μέλη θαυμαστά· δείξει δὴ τάχα.</l>
 						<l>εἰς ἓν γὰρ αὐτοῦ πάντα τὰ μέλη ξυντεμῶ.</l>
@@ -3826,7 +3826,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>Φθιῶτ’ Ἀχιλλεῦ, τί ποτ’ ἀνδροδάικτον ἀκούων</l>
 						<l n="1265">ἰὴ κόπον οὐ πελάθεις ἐπ’ ἀρωγάν;</l>
@@ -3841,7 +3841,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1270">κύδιστ’ Ἀχαιῶν Ἀτρέως πολυκοίρανε μάνθανέ μου παῖ.</l>
 						<l>ἰὴ κόπον οὐ πελάθεις ἐπ’ ἀρωγάν;</l>
@@ -3854,7 +3854,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>εὐφαμεῖτε· μελισσονόμοι δόμον Ἀρτέμιδος πέλας οἴγειν.</l>
 						<l n="1275">ἰὴ κόπον οὐ πελάθεις ἐπ’ ἀρωγάν;</l>
@@ -3867,7 +3867,7 @@ convert to p3
 						<l>ἐγὼ μὲν οὖν ἐς τὸ βαλανεῖον βούλομαι·</l>
 						<l n="1280">ὑπὸ τῶν κόπων γὰρ τὼ νεφρὼ βουβωνιῶ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>μὴ πρίν γ’ &lt;ἂν&gt; ἀκούσῃς χἀτέραν στάσιν μελῶν</l>
 						<l>ἐκ τῶν κιθαρῳδικῶν νόμων εἰργασμένην.</l>
@@ -3878,7 +3878,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1285">ὅπως Ἀχαιῶν δίθρονον κράτος, Ἑλλάδος ἥβας,</l>
 						<l>τοφλαττοθρατ τοφλαττοθρατ,</l>
@@ -3897,7 +3897,7 @@ convert to p3
 						<l>τί τὸ ‘φλαττοθρατ’ τοῦτ’ ἐστίν; ἐκ Μαραθῶνος ἢ</l>
 						<l>πόθεν συνέλεξας ἱμονιοστρόφου μέλη;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>ἀλλ’ οὖν ἐγὼ μὲν ἐς τὸ καλὸν ἐκ τοῦ καλοῦ</l>
 						<l>ἤνεγκον αὔθ’, ἵνα μὴ τὸν αὐτὸν Φρυνίχῳ</l>
@@ -3917,7 +3917,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>ἀλκυόνες, αἳ παρ’ ἀενάοις θαλάσσης</l>
 						<l n="1310">κύμασι στωμύλλετε,</l>
@@ -3943,7 +3943,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>τί δαί; τοῦτον ὁρᾷς;</l>
 					</sp>
@@ -3955,7 +3955,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l n="1325">τοιαυτὶ μέντοι σὺ ποιῶν</l>
 						<l>τολμᾷς τἀμὰ μέλη ψέγειν,</l>
@@ -4010,7 +4010,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>παύσασθον ἤδη τῶν μελῶν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">κἄμοιγ’ ἅλις.</l>
 						<l n="1365">ἐπὶ τὸν σταθμὸν γὰρ αὐτὸν ἀγαγεῖν βούλομαι,</l>
@@ -4025,7 +4025,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1370">ἐπίπονοί γ’ οἱ δεξιοί.</l>
 						<l>τόδε γὰρ ἕτερον αὖ τέρας</l>
@@ -4044,7 +4044,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ἴθι δὴ παρίστασθον παρὰ τὼ πλάστιγγ’,</l>
 					</sp>
-					<sp who="#aisxylos #eyripides">
+					<sp who="#aischylos #euripides">
 						<speaker>Αἰσχύλος καί Εὐριπίδης</speaker>
 						<l part="Y">ἰδού.</l>
 					</sp>
@@ -4053,7 +4053,7 @@ convert to p3
 						<l>καὶ λαβομένω τὸ ῥῆμ’ ἑκάτερος εἴπατον,</l>
 						<l n="1380">καὶ μὴ μεθῆσθον, πρὶν ἂν ἐγὼ σφῷν κοκκύσω.</l>
 					</sp>
-					<sp who="#aisxylos #eyripides">
+					<sp who="#aischylos #euripides">
 						<speaker>Αἰσχύλος καὶ Εὐριπίδης</speaker>
 						<l>ἐχόμεθα.</l>
 					</sp>
@@ -4061,11 +4061,11 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">τοὔπος νῦν λέγετον ἐς τὸν σταθμόν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>‘εἴθ’ ὤφελ’ Ἀργοῦς μὴ διαπτάσθαι σκάφος.’</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>‘Σπερχειὲ ποταμὲ βουνόμοι τ’ ἐπιστροφαί.’</l>
 					</sp>
@@ -4074,7 +4074,7 @@ convert to p3
 						<l>κόκκυ, μέθεσθε· καὶ πολύ γε κατωτέρω</l>
 						<l n="1385">χωρεῖ τὸ τοῦδε.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">καὶ τί ποτ’ ἐστὶ ταἴτιον;</l>
 					</sp>
@@ -4084,7 +4084,7 @@ convert to p3
 						<l>ὑγρὸν ποιήσας τοὔπος ὥσπερ τἄρια,</l>
 						<l>σὺ δ’ εἰσέθηκας τοὔπος ἐπτερωμένον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀλλ’ ἕτερον εἰπάτω τι κἀντιστησάτω.</l>
 					</sp>
@@ -4092,7 +4092,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l n="1390">λάβεσθε τοίνυν αὖθις.</l>
 					</sp>
-					<sp who="#aisxylos #eyripides">
+					<sp who="#aischylos #euripides">
 						<speaker>Αἰσχύλος καί Εὐριπίδης</speaker>
 						<l part="Y">ἢν ἰδού.</l>
 					</sp>
@@ -4100,11 +4100,11 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">λέγε.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>‘οὐκ ἔστι Πειθοῦς ἱερὸν ἄλλο πλὴν λόγος.’</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>‘μόνος θεῶν γὰρ Θάνατος οὐ δώρων ἐρᾷ.’</l>
 					</sp>
@@ -4113,7 +4113,7 @@ convert to p3
 						<l>μέθεσθε μέθεσθε· καὶ τὸ τοῦδέ γ’ αὖ ῥέπει·</l>
 						<l>θάνατον γὰρ εἰσέθηκε βαρύτατον κακόν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1395">ἐγὼ δὲ πειθώ γ’ ἔπος ἄριστ’ εἰρημένον.</l>
 					</sp>
@@ -4123,7 +4123,7 @@ convert to p3
 						<l>ἀλλ’ ἕτερον αὖ ζήτει τι τῶν βαρυστάθμων,</l>
 						<l>ὅ τι σοι καθέλξει, καρτερόν τε καὶ μέγα.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>φέρε ποῦ τοιοῦτον δῆτά μοὐστί; ποῦ;</l>
 					</sp>
@@ -4133,11 +4133,11 @@ convert to p3
 						<l n="1400">‘βέβληκ’ Ἀχιλλεὺς δύο κύβω καὶ τέτταρα.’</l>
 						<l>λέγοιτ’ ἄν, ὡς αὕτη ’στὶ λοιπὴ σφῷν στάσις.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>‘σιδηροβριθές τ’ ἔλαβε δεξιᾷ ξύλον.’</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>‘ἐφ’ ἅρματος γὰρ ἅρμα καὶ νεκρῷ νεκρός.’</l>
 					</sp>
@@ -4145,7 +4145,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>ἐξηπάτηκεν αὖ σὲ καὶ νῦν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τῷ τρόπῳ;</l>
 					</sp>
@@ -4154,7 +4154,7 @@ convert to p3
 						<l n="1405">δύ’ ἅρματ’ εἰσέθηκε καὶ νεκρὼ δύο,</l>
 						<l>οὓς οὐκ ἂν ἄραιντ’ οὐδ’ ἑκατὸν Αἰγύπτιοι.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>καὶ μηκέτ’ ἔμοιγε κατ’ ἔπος, ἀλλ’ ἐς τὸν σταθμὸν</l>
 						<l>αὐτὸς τὰ παιδί’ ἡ γυνὴ Κηφισοφῶν</l>
@@ -4168,7 +4168,7 @@ convert to p3
 						<l>τὸν μὲν γὰρ ἡγοῦμαι σοφὸν τῷ δ’ ἥδομαι.</l>
 						<milestone ed="p" n="1414" unit="card"/>
 					</sp>
-					<sp who="#ployton">
+					<sp who="#plouton">
 						<speaker>Πλούτων</speaker>
 						<l>οὐδὲν ἄρα πράξεις ὧνπερ ἦλθες οὕνεκα;</l>
 					</sp>
@@ -4176,7 +4176,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l n="1415">ἐὰν δὲ κρίνω;</l>
 					</sp>
-					<sp who="#ployton">
+					<sp who="#plouton">
 						<speaker>Πλούτων</speaker>
 						<l part="Y">τὸν ἕτερον λαβὼν ἄπει,</l>
 						<l>ὁπότερον ἂν κρίνῃς, ἵν’ ἔλθῃς μὴ μάτην.</l>
@@ -4191,7 +4191,7 @@ convert to p3
 						<l>πρῶτον μὲν οὖν περὶ Ἀλκιβιάδου τίν’ ἔχετον</l>
 						<l>γνώμην ἑκάτερος; ἡ πόλις γὰρ δυστοκεῖ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἔχει δὲ περὶ αὐτοῦ τίνα γνώμην;</l>
 					</sp>
@@ -4201,7 +4201,7 @@ convert to p3
 						<l n="1425">ποθεῖ μέν, ἐχθαίρει δέ, βούλεται δ’ ἔχειν.</l>
 						<l>ἀλλ’ ὅ τι νοεῖτον εἴπατον τούτου πέρι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>μισῶ πολίτην, ὅστις ὠφελεῖν πάτραν</l>
 						<l>βραδὺς πέφυκε μεγάλα δὲ βλάπτειν ταχύς,</l>
@@ -4224,7 +4224,7 @@ convert to p3
 						<l n="1435">ἀλλ’ ἔτι μίαν γνώμην ἑκάτερος εἴπατον</l>
 						<l>περὶ τῆς πόλεως ἥντιν’ ἔχετον σωτηρίαν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>εἴ τις πτερώσας Κλεόκριτον Κινησίᾳ,</l>
 						<l>αἴροιεν αὖραι πελαγίαν ὑπὲρ πλάκα.</l>
@@ -4233,7 +4233,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>γέλοιον ἂν φαίνοιτο· νοῦν δ’ ἔχει τίνα;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1440">εἰ ναυμαχοῖεν κᾆτ’ ἔχοντες ὀξίδας</l>
 						<l>ῥαίνοιεν ἐς τὰ βλέφαρα τῶν ἐναντίων.</l>
@@ -4243,7 +4243,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">λέγε.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὅταν τὰ νῦν ἄπιστα πίσθ’ ἡγώμεθα,</l>
 						<l>τὰ δ’ ὄντα πίστ’ ἄπιστα.</l>
@@ -4253,7 +4253,7 @@ convert to p3
 						<l part="Y">πῶς; οὐ μανθάνω.</l>
 						<l n="1445">ἀμαθέστερόν πως εἰπὲ καὶ σαφέστερον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>εἰ τῶν πολιτῶν οἷσι νῦν πιστεύομεν,</l>
 						<l>τούτοις ἀπιστήσαιμεν, οἷς δ’ οὐ χρώμεθα,</l>
@@ -4266,12 +4266,12 @@ convert to p3
 						<l>εὖ γ’ ὦ Παλάμηδες, ὦ σοφωτάτη φύσις.</l>
 						<l>ταυτὶ πότερ’ αὐτὸς ηὗρες ἢ Κηφισοφῶν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἐγὼ μόνος· τὰς δ’ ὀξίδας Κηφισοφῶν.</l>
 						<l>τί δαὶ σύ; τί λέγεις;</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">τὴν πόλιν νῦν μοι φράσον</l>
 						<l>πρῶτον τίσι χρῆται· πότερα τοῖς χρηστοῖς;</l>
@@ -4281,7 +4281,7 @@ convert to p3
 						<l part="Y">πόθεν;</l>
 						<l n="1456">μισεῖ κάκιστα.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l part="Y">τοῖς πονηροῖς δ’ ἥδεται;</l>
 					</sp>
@@ -4289,7 +4289,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>οὐ δῆτ’ ἐκείνη γ’, ἀλλὰ χρῆται πρὸς βίαν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>πῶς οὖν τις ἂν σώσειε τοιαύτην πόλιν,</l>
 						<l>ᾗ μήτε χλαῖνα μήτε σισύρα συμφέρει;</l>
@@ -4299,7 +4299,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l n="1460">εὕρισκε νὴ Δί’, εἴπερ ἀναδύσει πάλιν.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>ἐκεῖ φράσαιμ’ ἄν· ἐνθαδὶ δ’ οὐ βούλομαι.</l>
 					</sp>
@@ -4307,7 +4307,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>μὴ δῆτα σύ γ’, ἀλλ’ ἐνθένδ’ ἀνίει τἀγαθά.</l>
 					</sp>
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l>τὴν γῆν ὅταν νομίσωσι τὴν τῶν πολεμίων</l>
 						<l>εἶναι σφετέραν, τὴν δὲ σφετέραν τῶν πολεμίων,</l>
@@ -4317,7 +4317,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>εὖ, πλήν γ’ ὁ δικαστὴς αὐτὰ καταπίνει μόνος.</l>
 					</sp>
-					<sp who="#ployton">
+					<sp who="#plouton">
 						<speaker>Πλούτων</speaker>
 						<l>κρίνοις ἄν.</l>
 					</sp>
@@ -4326,7 +4326,7 @@ convert to p3
 						<l part="Y">αὕτη σφῷν κρίσις γενήσεται·</l>
 						<l>αἱρήσομαι γὰρ ὅνπερ ἡ ψυχὴ θέλει.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>μεμνημένος νυν τῶν θεῶν οὓς ὤμοσας</l>
 						<l n="1470">ἦ μὴν ἀπάξειν μ’ οἴκαδ’, αἱροῦ τοὺς φίλους.</l>
@@ -4335,7 +4335,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l>‘ἡ γλῶττ’ ὀμώμοκ’,’ Αἰσχύλον δ’ αἱρήσομαι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τί δέδρακας ὦ μιαρώτατ’ ἀνθρώπων;</l>
 					</sp>
@@ -4344,7 +4344,7 @@ convert to p3
 						<l part="Y">ἐγώ;</l>
 						<l>ἔκρινα νικᾶν Αἰσχύλον. τιὴ γὰρ οὔ;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>αἴσχιστον ἔργον προσβλέπεις μ’ εἰργασμένος;</l>
 					</sp>
@@ -4352,7 +4352,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l n="1475">τί δ’ αἰσχρόν, ἢν μὴ τοῖς θεωμένοις δοκῇ;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὦ σχέτλιε περιόψει με δὴ τεθνηκότα;</l>
 					</sp>
@@ -4361,7 +4361,7 @@ convert to p3
 						<l>τίς οἶδεν εἰ τὸ ζῆν μέν ἐστι κατθανεῖν,</l>
 						<l>τὸ πνεῖν δὲ δειπνεῖν, τὸ δὲ καθεύδειν κῴδιον;</l>
 					</sp>
-					<sp who="#ployton">
+					<sp who="#plouton">
 						<speaker>Πλούτων</speaker>
 						<l>χωρεῖτε τοίνυν ὦ Διόνυσ’ εἴσω.</l>
 					</sp>
@@ -4369,7 +4369,7 @@ convert to p3
 						<speaker>Διόνυσος</speaker>
 						<l part="Y">τί δαί;</l>
 					</sp>
-					<sp who="#ployton">
+					<sp who="#plouton">
 						<speaker>Πλούτων</speaker>
 						<l n="1480">ἵνα ξενίσω &lt;’γὼ&gt; σφὼ πρὶν ἀποπλεῖν.</l>
 					</sp>
@@ -4383,7 +4383,7 @@ convert to p3
 			</div1>
 			<div1 type="episode">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μακάριός γ’ ἀνὴρ ἔχων</l>
 						<l>ξύνεσιν ἠκριβωμένην.</l>
@@ -4398,7 +4398,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrohe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαρίεν οὖν μὴ Σωκράτει</l>
 						<l>παρακαθήμενον λαλεῖν,</l>
@@ -4415,7 +4415,7 @@ convert to p3
 			</div1>
 			<div1 type="Exodus">
 				<div2 type="anapests">
-					<sp who="#ployton">
+					<sp who="#plouton">
 						<speaker>Πλούτων</speaker>
 						<l n="1500">ἄγε δὴ χαίρων Αἰσχύλε χώρει,</l>
 						<l>καὶ σῷζε πόλιν τὴν ἡμετέραν</l>
@@ -4435,7 +4435,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#aisxylos">
+					<sp who="#aischylos">
 						<speaker>Αἰσχύλος</speaker>
 						<l n="1515">ταῦτα ποιήσω· σὺ δὲ τὸν θᾶκον</l>
 						<l>τὸν ἐμὸν παράδος Σοφοκλεῖ τηρεῖν</l>
@@ -4447,7 +4447,7 @@ convert to p3
 						<l>μηδέποτ’ ἐς τὸν θᾶκον τὸν ἐμὸν</l>
 						<l>μηδ’ ἄκων ἐγκαθεδεῖται.</l>
 					</sp>
-					<sp who="#ployton">
+					<sp who="#plouton">
 						<speaker>Πλούτων</speaker>
 						<l>φαίνετε τοίνυν ὑμεῖς τούτῳ</l>
 						<l n="1525">λαμπάδας ἱεράς, χἄμα προπέμπετε</l>
@@ -4457,7 +4457,7 @@ convert to p3
 					</sp>
 				</div2>
 				<div2 type="dactyls">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρῶτα μὲν εὐοδίαν ἀγαθὴν ἀπιόντι ποιητῇ</l>
 						<l>ἐς φάος ὀρνυμένῳ δότε δαίμονες οἱ κατὰ γαίας,</l>

--- a/tei/aristophanes-knights.xml
+++ b/tei/aristophanes-knights.xml
@@ -58,15 +58,15 @@
 					<person xml:id="allantopoles">
 						<persName>Ἀλλαντοπώλης</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="kleon">
 						<persName>Κλέων</persName>
 					</person>
-					<person xml:id="xorosippeon">
+					<personGrp xml:id="choros_hippeon">
 						<name>Χορός Ἱππεῶν</name>
-					</person>
+					</personGrp>
 					<person xml:id="demosthenes">
 						<persName>Δημοσθένης</persName>
 					</person>
@@ -822,7 +822,7 @@ bring up to P3
 						<l n="245">ὁ κονιορτὸς δῆλος αὐτῶν ὡς ὁμοῦ προσκειμένων.</l>
 						<l>ἀλλ’ ἀμύνου καὶ δίωκε καὶ τροπὴν αὐτοῦ ποιοῦ.</l>
 					</sp>
-					<sp who="#xorosippeon">
+					<sp who="#choros_hippeon">
 						<speaker>Χορός Ἱππεῶν</speaker>
 						<l>παῖε παῖε τὸν πανοῦργον καὶ ταραξιππόστρατον</l>
 						<l>καὶ τελώνην καὶ φάραγγα καὶ Χάρυβδιν ἁρπαγῆς,</l>
@@ -839,7 +839,7 @@ bring up to P3
 						<l>οὓς ἐγὼ βόσκω κεκραγὼς καὶ δίκαια κἄδικα,</l>
 						<l>παραβοηθεῖθ’, ὡς ὑπ’ ἀνδρῶν τύπτομαι ξυνωμοτῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐν δίκῃ γ’, ἐπεὶ τὰ κοινὰ πρὶν λαχεῖν κατεσθίεις,</l>
 						<l>κἀποσυκάζεις πιέζων τοὺς ὑπευθύνους σκοπῶν,</l>
@@ -856,7 +856,7 @@ bring up to P3
 						<l>ὅτι λέγειν γνώμην ἔμελλον ὡς δίκαιον ἐν πόλει</l>
 						<l>ἑστάναι μνημεῖον ὑμῶν ἐστιν ἀνδρείας χάριν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς δ’ ἀλαζών, ὡς δὲ μάσθλης· εἶδες οἷ’ ὑπέρχεται</l>
 						<l n="270">ὡσπερεὶ γέροντας ἡμᾶς καὶ κοβαλικεύεται;</l>
@@ -867,7 +867,7 @@ bring up to P3
 						<speaker>Κλέων</speaker>
 						<l>ὦ πόλις καὶ δῆμ’ ὑφ’ οἵων θηρίων γαστρίζομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ κέκραγας, ὥσπερ ἀεὶ τὴν πόλιν καταστρέφει;</l>
 					</sp>
@@ -875,7 +875,7 @@ bring up to P3
 						<speaker>Κλέων</speaker>
 						<l n="275">ἀλλ’ ἐγώ σε τῇ βοῇ ταύτῃ γε πρῶτα τρέψομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἐὰν μέντοι γε νικᾷς τῇ βοῇ, τήνελλος εἶ·</l>
 						<l>ἢν δ’ ἀναιδείᾳ παρέλθῃ σ’, ἡμέτερος ὁ πυραμοῦς.</l>
@@ -969,7 +969,7 @@ bring up to P3
 				 
 
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ μιαρὲ καὶ βδελυρὲ † καὶ κεκράκτα †, τοῦ σοῦ θράσους</l>
 						<l n="305">πᾶσα μὲν γῆ πλέα, πᾶσα δ’ ἐκκλησία, καὶ τέλη</l>
@@ -1001,7 +1001,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆρα δῆτ’ οὐκ ἀπ’ ἀρχῆς ἐδήλους ἀναίδειαν,</l>
 						<l n="325">ἥπερ μόνη προστατεῖ ῥητόρων;</l>
@@ -1033,7 +1033,7 @@ bring up to P3
 						<speaker>Ἀλλαντοπώλης</speaker>
 						<l part="Y">μὰ Δί’ ἐπεὶ κἀγὼ πονηρός εἰμι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐὰν δὲ μὴ ταύτῃ γ’ ὑπείκῃ, λέγ’ ὅτι κἀκ πονηρῶν.</l>
 					</sp>
@@ -1062,7 +1062,7 @@ bring up to P3
 						<speaker>Ἀλλαντοπώλης</speaker>
 						<l part="Y">καὶ μὴν ἐγὼ οὐ παρήσω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάρες πάρες πρὸς τῶν θεῶν αὐτῷ διαρραγῆναι.</l>
 					</sp>
@@ -1101,7 +1101,7 @@ bring up to P3
 						<l>καταβροχθίσας κᾆτ’ ἐπιπιὼν τὸν ζωμὸν ἀναπόνιπτος</l>
 						<l>λαρυγγιῶ τοὺς ῥήτορας καὶ Νικίαν ταράξω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὰ μὲν ἄλλα μ’ ἤρεσας λέγων·. ἓν δ’ οὐ προσίεταί με,</l>
 						<l n="360">τῶν πραγμάτων ὁτιὴ μόνος τὸν ζωμὸν ἐκροφήσει.</l>
@@ -1126,7 +1126,7 @@ bring up to P3
 						<speaker>Κλέων</speaker>
 						<l n="365">ἐγὼ δέ γ’ ἐξέλξω σε τῆς πυγῆς θύραζε κύβδα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νὴ τὸν Ποσειδῶ κἀμέ τἄρ’, ἤνπερ γε τοῦτον ἕλκῃς.</l>
 						<milestone ed="p" n="367" unit="card"/>
@@ -1178,7 +1178,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦν ἄρα πυρός γ’ ἕτερα θερμότερα καὶ λόγων</l>
 						<l n="385">ἐν πόλει τῶν ἀναιδῶν ἀναιδέστεροι· καὶ τὸ πρᾶγμ’</l>
@@ -1205,7 +1205,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς δὲ πρὸς πᾶν ἀναιδεύεται κοὐ μεθίστησι</l>
 						<l>τοῦ χρώματος τοῦ παρεστηκότος.</l>
@@ -1249,7 +1249,7 @@ bring up to P3
 						<l>‘σκέψασθε παῖδες· οὐχ ὁρᾶθ’; ὥρα νέα, χελιδών.’</l>
 						<l n="420">οἱ δ’ ἔβλεπον, κἀγὼ ’ν τοσούτῳ τῶν κρεῶν ἔκλεπτον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ δεξιώτατον κρέας σοφῶς γε προὐνοήσω·</l>
 						<l>ὥσπερ ἀκαλήφας ἐσθίων πρὸ χελιδόνων ἔκλεπτες.</l>
@@ -1261,7 +1261,7 @@ bring up to P3
 						<l n="425">ὥστ’ εἶπ’ ἀνὴρ τῶν ῥητόρων ἰδών με τοῦτο δρῶντα·</l>
 						<l>‘οὐκ ἔσθ’ ὅπως ὁ παῖς ὅδ’ οὐ τὸν δῆμον ἐπιτροπεύσει.’</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὖ γε ξυνέβαλεν αὔτ’· ἀτὰρ δῆλόν γ’ ἀφ’ οὗ ξυνέγνω·</l>
 						<l>ὁτιὴ ’πιώρκεις θ’ ἡρπακὼς καὶ κρέας ὁ πρωκτὸς εἶχεν.</l>
@@ -1299,7 +1299,7 @@ bring up to P3
 						<speaker>Κλέων</speaker>
 						<l>τί δῆτα; βούλει τῶν ταλάντων ἓν λαβὼν σιωπᾶν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="440">ἁνὴρ ἂν ἡδέως λάβοι. τοὺς τερθρίους παρίει·</l>
 						<milestone ed="p" n="441" unit="card"/>
@@ -1343,7 +1343,7 @@ bring up to P3
 						<speaker>Ἀλλαντοπώλης</speaker>
 						<l part="Y">πανοῦργος εἶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παῖ’ ἀνδρικῶς.</l>
 					</sp>
@@ -1352,7 +1352,7 @@ bring up to P3
 						<l part="Y">ἰοὺ ἰού,</l>
 						<l>τύπτουσί μ’ οἱ ξυνωμόται.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παῖ’ αὐτὸν ἀνδρειότατα, καὶ</l>
 						<l>γάστριζε καὶ τοῖς ἐντέροις</l>
@@ -1362,7 +1362,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="sphragis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ γεννικώτατον κρέας ψυχήν τ’ ἄριστε πάντων,</l>
 						<l>καὶ τῇ πόλει σωτὴρ φανεὶς ἡμῖν τε τοῖς πολίταις,</l>
@@ -1379,7 +1379,7 @@ bring up to P3
 					<l>τεκταινόμενα τὰ πράγματ’, ἀλλ’ ἠπιστάμην</l>
 					<l>γομφούμεν’ αὐτὰ πάντα καὶ κολλώμενα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οἴμοι σὺ δ’ οὐδὲν ἐξ ἁμαξουργοῦ λέγεις;</l>
 				</sp>
@@ -1391,7 +1391,7 @@ bring up to P3
 					<l>καὶ ταῦτ’ ἐφ’ οἷσίν ἐστι συμφυσώμενα</l>
 					<l>ἐγᾦδ’· ἐπὶ γὰρ τοῖς δεδεμένοις χαλκεύεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="470">εὖ γ’ εὖ γε, χάλκεὐ ἀντὶ τῶν κολλωμένων.</l>
 				</sp>
@@ -1418,7 +1418,7 @@ bring up to P3
 					<speaker>Κλέων</speaker>
 					<l>ἐγώ σε νὴ τὸν Ἡρακλέα παραστορῶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄγε δὴ σὺ τίνα νοῦν ἢ τίνα ψυχὴν ἔχεις;</l>
 					<l>νυνί γε δείξεις, εἴπερ ἀπεκρύψω τότε</l>
@@ -1468,7 +1468,7 @@ bring up to P3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 met="anapests" type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄλλ’ ἴθι χαίρων, καὶ πράξειας</l>
 						<l>κατὰ νοῦν τὸν ἐμόν, καί σε φυλάττοι</l>
@@ -1485,7 +1485,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="parabasis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ μέν τις ἀνὴρ τῶν ἀρχαίων κωμῳδοδιδάσκαλος ἡμᾶς</l>
 						<l>ἠνάγκαζεν λέξοντας ἔπη πρὸς τὸ θέατρον παραβῆναι,</l>
@@ -1531,7 +1531,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θόρυβον χρηστὸν ληναΐτην,</l>
 						<l>ἵν’ ὁ ποιητὴς ἀπίῃ χαίρων</l>
@@ -1541,7 +1541,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἵππῑ ἄναξ Πόσειδον, ᾧ</l>
 						<l>χαλκοκρότων ἵππων κτύπος</l>
@@ -1560,7 +1560,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="565">εὐλογῆσαι βουλόμεσθα τοὺς πατέρας ἡμῶν, ὅτι</l>
 						<l>ἄνδρες ἦσαν τῆσδε τῆς γῆς ἄξιοι καὶ τοῦ πέπλου,</l>
@@ -1582,7 +1582,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ὦ πολιοῦχε Παλλάς, ὦ</l>
 						<l>τῆς ἱερωτάτης ἁπασῶν</l>
@@ -1602,7 +1602,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="595">ἃ ξύνισμεν τοῖσιν ἵπποις, βουλόμεσθ’ ἐπαινέσαι.</l>
 						<l>ἄξιοι δ’ εἴσ’ εὐλογεῖσθαι· πολλὰ γὰρ δὴ πάγματα</l>
@@ -1625,7 +1625,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Lyric-Scene">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ φίλτατ’ ἀνδρῶν καὶ νεανικώτατε.</l>
 					<l>ὅσην ἀπὼν παρέσχες ἡμῖν φροντίδα·</l>
@@ -1638,7 +1638,7 @@ bring up to P3
 					<milestone ed="p" n="616" unit="card"/>
 				</sp>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν ἄρ’ ἄξιόν γε πᾶσίν ἐστιν ἐπολολύξαι.</l>
 						<l>ὦ καλὰ λέγων πολὺ δ’ ἀμείνον’ ἔτι τῶν λόγων</l>
@@ -1721,7 +1721,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάντα τοι πέπραγας οἷα χρὴ τὸν εὐτυχοῦντα·</l>
 						<l>ηὗρε δ’ ὁ πανοῦργος ἕτερον πολὺ πανουργίαις</l>
@@ -1928,7 +1928,7 @@ bring up to P3
 			</div1>
 			<div1 type="Agon">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν δή σε πάντα δεῖ κάλων ἐξιέναι σεαυτοῦ,</l>
 						<l>καὶ λῆμα θούριον φορεῖν καὶ λόγους ἀφύκτους</l>
@@ -1939,7 +1939,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="Katakeleusmos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ φυλάττου καὶ πρὶν ἐκεῖνον προσκεῖσθαί σοι πρότερος σὺ</l>
 						<l>τοὺς δελφῖνας μετεωρίζου καὶ τὴν ἄκατον παραβάλλου.</l>
@@ -2085,7 +2085,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πᾶσιν ἀνθρώποις φανεὶς μέγιστον ὠφέλημα,</l>
 						<l>ζηλῶ σε τῆς εὐγλωττίας. εἰ γὰρ ὧδ’ ἐποίσεις,</l>
@@ -2096,7 +2096,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="Antikatakeleusmos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴ μεθῇς τὸν ἄνδρ’, ἐπειδή σοι λαβὴν δέδωκεν·</l>
 						<l>κατεργάσει γὰρ ῥᾳδίως πλευρὰς ἔχων τοιαύτας.</l>
@@ -2278,7 +2278,7 @@ bring up to P3
 						<l>διαμηχανήσομαί θ’ ὅπως</l>
 						<l>ἂν ἱστίον σαπρὸν λάβῃς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἁνὴρ παφλάζει, παῦε παῦ’,</l>
 						<l n="920">ὑπερζέων· ὑφελκτέον</l>
@@ -2311,7 +2311,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="sphragis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὖ γε νὴ τὸν Δία καὶ τὸν Ἀπόλλω καὶ τὴν Δήμητρα.</l>
 					</sp>
@@ -2404,7 +2404,7 @@ bring up to P3
 					<l>ἔχων κατάπαστον καὶ στεφάνην ἐφ’ ἅρματος</l>
 					<l>χρυσοῦ διώξει Σμικύθην καὶ κύριον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="970">καὶ μὴν ἔνεγκ’ αὐτοὺς ἰών, ἵν’ οὑτοσὶ</l>
 					<l>αὐτῶν ἀκούσῃ.</l>
@@ -2425,7 +2425,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἥδιστον φάος ἡμέρας</l>
 						<l>ἔσται τοῖσι παροῦσι καὶ</l>
@@ -2443,7 +2443,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="985">ἀλλὰ καὶ τόδ’ ἔγωγε θαυμάζω</l>
 						<l>τῆς ὑομουσίας</l>
@@ -2782,7 +2782,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Δῆμε καλήν γ’ ἔχεις</l>
 						<l>ἀρχήν, ὅτε πάντες ἄνθρωποι</l>
@@ -2812,7 +2812,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χοὔτω μὲν ἂν εὖ ποιοῖς,</l>
 						<l>εἴ σοι πυκνότης ἔνεστ’</l>
@@ -3173,7 +3173,7 @@ bring up to P3
 					<speaker>Ἀλλαντοπώλης</speaker>
 					<l>Ἑλλάνιε Ζεῦ σὸν τὸ νικητήριον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ χαῖρε καλλίνικε καὶ μέμνησ’ ὅτι</l>
 					<l n="1255">ἀνὴρ γεγένησαι δῑ ἐμέ· καί σ’ αἰτῶ βραχύ,</l>
@@ -3203,7 +3203,7 @@ bring up to P3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί κάλλιον ἀρχομένοισιν</l>
 						<l n="1265">ἢ καταπαυομένοισιν</l>
@@ -3217,7 +3217,7 @@ bring up to P3
 				 
 
 				<div2 type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λοιδορῆσαι τοὺς πονηροὺς οὐδέν ἐστ’ ἐπίφθονον,</l>
 						<l n="1275">ἀλλὰ τιμὴ τοῖσι χρηστοῖς, ὅστις εὖ λογίζεται.</l>
@@ -3239,7 +3239,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1290">ἦ πολλάκις ἐννυχίαισι</l>
 						<l>φροντίσι συγγεγένημαι,</l>
@@ -3251,7 +3251,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1300">φασὶν ἀλλήλαις ξυνελθεῖν τὰς τριήρεις ἐς λόγον,</l>
 						<l>καὶ μίαν λέξαι τιν’ αὐτῶν ἥτις ἦν γεραιτέρα·</l>
@@ -3281,7 +3281,7 @@ bring up to P3
 						<l>καὶ τὰ δικαστήρια συγκλῄειν οἷς ἡ πόλις ἥδε γέγηθεν,</l>
 						<l>ἐπὶ καιναῖσιν δ’ εὐτυχίαισιν παιωνίζειν τὸ θέατρον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ ταῖς ἱεραῖς φέγγος Ἀθήναις καὶ ταῖς νήσοις ἐπίκουρε,</l>
 						<l n="1320">τίν’ ἔχων φήμην ἀγαθὴν ἥκεις, ἐφ’ ὅτῳ κνισῶμεν ἀγυιάς;</l>
@@ -3290,7 +3290,7 @@ bring up to P3
 						<speaker>Ἀλλαντοπώλης</speaker>
 						<l>τὸν Δῆμον ἀφεψήσας ὑμῖν καλὸν ἐξ αἰσχροῦ πεποίηκα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ ποῦ  ’στιν νῦν ὦ θαυμαστὰς ἐξευρίσκων ἐπινοίας;</l>
 					</sp>
@@ -3298,7 +3298,7 @@ bring up to P3
 						<speaker>Ἀλλαντοπώλης</speaker>
 						<l>ἐν ταῖσιν ἰοστεφάνοις οἰκεῖ ταῖς ἀρχαίαισιν Ἀθήναις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς ἂν ἴδοιμεν; ποίαν &lt;τιν’&gt; ἔχει σκευήν; ποῖος γεγένηται;</l>
 					</sp>
@@ -3309,7 +3309,7 @@ bring up to P3
 						<l>ἀλλ’ ὀλολύξατε φαινομέναισιν ταῖς ἀρχαίαισιν Ἀθήναις</l>
 						<l>καὶ θαυμασταῖς καὶ πολυύμνοις, ἵν’ ὁ κλεινὸς Δῆμος ἐνοικεῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ ταὶ λιπαραὶ καὶ ἰοστέφανοι καὶ ἀριζήλωτοι Ἀθῆναι,</l>
 						<l n="1330">δείξατε τὸν τῆς Ἑλλάδος ὑμῖν καὶ τῆς γῆς τῆσδε μόναρχον.</l>
@@ -3319,7 +3319,7 @@ bring up to P3
 						<l>ὅδ’ ἐκεῖνος ὁρᾶν τεττιγοφόρας, ἀρχαίῳ σχήματι λαμπρός,</l>
 						<l>οὐ χοιρινῶν ὄζων ἀλλὰ σπονδῶν, σμύρνῃ κατάλειπτος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαῖρ’ ὦ βασιλεῦ τῶν Ἑλλήνων· καί σοι ξυγχαίρομεν ἡμεῖς.</l>
 						<l>τῆς γὰρ πόλεως ἄξια πράττεις καὶ τοῦ ’ν Μαραθῶνι τροπαίου.</l>

--- a/tei/aristophanes-lysistrata.xml
+++ b/tei/aristophanes-lysistrata.xml
@@ -58,19 +58,19 @@
 					<person xml:id="kinesias">
 						<persName>Κινησίας</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός </name>
 					</personGrp>
 					<person xml:id="lakon">
 						<persName>Λάκων</persName>
 					</person>
-					<person xml:id="paiskinesioy">
+					<person xml:id="pais_kinesiou">
 						<persName>Παῖς Κινησίου</persName>
 					</person>
-					<person xml:id="athenaiosb">
+					<person xml:id="athenaios_b">
 						<persName>Ἀθηναῖος Β</persName>
 					</person>
-					<person xml:id="gyned">
+					<person xml:id="gyne_d">
 						<persName>Γυνὴ Δ</persName>
 					</person>
 					<personGrp xml:id="xorosgynaikon">
@@ -79,19 +79,19 @@
 					<person xml:id="alle">
 						<persName>Ἄλλη</persName>
 					</person>
-					<person xml:id="gynea">
+					<person xml:id="gyne_a">
 						<persName>Γυνὴ Α</persName>
 					</person>
 					<person xml:id="lampito">
 						<persName>Λαμπιτῶ</persName>
 					</person>
-					<person xml:id="kerykslakedaimonion">
+					<person xml:id="keryx_lakedaimonion">
 						<persName>Κῆρυξ Λακεδαιμονίων</persName>
 					</person>
 					<personGrp xml:id="xoroslakedaimonion">
 						<name>Χορὸς Λακεδαιμονίων</name>
 					</personGrp>
-					<person xml:id="gyneb">
+					<person xml:id="gyne_b">
 						<persName>Γυνὴ Β</persName>
 					</person>
 					<personGrp xml:id="xorosgeronton">
@@ -103,7 +103,7 @@
 					<person xml:id="kalonike">
 						<persName>Καλονίκη</persName>
 					</person>
-					<person xml:id="athenaiosa">
+					<person xml:id="athenaios_a">
 						<persName>Ἀθηναῖος Α</persName>
 					</person>
 					<person xml:id="gyne">
@@ -115,16 +115,16 @@
 					<personGrp xml:id="xorosathenaion">
 						<name>Χορὸς Ἀθηναίων</name>
 					</personGrp>
-					<person xml:id="proboylos">
+					<person xml:id="proboulos">
 						<persName>Πρόβουλος</persName>
 					</person>
 					<person xml:id="pasai">
 						<persName>Πᾶσαι</persName>
 					</person>
-					<person xml:id="gyneks">
+					<person xml:id="gyne_x">
 						<persName>Γυνὴ Ξ</persName>
 					</person>
-					<person xml:id="gyneg">
+					<person xml:id="gyne_g">
 						<persName>Γυνὴ Γ</persName>
 					</person>
 					<person xml:id="geron">
@@ -1293,7 +1293,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>ἆρ’ ἐξέλαμψε τῶν γυναικῶν ἡ τρυφὴ</l>
 					<l>χὠ τυμπανισμὸς χοἰ πυκνοὶ Σαβάζιοι,</l>
@@ -1315,7 +1315,7 @@ bring up to P3
 					<l>ἔλουσαν ἡμᾶς, ὥστε θαἰματίδια</l>
 					<l>σείειν πάρεστιν ὥσπερ ἐνεουρηκότας.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>νὴ τὸν Ποσειδῶ τὸν ἁλυκὸν δίκαιά γε.</l>
 					<l>ὅταν γὰρ αὐτοὶ ξυμπονηρευώμεθα</l>
@@ -1352,7 +1352,7 @@ bring up to P3
 					<l>ἐξέρχομαι γὰρ αὐτομάτη. τί δεῖ μοχλῶν;</l>
 					<l>οὐ γὰρ μοχλῶν δεῖ μᾶλλον ἢ νοῦ καὶ φρενῶν.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>ἄληθες ὦ μιαρὰ σύ; ποῦ ’σθ’ ὁ τοξότης;</l>
 					<l>ξυλλάμβαν’ αὐτὴν κὠπίσω τὼ χεῖρε δεῖ.</l>
@@ -1362,38 +1362,38 @@ bring up to P3
 					<l n="435">εἴ τἄρα νὴ τὴν Ἄρτεμιν τὴν χεῖρά μοι</l>
 					<l>ἄκραν προσοίσει δημόσιος ὤν, κλαύσεται.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>ἔδεισας οὗτος; οὐ ξυναρπάσει μέσην</l>
 					<l>καὶ σὺ μετὰ τούτου κἀνύσαντε δήσετον;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>εἴ τἄρα νὴ τὴν Πάνδροσον ταύτῃ μόνον</l>
 					<l n="440">τὴν χεῖρ’ ἐπιβαλεῖς, ἐπιχεσεῖ πατούμενος.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>ἰδού γ’ἐπιχεσεῖ. ποῦ ’στιν ἕτερος τοξότης;</l>
 					<l>ταύτην προτέραν ξύνδησον, ὁτιὴ καὶ λαλεῖ.</l>
 					<milestone ed="p" n="443" unit="card"/>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l>εἴ τἄρα νὴ τὴν Φωσφόρον τὴν χεῖρ’ ἄκραν</l>
 					<l>ταύτῃ προσοίσεις, κύαθον αἰτήσεις τάχα.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l n="445">τουτὶ τί ἦν; ποῦ τοξότης; ταύτης ἔχου.</l>
 					<l>παύσω τιν’ ὑμῶν τῆσδ’ ἐγὼ τῆς ἐξόδου.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>εἴ τἄρα νὴ τὴν Ταυροπόλον ταύτῃ πρόσει,</l>
 					<l>ἐκκοκκιῶ σου τὰς στενοκωκύτους τρίχας.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>οἴμοι κακοδαίμων· ἐπιλέλοιφ’ ὁ τοξότης.</l>
 					<l n="450">ἀτὰρ οὐ γυναικῶν οὐδέποτ’ ἔσθ’ ἡττητέα</l>
@@ -1406,7 +1406,7 @@ bring up to P3
 					<l>ὅτι καὶ παρ’ ἡμῖν εἰσι τέτταρες λόχοι</l>
 					<l>μαχίμων γυναικῶν ἔνδον ἐξωπλισμένων.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l n="455">ἀποστρέφετε τὰς χεῖρας αὐτῶν ὦ Σκύθαι.</l>
 				</sp>
@@ -1419,7 +1419,7 @@ bring up to P3
 					<l n="460">οὐ λοιδορήσετ’, οὐκ ἀναισχυντήσετε;</l>
 					<l>παύσασθ’, ἐπαναχωρεῖτε, μὴ σκυλεύετε.</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>οἴμ’ ὡς κακῶς πέπραγέ μου τὸ τοξικόν.</l>
 				</sp>
@@ -1429,7 +1429,7 @@ bring up to P3
 					<l>ἥκειν ἐνόμισας, ἢ γυναιξὶν οὐκ οἴει</l>
 					<l n="465">χολὴν ἐνεῖναι;</l>
 				</sp>
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l part="Y">νὴ τὸν Ἀπόλλω καὶ μάλα</l>
 					<l>πολλήν γ’, ἐάνπερ πλησίον κάπηλος ᾖ.</l>
@@ -1477,7 +1477,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="epirrheme">
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>καὶ μὴν αὐτῶν τοῦτ’ ἐπιθυμῶ νὴ τὸν Δία πρῶτα πυθέσθαι,</l>
 						<l>ὅ τι βουλόμεναι τὴν πόλιν ἡμῶν ἀπεκλῄσατε τοῖσι μοχλοῖσιν.</l>
@@ -1486,7 +1486,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l>ἵνα τἀργύριον σῶν παρέχοιμεν καὶ μὴ πολεμοῖτε δῑ αὐτό.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>διὰ τἀργύριον πολεμοῦμεν γάρ;</l>
 					</sp>
@@ -1497,7 +1497,7 @@ bring up to P3
 						<l>ἀεί τινα κορκορυγὴν ἐκύκων. οἱ δ’ οὖν τοῦδ’ οὕνεκα δρώντων</l>
 						<l>ὅ τι βούλονται· τὸ γὰρ ἀργύριον τοῦτ’ οὐκέτι μὴ καθέλωσιν.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ἀλλὰ τί δράσεις;</l>
 					</sp>
@@ -1505,7 +1505,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l part="Y">τοῦτό μ’ ἐρωτᾷς; ἡμεῖς ταμιεύσομεν αὐτό.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ὑμεῖς ταμιεύσετε τἀργύριον;</l>
 					</sp>
@@ -1514,7 +1514,7 @@ bring up to P3
 						<l part="Y">τί &lt;δὲ&gt; δεινὸν τοῦτο νομίζεις;</l>
 						<l n="495">οὐ καὶ τἄνδον χρήματα πάντως ἡμεῖς ταμιεύομεν ὑμῖν;</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ἀλλ’ οὐ ταὐτόν.</l>
 					</sp>
@@ -1522,7 +1522,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l part="Y">πῶς οὐ ταὐτόν;</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">πολεμητέον ἔστ’ ἀπὸ τούτου.</l>
 					</sp>
@@ -1530,7 +1530,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l>ἀλλ’ οὐδὲν δεῖ πρῶτον πολεμεῖν.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">πῶς γὰρ σωθησόμεθ’ ἄλλως;</l>
 					</sp>
@@ -1538,7 +1538,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l>ἡμεῖς ὑμᾶς σώσομεν.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">ὑμεῖς;</l>
 					</sp>
@@ -1546,7 +1546,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l part="Y">ἡμεῖς μέντοι.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">σχέτλιόν γε.</l>
 					</sp>
@@ -1554,7 +1554,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l>ὡς σωθήσει, κἂν μὴ βούλῃ.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">δεινόν &lt;γε&gt; λέγεις.</l>
 					</sp>
@@ -1563,7 +1563,7 @@ bring up to P3
 						<l part="Y">ἀγανακτεῖς.</l>
 						<l n="500">ἀλλὰ ποιητέα ταῦτ’ ἐστὶν ὅμως.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">νὴ τὴν Δήμητρ’ ἄδικόν γε.</l>
 					</sp>
@@ -1571,7 +1571,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l>σωστέον ὦ τᾶν.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">κεἰ μὴ δέομαι;</l>
 					</sp>
@@ -1579,7 +1579,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l part="Y">τοῦδ’ οὕνεκα καὶ πολὺ μᾶλλον.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ὑμῖν δὲ πόθεν περὶ τοῦ πολέμου τῆς τ’ εἰρήνης ἐμέλησεν;</l>
 					</sp>
@@ -1587,7 +1587,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l>ἡμεῖς φράσομεν.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">λέγε δὴ ταχέως, ἵνα μὴ κλάῃς,</l>
 					</sp>
@@ -1596,16 +1596,16 @@ bring up to P3
 						<l part="Y">ἀκροῶ δή,</l>
 						<l>καὶ τὰς χεῖρας πειρῶ κατέχειν.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">ἀλλ’ οὐ δύναμαι· χαλεπὸν γὰρ</l>
 						<l n="505">ὑπὸ τῆς ὀργῆς αὐτὰς ἴσχειν.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α.</speaker>
 						<l part="Y">κλαύσει τοίνυν πολὺ μᾶλλον.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>τοῦτο μὲν ὦ γραῦ σαυτῇ κρώξαις· σὺ δέ μοι λέγε.</l>
 					</sp>
@@ -1622,11 +1622,11 @@ bring up to P3
 						<l>ἐν τῷ δήμῳ τήμερονὑμῖν;’ ‘τίδὲ σοὶ ταῦτ’;’ ἦ δ’ ὃς ἂν ἁνήρ.</l>
 						<l n="515">‘οὐ σιγήσει;’ κἀγὼ ἐσίγων.</l>
 					</sp>
-					<sp who="#gyneb">
+					<sp who="#gyne_b">
 						<speaker>Γυνὴ Β.</speaker>
 						<l part="Y">ἀλλ’ οὐκ ἂν ἐγώ ποτ’ ἐσίγων.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>κἂν ᾤμωζές γ’, εἰ μὴ ’σίγας.</l>
 					</sp>
@@ -1638,7 +1638,7 @@ bring up to P3
 						<l>ὁ δέ μ’ εὐθὺς ὑποβλέψας &lt;ἂν&gt; ἔφασκ’, εἰ μὴ τὸν στήμονα νήσω,</l>
 						<l n="520">ὀτοτύξεσθαι μακρὰ τὴν κεφαλήν· ‘πόλεμος δ’ ἄνδρεσσι μελήσει.’</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ὀρθῶς γε λέγων νὴ Δί’ ἐκεῖνος.</l>
 					</sp>
@@ -1653,7 +1653,7 @@ bring up to P3
 						<l>ἢν οὖν ἡμῶν χρηστὰ λεγουσῶν ἐθελήσητ’ ἀντακροᾶσθαι</l>
 						<l>κἀντισιωπᾶθ’ ὥσπερ χἠμεῖς, ἐπανορθώσαιμεν ἂν ὑμᾶς.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ὑμεῖς ἡμᾶς; δεινόν γε λέγεις κοὐ τλητὸν ἔμοιγε.</l>
 					</sp>
@@ -1661,7 +1661,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l part="Y">σιώπα.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l n="530">σοί γ’ ὦ κατάρατε σιωπῶ ’γώ, καὶ ταῦτα κάλυμμα φορούσῃ</l>
 						<l>περὶ τὴν κεφαλήν; μή νυν ζῴην.</l>
@@ -1676,7 +1676,7 @@ bring up to P3
 						<l>ἔχε καὶ περίθου περὶ τὴν κεφαλήν,</l>
 						<l>κᾆτα σιώπα</l>
 					</sp>
-					<sp who="#gyneg">
+					<sp who="#gyne_g">
 						<speaker>Γυνὴ Γ.</speaker>
 						<l n="535">καὶ τοῦτον τὸν καλαθίσκον.</l>
 					</sp>
@@ -1725,7 +1725,7 @@ bring up to P3
 						<l>κᾆτ’ ἐντήξῃ τέτανον τερπνὸν τοῖς ἀνδράσι καὶ ῥοπαλισμούς,</l>
 						<l>οἶμαί ποτε Λυσιμάχας ἡμᾶς ἐν τοῖς Ἕλλησι καλεῖσθαι.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l n="555">τί ποιησάσας;</l>
 					</sp>
@@ -1734,7 +1734,7 @@ bring up to P3
 						<l part="Y">ἢν παύσωμεν πρώτιστον μὲν ξὺν ὅπλοισιν</l>
 						<l>ἀγοράζοντας καὶ μαινομένους.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α.</speaker>
 						<l part="Y">νὴ τὴν Παφίαν Ἀφροδίτην.</l>
 					</sp>
@@ -1743,7 +1743,7 @@ bring up to P3
 						<l>νῦν μὲν γὰρ δὴ κἀν ταῖσι χύτραις κἀν τοῖς λαχάνοισιν ὁμοίως</l>
 						<l>περιέρχονται κατὰ τὴν ἀγορὰν ξὺν ὅπλοις ὥσπερ Κορύβαντες.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>νὴ Δία· χρὴ γὰρ τοὺς ἀνδρείους.</l>
 					</sp>
@@ -1752,14 +1752,14 @@ bring up to P3
 						<l part="Y">καὶ μὴν τό γε πρᾶγμα γέλοιον,</l>
 						<l n="560">ὅταν ἀσπίδ’ ἔχων καὶ Γοργόνα τις κᾆτ’ ὠνῆται κορακίνους.</l>
 					</sp>
-					<sp who="#gyneb">
+					<sp who="#gyne_b">
 						<speaker>Γυνὴ Β.</speaker>
 						<l>νὴ Δί’ ἐγὼ γοῦν ἄνδρα κομήτην φυλαρχοῦντ’ εἶδον ἐφ’ ἵππου</l>
 						<l>ἐς τὸν χαλκοῦν ἐμβαλλόμενον πῖλον λέκιθον παρὰ γραός·</l>
 						<l>ἕτερος δ’ &lt;αὖ&gt; Θρᾷξ πέλτην σείων κἀκόντιον ὥσπερ ὁ Τηρεύς,</l>
 						<l>ἐδεδίσκετο τὴν ἰσχαδόπωλιν καὶ τὰς δρυπεπεῖς κατέπινεν.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l n="565">πῶς οὖν ὑμεῖς δυναταὶ παῦσαι τεταραγμένα πράγματα πολλὰ</l>
 						<l>ἐν ταῖς χώραις καὶ διαλῦσαι;</l>
@@ -1768,7 +1768,7 @@ bring up to P3
 						<speaker>Λυσιστράτη</speaker>
 						<l part="Y">φαύλως πάνυ.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">πῶς; ἀπόδειξον.</l>
 					</sp>
@@ -1779,7 +1779,7 @@ bring up to P3
 						<l>οὕτως καὶ τὸν πόλεμον τοῦτον διαλύσομεν, ἤν τις ἐάσῃ,</l>
 						<l n="570">διενεγκοῦσαι διὰ πρεσβειῶν τὸ μὲν ἐνταυθοῖ τὸ δ’ ἐκεῖσε.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ἐξ ἐρίων δὴ καὶ κλωστήρων καὶ ἀτράκτων πράγματα δεινὰ</l>
 						<l>παύσειν οἴεσθ’ ὦ ἀνόητοι;</l>
@@ -1789,7 +1789,7 @@ bring up to P3
 						<l part="Y">κἂν ὑμῖν γ’ εἴ τις ἐνῆν νοῦς,</l>
 						<l>ἐκ τῶν ἐρίων τῶν ἡμετέρων ἐπολιτεύεσθ’ ἂν ἅπαντα.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>πῶς δή; φέρ’ ἴδω.</l>
 					</sp>
@@ -1809,7 +1809,7 @@ bring up to P3
 						<l n="585">δεῦρο ξυνάγειν καὶ συναθροίξειν εἰς ἕν, κἄπειτα ποιῆσαι</l>
 						<l>τολύπην μεγάλην κᾆτ’ ἐκ ταύτης τῷ δήμῳ χλαῖναν ὑφῆναι.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>οὔκουν δεινὸν ταυτὶ ταύτας ῥαβδίξειν καὶ τολυπεύειν,</l>
 						<l>αἶς οὐδὲ μετῆν πάνυ τοῦ πολέμου;</l>
@@ -1820,7 +1820,7 @@ bring up to P3
 						<l>πλεῖν ἤ γε διπλοῦν αὐτὸν φέρομεν, πρώτιστον μέν γε τεκοῦσαι</l>
 						<l n="590">κἀκπέμψασαι παῖδας ὁπλίτας.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l part="Y">σίγα, μὴ μνησικακήσῃς.</l>
 					</sp>
@@ -1830,7 +1830,7 @@ bring up to P3
 						<l>μονοκοιτοῦμεν διὰ τὰς στρατιάς. καὶ θἠμέτερον μὲν ἐᾶτε,</l>
 						<l>περὶ τῶν δὲ κορῶν ἐν τοῖς θαλάμοις γηρασκουσῶν ἀνιῶμαι.</l>
 					</sp>
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>οὔκουν χἄνδρες γηράσκουσιν;</l>
 					</sp>
@@ -1845,7 +1845,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="antipnigos">
-					<sp who="#proboylos">
+					<sp who="#proboulos">
 						<speaker>Πρόβουλος</speaker>
 						<l>ἀλλ’ ὅστις ἔτι στῦσαι δυνατὸς—</l>
 					</sp>
@@ -1856,11 +1856,11 @@ bring up to P3
 						<l>μελιτοῦτταν ἐγὼ καὶ δὴ μάξω.</l>
 						<l>λαβὲ ταυτὶ καὶ στεφάνωσαι.</l>
 					</sp>
-					<sp who="#gyneks">
+					<sp who="#gyne_x">
 						<speaker>Γυνὴ Ξ.</speaker>
 						<l>καὶ ταυτασὶ δέξαι παρ’ ἐμοῦ.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α.</speaker>
 						<l>καὶ τουτονγὶ λαβὲ τὸν στέφανον.</l>
 					</sp>
@@ -1874,7 +1874,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#proboylos">
+				<sp who="#proboulos">
 					<speaker>Πρόβουλος</speaker>
 					<l>εἶτ’ οὐχὶ ταῦτα δεινὰ πάσχειν ἔστ’ ἐμέ;</l>
 					<l>νὴ τὸν Δί’ ἀλλὰ τοῖς προβούλοις ἄντικρυς</l>
@@ -2074,7 +2074,7 @@ bring up to P3
 					<l>ἕλκουσιν. ἤδη γοῦν τις αὐτῶν ἔρχεται.</l>
 					<l>αὕτη σὺ ποῖ θεῖς;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α.</speaker>
 					<l part="Y">οἴκαδ’ ἐλθεῖν βούλομαι.</l>
 					<l>οἴκοι γάρ ἐστιν ἔριά μοι Μιλήσια</l>
@@ -2085,7 +2085,7 @@ bring up to P3
 					<l part="Y">ποίων σέων;</l>
 					<l>οὐκ εἶ πάλιν;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α.</speaker>
 					<l part="Y">ἀλλ’ ἥξω ταχέως νὴ τὼ θεὼ</l>
 					<l>ὅσον διαπετάσασ’ ἐπὶ τῆς κλίνης μόνον.</l>
@@ -2094,7 +2094,7 @@ bring up to P3
 					<speaker>Λυσιστράτη</speaker>
 					<l>μὴ διαπετάννυ, μηδ’ ἀπέλθῃς μηδαμῇ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α.</speaker>
 					<l>ἀλλ’ ἐῶ ’πολέσθαι τἄρῑ;</l>
 				</sp>
@@ -2102,7 +2102,7 @@ bring up to P3
 					<speaker>Λυσιστράτη</speaker>
 					<l part="Y">ἢν τούτου δέῃ.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β.</speaker>
 					<l n="735">τάλαιν’ ἐγώ, τάλαινα τῆς Ἀμοργίδος,</l>
 					<l>ἣν ἄλοπον οἴκοι καταλέλοιφ’.</l>
@@ -2113,7 +2113,7 @@ bring up to P3
 					<l>ἐπὶ τὴν Ἄμοργιν τὴν ἄλοπον ἐξέρχεται.</l>
 					<l>χώρει πάλιν δεῦρ’.</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β.</speaker>
 					<l part="Y">ἀλλὰ νὴ τὴν Φωσφόρον</l>
 					<l>ἔγωγ’ ἀποδείρασ’ αὐτίκα μάλ’ ἀνέρχομαι.</l>
@@ -2123,7 +2123,7 @@ bring up to P3
 					<l n="740">μή μἀποδείρῃς. ἢν γὰρ ἄρξῃς τοῦτο σύ,</l>
 					<l>ἑτέρα γυνὴ ταὐτὸν ποιεῖν βουλήσεται.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>ὦ πότνῑ Εἰλείθυῑ ἐπίσχες τοῦ τόκου,</l>
 					<l>ἕως ἂν εἰς ὅσιον μόλω ’γὼ χωρίον.</l>
@@ -2132,7 +2132,7 @@ bring up to P3
 					<speaker>Λυσιστράτη</speaker>
 					<l>τί ταῦτα ληρεῖς;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">αὐτίκα μάλα τέξομαι.</l>
 				</sp>
@@ -2140,7 +2140,7 @@ bring up to P3
 					<speaker>Λυσιστράτη</speaker>
 					<l n="745">ἀλλ’ οὐκ ἐκύεις σύ γ’ ἐχθές.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">ἀλλὰ τήμερον.</l>
 					<l>ἀλλ’ οἴκαδέ μ’ ὡς τὴν μαῖαν ὦ Λυσιστράτη</l>
@@ -2151,7 +2151,7 @@ bring up to P3
 					<l part="Y">τίνα λόγον λέγεις;</l>
 					<l>τί τοῦτ’ ἔχεις τὸ σκληρόν;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">ἄρρεν παιδίον.</l>
 					<milestone ed="p" n="749" unit="card"/>
@@ -2163,7 +2163,7 @@ bring up to P3
 					<l>ὦ καταγέλαστ’ ἔχουσα τὴν ἱερὰν κυνῆν</l>
 					<l>κυεῖν ἔφασκες;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">καὶ κυῶ γε νὴ Δία.</l>
 				</sp>
@@ -2171,7 +2171,7 @@ bring up to P3
 					<speaker>Λυσιστράτη</speaker>
 					<l>τί δῆτα ταύτην εἶχες;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">ἵνα μ’ εἰ καταλάβοι</l>
 					<l>ὁ τόκος ἔτ’ ἐν πόλει, τέκοιμ’ ἐς τὴν κυνῆν</l>
@@ -2182,12 +2182,12 @@ bring up to P3
 					<l>τί λέγεις; προφασίζει· περιφανῆ τὰ πράγματα.</l>
 					<l>οὐ τἀμφιδρόμια τῆς κυνῆς αὐτοῦ μενεῖς;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>ἀλλ’ οὐ δύναμαι ’γωγ’ οὐδὲ κοιμᾶσθ’ ἐν πόλει,</l>
 					<l>ἐξ οὗ τὸν ὄφιν εἶδον τὸν οἰκουρόν ποτε.</l>
 				</sp>
-				<sp who="#gyned">
+				<sp who="#gyne_d">
 					<speaker>Γυνὴ Δ</speaker>
 					<l n="760">ἐγὼ δ’ ὑπὸ τῶν γλαυκῶν γε τάλαιν’ ἀπόλλυμαι</l>
 					<l>ταῖς ἀγρυπνίαισι κακκαβαζουσῶν ἀεί.</l>
@@ -2202,7 +2202,7 @@ bring up to P3
 					<l>ὡς χρησμὸς ἡμῖν ἐστιν ἐπικρατεῖν, ἐὰν</l>
 					<l>μὴ στασιάσωμεν· ἔστι δ’ ὁ χρησμὸς οὑτοσί.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>λέγ’ αὐτὸν ἡμῖν ὅ τι λέγει.</l>
 				</sp>
@@ -2214,7 +2214,7 @@ bring up to P3
 					<l>παῦλα κακῶν ἔσται, τὰ δ’ ὑπέρτερα νέρτερα θήσει</l>
 					<l>Ζεὺς ὑψιβρεμέτης—</l>
 				</sp>
-				<sp who="#gyneb">
+				<sp who="#gyne_b">
 					<speaker>Γυνὴ Β</speaker>
 					<l part="Y">ἐπάνω κατακεισόμεθ’ ἡμεῖς;</l>
 				</sp>
@@ -2224,7 +2224,7 @@ bring up to P3
 					<l n="775">ἐξ ἱεροῦ ναοῖο χελιδόνες, οὐκέτι δόξει</l>
 					<l>ὄρνεον οὐδ’ ὁτιοῦν καταπυγωνέστερον εἶναι.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>σαφής γ’ ὁ χρησμὸς νὴ  Δί’.</l>
 				</sp>
@@ -2502,7 +2502,7 @@ bring up to P3
 					<l part="Y">μὴ δῆτ’, ἀλλὰ τῷ γοῦν παιδίῳ</l>
 					<l>ὑπάκουσον· οὗτος οὐ καλεῖς τὴν μαμμίαν;</l>
 				</sp>
-				<sp who="#paiskinesioy">
+				<sp who="#pais_kinesiou">
 					<speaker>Παῖς Κινησίου</speaker>
 					<l>μαμμία, μαμμία, μαμμία.</l>
 				</sp>
@@ -2849,7 +2849,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l n="980">πᾷ τᾶν Ἀσανᾶν ἐστιν ἁ γερωχία</l>
 						<l>ἢ τοὶ πρυτάνιες; λῶ τι μυσίξαι νέον.</l>
@@ -2858,7 +2858,7 @@ bring up to P3
 						<speaker>Κινησίας</speaker>
 						<l>σὺ δ’ εἶ πότερον ἄνθρωπος ἢ κονίσαλος;</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l>κᾶρυξ ἐγὼν ὦ κυρσάνιε ναὶ τὼ σιὼ</l>
 						<l>ἔμολον ἀπὸ Σπάρτας περὶ τᾶν διαλλαγᾶν.</l>
@@ -2867,7 +2867,7 @@ bring up to P3
 						<speaker>Κινησίας</speaker>
 						<l n="985">κἄπειτα δόρυ δῆθ’ ὑπὸ μάλης ἥκεις ἔχων;</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l>οὐ τὸν Δί’ οὐκ ἐγών γα.</l>
 					</sp>
@@ -2877,7 +2877,7 @@ bring up to P3
 						<l>τί δὴ προβάλλει τὴν χλαμύδ’; ἢ βουβωνιᾷς</l>
 						<l>ὑπὸ τῆς ὁδοῦ;</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l part="Y">παλαιόρ γα ναὶ τὸν Κάστορα</l>
 						<l>ὥνθρωπος.</l>
@@ -2886,7 +2886,7 @@ bring up to P3
 						<speaker>Κινησίας</speaker>
 						<l part="Y">ἀλλ’ ἔστυκας ὦ μιαρώτατε.</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l n="990">οὐ τὸν Δί’ οὐκ ἐγών γα· μηδ’ αὖ πλαδδίη.</l>
 					</sp>
@@ -2894,7 +2894,7 @@ bring up to P3
 						<speaker>Κινησίας</speaker>
 						<l>τί δ’ ἐστί σοι τοδί;</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l part="Y">σκυτάλα Λακωνικά.</l>
 					</sp>
@@ -2904,7 +2904,7 @@ bring up to P3
 						<l>ἀλλ’ ὡς πρὸς εἰδότ’ ἐμὲ σὺ τἀληθῆ λέγε.</l>
 						<l>τί τὰ πράγμαθ’ ὑμῖν ἐστι τἀν Λακεδαίμονι;</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l n="995">ὀρσὰ Λακεδαίμων πᾶα καὶ τοὶ σύμμαχοι</l>
 						<l>ἅπαντες ἐστύκαντι· Πελλάνας δὲ δεῖ.</l>
@@ -2914,7 +2914,7 @@ bring up to P3
 						<l>ἀπὸ τοῦ δὲ τουτὶ τὸ κακὸν ὑμῖν ἐνέπεσεν;</l>
 						<l>ἀπὸ Πανός;</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l part="Y">οὔκ, ἀλλ’ ἆρχεν οἰῶ Λαμπιτώ,</l>
 						<l>ἔπειτα τἄλλαι ταὶ κατὰ Σπάρταν ἅμα</l>
@@ -2925,7 +2925,7 @@ bring up to P3
 						<speaker>Κινησίας</speaker>
 						<l>πῶς οὖν ἔχετε;</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l part="Y">μογίομες. ἂν γὰρ τὰν πόλιν</l>
 						<l>ᾇπερ λυχνοφορίοντες ἐπικεκύφαμες.</l>
@@ -2942,7 +2942,7 @@ bring up to P3
 						<l>ἐγὼ δ’ ἑτέρους ἐνθένδε τῇ βουλῇ φράσω</l>
 						<l>πρέσβεις ἑλέσθαι τὸ πέος ἐπιδείξας τοδί.</l>
 					</sp>
-					<sp who="#kerykslakedaimonion">
+					<sp who="#keryx_lakedaimonion">
 						<speaker>Κῆρυξ Λακεδαιμονίων</speaker>
 						<l>ποτάομαι· κράτιστα γὰρ παντᾷ λέγεις.</l>
 						<milestone ed="p" n="1014" unit="card"/>
@@ -3027,7 +3027,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐ παρασκευαζόμεσθα</l>
 						<l>τῶν πολιτῶν οὐδέν’ ὦνδρες</l>
@@ -3047,7 +3047,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἑστιᾶν δὲ μέλλομεν ξένους</l>
 						<l>τινὰς Καρυστίους, ἄν‐</l>
@@ -3066,7 +3066,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ἀπὸ τῆς Σπάρτης οἱδὶ πρέσβεις ἕλκοντες ὑπήνας</l>
 						<l>χωροῦσ’, ὥσπερ χοιροκομεῖον περὶ τοῖς μηροῖσιν ἔχοντες.</l>
@@ -3080,7 +3080,7 @@ bring up to P3
 						<l>τί δεῖ ποθ’ ὑμὲ πολλὰ μυσίδδειν ἔπη;</l>
 						<l>ὁρῆν γὰρ ἔξεσθ’ ὡς ἔχοντες ἵκομες.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός </speaker>
 						<l>βαβαί· νενεύρωται μὲν ἥδε συμφορὰ</l>
 						<l>δεινῶς, †τεθερμῶσθαί γε† χεῖρον φαίνεται.</l>
@@ -3090,7 +3090,7 @@ bring up to P3
 						<l n="1080">ἄφατα. τί κα λέγοι τις; ἀλλ’ ὅπᾳ σέλει</l>
 						<l>παντᾷ τις ἐλσὼν ἁμὶν εἰράναν σέτω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός </speaker>
 						<l>καὶ μὴν ὁρῶ καὶ τούσδε τοὺς αὐτόχθονας</l>
 						<l>ὥσπερ παλαιστὰς ἄνδρας ἀπὸ τῶν γαστέρων</l>
@@ -3102,7 +3102,7 @@ bring up to P3
 						<l>τίς ἂν φράσεις ποῦ’ στιν ἡ Λυσιστράτη;</l>
 						<l>ὡς ἄνδρες ἡμεῖς οὑτοιὶ τοιουτοιί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός </speaker>
 						<l>χαὔτη ξυνᾴδει χἠτέρα ταύτῃ νόσῳ.</l>
 						<l>ἦ που πρὸς ὄρθρον σπασμὸς ὑμᾶς λαμβάνει;</l>
@@ -3113,7 +3113,7 @@ bring up to P3
 						<l>ὥστ’ εἴ τις ἡμᾶς μὴ διαλλάξει ταχύ,</l>
 						<l>οὐκ ἔσθ’ ὅπως οὐ Κλεισθένη βινήσομεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ σωφρονεῖτε, θαἰμάτια λήψεσθ’, ὅπως</l>
 						<l>τῶν Ἑρμοκοπιδῶν μή τις ὑμᾶς ὄψεται.</l>
@@ -3163,7 +3163,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαῖρ’ ὦ πασῶν ἀνδρειοτάτη· δεῖ δὴ νυνί σε γενέσθαι</l>
 						<l>δεινὴν &lt;δειλὴν&gt; ἀγαθὴν φαύλην σεμνὴν ἀγανὴν πολύπειρον·</l>
@@ -3346,7 +3346,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στρωμάτων δὲ ποικίλων καὶ</l>
 						<l n="1190">χλανιδίων καὶ ξυστίδων καὶ</l>
@@ -3367,7 +3367,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δέ τῳ μὴ σῖτος ὑμῶν</l>
 						<l>ἔστι, βόσκει δ’ οἰκέτας καὶ</l>
@@ -3388,7 +3388,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Lyric-Scene">
-				<sp who="#athenaiosa">
+				<sp who="#athenaios_a">
 					<speaker>Ἀθηναῖος Α.</speaker>
 					<l>ἄνοιγε τὴν θύραν· παραχωρεῖν οὐ θέλεις;</l>
 					<l>ὑμεῖς τί κάθησθε; μῶν ἐγὼ τῇ λαμπάδι</l>
@@ -3396,23 +3396,23 @@ bring up to P3
 					<l>οὐκ ἂν ποιήσαιμ’. εἰ δὲ πάνυ δεῖ τοῦτο δρᾶν,</l>
 					<l n="1220">ὑμῖν χαρίσασθαι, προσταλαιπωρήσομεν.</l>
 				</sp>
-				<sp who="#athenaiosb">
+				<sp who="#athenaios_b">
 					<speaker>Ἀθηναῖος Β</speaker>
 					<l>χἠμεῖς γε μετὰ σοῦ ξυνταλαιπωρήσομεν.</l>
 				</sp>
-				<sp who="#athenaiosa">
+				<sp who="#athenaios_a">
 					<speaker>Ἀθηναῖος Α.</speaker>
 					<l>οὐκ ἄπιτε; κωκύσεσθε τὰς τρίχας μακρά.</l>
 					<l>οὐκ ἄπιθ’, ὅπως ἂν οἱ Λάκωνες ἔνδοθεν</l>
 					<l>καθ’ ἡσυχίαν ἀπίωσιν εὐωχημένοι;</l>
 				</sp>
-				<sp who="#athenaiosb">
+				<sp who="#athenaios_b">
 					<speaker>Ἀθηναῖος Β.</speaker>
 					<l n="1225">οὔπω τοιοῦτον συμπόσιον ὄπωπ’ ἐγώ.</l>
 					<l>ἦ καὶ χαρίεντες ἦσαν οἱ Λακωνικοί·</l>
 					<l>ἡμεῖς δ’ ἐν οἴνῳ συμπόται σοφώτατοι.</l>
 				</sp>
-				<sp who="#athenaiosa">
+				<sp who="#athenaios_a">
 					<speaker>Ἀθηναῖος Α.</speaker>
 					<l>ὀρθῶς γ’, ὁτιὴ νήφοντες οὐχ ὑγιαίνομεν·</l>
 					<l>ἢν τοὺς Ἀθηναίους ἐγὼ πείσω λέγων,</l>
@@ -3428,7 +3428,7 @@ bring up to P3
 					<l>ἀλλ’ οὑτοιὶ γὰρ αὖθις ἔρχονται πάλιν</l>
 					<l n="1240">ἐς ταὐτόν. οὐκ ἐρρήσετ’ ὦ μαστιγίαι;</l>
 				</sp>
-				<sp who="#athenaiosb">
+				<sp who="#athenaios_b">
 					<speaker>Ἀθηναῖος Β.</speaker>
 					<l>νὴ τὸν Δί’ ὡς ἤδη γε χωροῦσ’ ἔνδοθεν.</l>
 				</sp>

--- a/tei/aristophanes-peace.xml
+++ b/tei/aristophanes-peace.xml
@@ -55,32 +55,32 @@
 					<person xml:id="paidion">
 						<persName>Παιδίον</persName>
 					</person>
-					<person xml:id="drepanoyrgos">
+					<person xml:id="drepanourgos">
 						<persName>Δρεπανουργός</persName>
 					</person>
 					<person xml:id="thorakopoles">
 						<persName>Θωρακοπώλης</persName>
 					</person>
-					<person xml:id="emixoriona">
-						<persName>Ἡμιχόριον Α</persName>
-					</person>
-					<person xml:id="salpiggopoios">
+					<personGrp xml:id="hemichorion_a">
+						<name>Ἡμιχόριον Α</name>
+					</personGrp>
+					<personGrp xml:id="hemichorion_b">
+						<name>Ἡμιχόριον Β</name>
+					</personGrp>
+					<person xml:id="salpingopoios">
 						<persName>Σαλπιγγοποιός</persName>
 					</person>
-					<person xml:id="paiskleonymoy">
+					<person xml:id="pais_kleonymou">
 						<persName>Παῖς Κλεωνύμου</persName>
 					</person>
 					<person xml:id="trygaios">
 						<persName>Τρυγαῖος</persName>
 					</person>
-					<person xml:id="ierokles">
+					<person xml:id="hierokles">
 						<persName>Ἱεροκλῆς</persName>
 					</person>
 					<person xml:id="kydoimos">
 						<persName>Κύδοιμος</persName>
-					</person>
-					<person xml:id="emixorionb">
-						<persName>Ἡμιχόριον Β</persName>
 					</person>
 					<person xml:id="polemos">
 						<persName>Πόλεμος</persName>
@@ -88,7 +88,7 @@
 					<person xml:id="doryksos">
 						<persName>Δορυξός</persName>
 					</person>
-					<person xml:id="lofopoios">
+					<person xml:id="lophopoios">
 						<persName>Λοφοποιός</persName>
 					</person>
 					<person xml:id="kranopoios">
@@ -97,19 +97,19 @@
 					<person xml:id="oiketes">
 						<persName>Οἰκέτης</persName>
 					</person>
-					<person xml:id="oiketesa">
+					<person xml:id="oiketes_a">
 						<persName>Οἰκέτης Α</persName>
 					</person>
-					<person xml:id="oiketesb">
+					<person xml:id="oiketes_b">
 						<persName>Οἰκέτης Β</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="ermes">
+					<person xml:id="hermes">
 						<persName>Ἑρμῆς</persName>
 					</person>
-					<person xml:id="paislamaxoy">
+					<person xml:id="pais_lamachou">
 						<persName>Παῖς Λαμάχου</persName>
 					</person>
 				</listPerson>
@@ -195,61 +195,61 @@ bring up to P3
 		<body>
 			<div1 type="Prologue">
 				<milestone n="1" unit="card"/>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l>αἶρ’ αἶρε μᾶζαν ὡς τάχιστα κανθάρῳ.</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l>ἰδού. δὸς αὐτῷ, τῷ κάκιστ’ ἀπολουμένῳ</l>
 					<l>καὶ μήποτ’ αὐτῆς μᾶζαν ἡδίω φάγοι.</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l>δὸς μᾶζαν ἑτέραν, ἐξ ὀνίδων πεπλασμένην.</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l n="5">ἰδοὺ μάλ’ αὖφις. ποῦ γὰρ ἣν νῦν δὴ ’φερες;</l>
 					<l>κατέφαγεν;</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l part="Y">οὐ μὰ τὸν Δί’ ἀλλ’ ἐξαρπάσας</l>
 					<l>ὅλην ἐνέκαψε περικυλίσας τοῖν ποδοῖν.</l>
 					<l>ἀλλ’ ὡς τάχιστα τρῖβε πολλὰς καὶ πυκνάς.</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l>ἄνδρες κοπρολόγοι προσλάβεσθε πρὸς θεῶν,</l>
 					<l n="10">εἰ μή με βούλεσθ’ ἀποπνιγέντα περιιδεῖν.</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l>ἑτέραν ἑτέραν δός, παιδὸς ἡταιρηκότος·</l>
 					<l>τετριμμένης γάρ φησιν ἐπιθυμεῖν.</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l part="Y">ἰδού.</l>
 					<l>ἑνὸς μὲν ὦνδρες ἀπολελύσθαι μοι δοκῶ·</l>
 					<l>οὐδεὶς γὰρ ἂν φαίη με μάττοντ’ ἐσθίειν.</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l n="15">αἰβοῖ, φέρ’ ἄλλην χἀτέραν μοι χἀτέραν,</l>
 					<l>καὶ τρῖβ’ &lt;ἔθ’&gt; ἑτέρας.</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l part="Y">μὰ τὸν Ἀπόλλω ’γὼ μὲν οὔ·</l>
 					<l>οὐ γὰρ ἔθ’ οἶός τ’ εἴμ’ ὑπερέχειν τῆς ἀντλίας.</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l>αὐτὴν ἄρ’ οἴσω συλλαβὼν τὴν ἀντλίαν.</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l>νὴ τὸν Δί’ ἐς κόρακάς γε καὶ σαυτόν γε πρός.</l>
 					<l n="20">ὑμῶν δέ γ’ εἴ τις οἶδ’ ἐμοὶ κατειπάτω,</l>
@@ -275,16 +275,16 @@ bring up to P3
 					<l n="40">οὐκ οἶδ’. Ἀφροδίτης μὲν γὰρ οὔ μοι φαίνεται,</l>
 					<l>οὐ μὴν Χαρίτων γε.</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l part="Y">τοῦ γάρ ἐστ’;</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l part="Y">οὐκ ἔσθ’ ὅπως</l>
 					<l>τοῦτ’ ἔστι τὸ τέρας οὐ Διὸς καταιβάτου.</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l>οὐκοῦν ἂν ἤδη τῶν θεατῶν τις λέγοι</l>
 					<l>νεανίας δοκησίσοφος, ‘τὸ δὲ πρᾶγμα τί;</l>
@@ -293,12 +293,12 @@ bring up to P3
 					<l>‘δοκέω μέν, ἐς Κλέωνα τοῦτ’ αἰνίσσεται,</l>
 					<l>ὡς κεῖνος ἀναιδέως τὴν σπατίλην ἐσθίει.’</l>
 				</sp>
-				<sp who="#oiketesb">
+				<sp who="#oiketes_b">
 					<speaker>Οἰκέτης Β</speaker>
 					<l>ἀλλ’ εἰσιὼν τῷ κανθάρῳ δώσω πιεῖν.</l>
 					<milestone ed="p" n="50" unit="card"/>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l n="50">ἐγὼ δὲ τὸν λόγον γε τοῖσι παιδίοις</l>
 					<l>καὶ τοῖσιν ἀνδρίοισι καὶ τοῖς ἀνδράσιν</l>
@@ -318,7 +318,7 @@ bring up to P3
 					<l>ὦ Ζεῦ τί δρασείεις ποθ’ ἡμῶν τὸν λεών;</l>
 					<l>λήσεις σεαυτὸν τὰς πόλεις ἐκκοκκίσας.</l>
 				</sp>
-				<sp who="#oiketesa">
+				<sp who="#oiketes_a">
 					<speaker>Οἰκέτης Α</speaker>
 					<l>τοῦτ’ ἔστι τουτὶ τὸ κακὸν αὔθ’ οὑγὼ ’λεγον.</l>
 					<l n="65">τὸ γὰρ παράδειγμα τῶν μανιῶν ἀκούετε·</l>
@@ -352,7 +352,7 @@ bring up to P3
 						<l>εἰ δὲ ποιήσεις τοῦτο, κατ’ οἴκους</l>
 						<l>αὐτοῦ μεῖνον τοὺς ἡμετέρους.</l>
 					</sp>
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l n="90">ὦ δέσποτ’ ἄναξ ὡς παραπαίεις.</l>
 					</sp>
@@ -360,7 +360,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>σίγα σίγα.</l>
 					</sp>
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l>ποῖ δῆτ’ ἄλλως μετεωροκοπεῖς;</l>
 					</sp>
@@ -369,7 +369,7 @@ bring up to P3
 						<l>ὑπὲρ Ἑλλήνων πάντων πέτομαι</l>
 						<l>τόλμημα νέον παλαμησάμενος.</l>
 					</sp>
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l n="95">τί πέτει; τί μάτην οὐχ ὑγιαίνεις;</l>
 					</sp>
@@ -384,7 +384,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l>οὐκ ἔσθ’ ὅπως σιγήσομ’, ἢν μή μοι φράσῃς</l>
 						<l>ὅποι πέτεσθαι διανοεῖ.</l>
@@ -394,7 +394,7 @@ bring up to P3
 						<l part="Y">τί δ’ ἄλλο γ’ ἢ</l>
 						<l>ὡς τὸν Δί’ ἐς τὸν οὐρανόν;</l>
 					</sp>
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l part="Y">τίνα νοῦν ἔχων;</l>
 					</sp>
@@ -403,7 +403,7 @@ bring up to P3
 						<l n="105">ἐρησόμενος ἐκεῖνον Ἑλλήνων πέρι</l>
 						<l>ἁπαξαπάντων ὅ τι ποιεῖν βουλεύεται.</l>
 					</sp>
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l>ἐὰν δὲ μή σοι καταγορεύῃ;</l>
 					</sp>
@@ -412,7 +412,7 @@ bring up to P3
 						<l part="Y">γράψομαι</l>
 						<l>Μήδοισιν αὐτὸν προδιδόναι τὴν Ἑλλάδα.</l>
 					</sp>
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l>μὰ τὸν Διόνυσον οὐδέποτε ζῶντός γ’ ἐμοῦ.</l>
 					</sp>
@@ -420,7 +420,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="110">οὐκ ἔστι παρὰ ταῦτ’ ἄλλ’.</l>
 					</sp>
-					<sp who="#oiketesa">
+					<sp who="#oiketes_a">
 						<speaker>Οἰκέτης Α</speaker>
 						<l part="Y">ἰοὺ ἰοὺ ἰού·</l>
 						<l>ὦ παιδί’ ὁ πατὴρ ἀπολιπὼν ἀπέρχεται</l>
@@ -556,7 +556,7 @@ bring up to P3
 						<l>καὶ δὴ καθορῶ τὴν οἰκίαν τὴν τοῦ Διός.</l>
 						<l>τίς ἐν Διὸς θύραισιν; οὐκ ἀνοίξετε;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l n="180">πόθεν βροτοῦ με προσέβαλ’; ὦναξ Ἡράκλεις</l>
 						<l>τουτὶ τί ἐστι τὸ κακόν;</l>
@@ -565,7 +565,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">ἱπποκάνθαρος.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ βδελυρὲ καὶ τολμηρὲ κἀναίσχυντε σὺ</l>
 						<l>καὶ μιαρὲ καὶ παμμίαρε καὶ μιαρώτατε,</l>
@@ -576,7 +576,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">μιαρώτατος.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ποδαπὸς τὸ γένος δ’ εἶ; φράζε μοι.</l>
 					</sp>
@@ -584,7 +584,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">μιαρώτατος.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>πατὴρ δέ σοι τίς ἐστ’;</l>
 					</sp>
@@ -592,7 +592,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">ἐμοί; μιαρώτατος.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>οὔτοι μὰ τὴν γῆν ἔσθ’ ὅπως οὐκ ἀποθανεῖ,</l>
 						<l>εἰ μὴ κατερεῖς μοι τοὔνομ’ ὅ τι ποτ’ ἔστι σοι.</l>
@@ -602,7 +602,7 @@ bring up to P3
 						<l n="190">Τρυγαῖος Ἀθμονεύς, ἀμπελουργὸς δεξιός,</l>
 						<l>οὐ συκοφάντης οὐδ’ ἐραστὴς πραγμάτων.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ἥκεις δὲ κατὰ τί;</l>
 					</sp>
@@ -610,7 +610,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">τὰ κρέα ταυτί σοι φέρων.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ δειλακρίων πῶς ἦλθες;</l>
 					</sp>
@@ -620,7 +620,7 @@ bring up to P3
 						<l>ὡς οὐκέτ’ εἶναί σοι δοκῶ μιαρώτατος;</l>
 						<l n="195">ἴθι νυν κάλεσόν μοι τὸν Δί’.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">ἰὴ ἰὴ ἰή,</l>
 						<l>ὅτι οὐδὲ μέλλεις ἐγγὺς εἶναι τῶν θεῶν·</l>
@@ -630,7 +630,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ποῖ γῆς;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">ἰδοὺ γῆς.</l>
 					</sp>
@@ -638,7 +638,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">ἀλλὰ ποῖ;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">πόρρω πάνυ;</l>
 						<l>ὑπ’ αὐτὸν ἀτεχνῶς τοὐρανοῦ τὸν κύτταρον.</l>
@@ -648,7 +648,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="200">πῶς οὖν σὺ δῆτ’ ἐνταῦθα κατελείφθης μόνος;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>τὰ λοιπὰ τηρῶ σκευάρια τὰ τῶν θεῶν,</l>
 						<l>χυτρίδια καὶ σανίδια κἀμφορείδια.</l>
@@ -657,7 +657,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἐξῳκίσαντο δ’ οἱ θεοὶ τίνος οὕνεκα;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>Ἕλλησιν ὀργισθέντες. εἶτ’ ἐνταῦθα μὲν</l>
 						<l n="205">ἵν’ ἦσαν αὐτοὶ τὸν Πόλεμον κατῴκισαν,</l>
@@ -670,7 +670,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="210">τοῦ δ’ οὕνεχ’ ἡμᾶς ταῦτ’ ἔδρασαν; εἰπέ μοι.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὁτιὴ πολεμεῖν ᾑρεῖσθ’ ἐκείνων πολλάκις</l>
 						<l>σπονδὰς ποιούντων· κεἰ μὲν οἱ Λακωνικοὶ</l>
@@ -686,7 +686,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="220">ὁ γοῦν χαρακτὴρ ἡμεδαπὸς τῶν ῥημάτων.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὧν οὕνεκ’ οὐκ οἶδ’ εἴ ποτ’ Εἰρήνην ἔτι</l>
 						<l>τὸ λοιπὸν ὄψεσθ’.</l>
@@ -695,7 +695,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">ἀλλὰ ποῖ γὰρ οἴχεται;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὁ Πόλεμος αὐτὴν ἐνέβαλ’ εἰς ἄντρον βαθύ.</l>
 					</sp>
@@ -703,7 +703,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἐς ποῖον;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">ἐς τουτὶ τὸ κάτω, κἄπειθ’ ὁρᾷς</l>
 						<l n="225">ὅσους ἄνωθεν ἐπεφόρησε τῶν λίθων,</l>
@@ -714,7 +714,7 @@ bring up to P3
 						<l part="Y">εἰπέ μοι,</l>
 						<l>ἡμᾶς δὲ δὴ τί δρᾶν παρασκευάζεται;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>οὐκ οἶδα πλὴν ἕν, ὅτι θυείαν ἑσπέρας</l>
 						<l>ὑπερφυᾶ τὸ μέγεθος εἰσηνέγκατο.</l>
@@ -723,7 +723,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="230">τί δῆτα ταύτῃ τῇ θυείᾳ χρήσεται;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>τρίβειν ἐν αὐτῇ τὰς πόλεις βουλεύεται.</l>
 						<l>ἀλλ’ εἶμι· καὶ γὰρ ἐξιέναι γνώμην ἐμὴν</l>
@@ -924,7 +924,7 @@ bring up to P3
 			<milestone ed="p" n="301" unit="card"/>
 			<div1 type="Parodos">
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεῦρο πᾶς χώρει προθύμως εὐθὺ τῆς σωτηρίας.</l>
 						<l>ὦ Πανέλληνες βοηθήσωμεν, εἴπερ πώποτε,</l>
@@ -940,7 +940,7 @@ bring up to P3
 						<l>οὐ σιωπήσεσθ’, ὅπως μὴ περιχαρεῖς τῷ πράγματι</l>
 						<l n="310">τὸν Πόλεμον ἐκζωπυρήσετ’ ἔνδοθεν κεκραγότες;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἀκούσαντες τοιούτου χαίρομεν κηρύγματος.</l>
 						<l>οὐ γὰρ ἦν ἔχοντας ἥκειν σιτί’ ἡμερῶν τριῶν.</l>
@@ -951,7 +951,7 @@ bring up to P3
 						<l>μὴ παφλάζων καὶ κεκραγὼς ὥσπερ ἡνίκ’ ἐνθάδ’ ἦν,</l>
 						<l n="315">ἐμποδὼν ἡμῖν γένηται τὴν θεὸν μὴ ’ξελκύσαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔτι καὶ νῦν ἔστιν αὐτὴν ὅστις ἐξαιρήσεται,</l>
 						<l>ἢν ἅπαξ ἐς χεῖρας ἔλθῃ τὰς ἐμάς. ἰοῦ ἰοῦ.</l>
@@ -961,7 +961,7 @@ bring up to P3
 						<l>ἐξολεῖτέ μ’ ὦνδρες, εἰ μὴ τῆς βοῆς ἀνήσετε·</l>
 						<l>ἐκδραμὼν γὰρ πάντα ταυτὶ συνταράξει τοῖν ποδοῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="320">ὡς κυκάτω καὶ πατείτω πάντα καὶ ταραττέτω,</l>
 						<l>οὐ γὰρ ἂν χαίροντες ἡμεῖς τήμερον παυσαίμεθ’ ἄν.</l>
@@ -971,7 +971,7 @@ bring up to P3
 						<l>τί τὸ κακόν; τί πάσχετ’ ὦνδρες; μηδαμῶς πρὸς τῶν θεῶν</l>
 						<l>πρᾶγμα κάλλιστον διαφθείρητε διὰ τὰ σχήματα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἔγωγ’ οὐ σχηματίζειν βούλομ’, ἀλλ’ ὑφ’ ἡδονῆς</l>
 						<l n="325">οὐκ ἐμοῦ κινοῦντος αὐτὼ τὼ σκέλει χορεύετον.</l>
@@ -980,7 +980,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>μή τι καὶ νυνί γ’ ἔτ’, ἀλλὰ παῦε παῦ’ ὀρχούμενος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἢν ἰδοὺ καὶ δὴ πέπαυμαι.</l>
 					</sp>
@@ -988,7 +988,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">φῄς γε, παύει δ’ οὐδέπω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἓν μὲν οὖν τουτί μ’ ἔασον ἑλκύσαι, καὶ μηκέτι.</l>
 					</sp>
@@ -996,7 +996,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>τοῦτό νυν, καὶ μηκέτ’ ἄλλο μηδὲν ὀρχήσησθ’ ἔτι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="330">οὐκ ἂν ὀρχησαίμεθ’, εἴπερ ὠφελήσαιμέν τί σε.</l>
 					</sp>
@@ -1004,7 +1004,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἀλλ’ ὁρᾶτ’ οὔπω πέπαυσθε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τουτογὶ νὴ τὸν Δία</l>
 						<l>τὸ σκέλος ῥίψαντες ἤδη λήγομεν τὸ δεξιόν.</l>
@@ -1013,7 +1013,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἐπιδίδωμι τοῦτό γ’ ὑμῖν ὥστε μὴ λυπεῖν ἔτι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ καὶ τἀριστερόν τοί μ’ ἐστ’ ἀναγκαίως ἔχον.</l>
 						<l n="335">ἥδομαι γὰρ καὶ γέγηθα καὶ πέπορδα καὶ γελῶ</l>
@@ -1038,7 +1038,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ γὰρ ἐκγένοιτ’ ἰδεῖν ταύτην με τὴν ἡμέραν [ποτέ].</l>
 						<l>πολλὰ γὰρ ἀνεσχόμην πράγματά τε καὶ στιβάδας, ἃς</l>
@@ -1057,7 +1057,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>φέρε δὴ κατίδω ποῖ τοὺς λίθους ἀφέλξομεν.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ μιαρὲ καὶ τολμηρὲ τί ποιεῖν διανοεῖ;</l>
 					</sp>
@@ -1065,7 +1065,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>οὐδὲν πονηρόν, ἀλλ’ ὅπερ καὶ Κιλλικῶν.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ἀπόλωλας ὦ κακόδαιμον.</l>
 					</sp>
@@ -1074,7 +1074,7 @@ bring up to P3
 						<l part="Y">οὐκοῦν ἢν λάχω.</l>
 						<l n="365">Ἑρμῆς γὰρ ὢν κλήρῳ ποιήσεις οἶδ’ ὅτι.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ἀπόλωλας, ἐξόλωλας.</l>
 					</sp>
@@ -1082,7 +1082,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">ἐς τίν’ ἡμέραν;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>εἰς αὐτίκα μάλ’.</l>
 					</sp>
@@ -1091,7 +1091,7 @@ bring up to P3
 						<l part="Y">ἀλλ’ οὐδὲν ἠμπόληκά πω,</l>
 						<l>οὔτ’ ἄλφιτ’ οὔτε τυρόν, ὡς ἀπολούμενος.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>καὶ μὴν ἐπιτέτριψαί γε.</l>
 					</sp>
@@ -1100,7 +1100,7 @@ bring up to P3
 						<l part="Y">κᾆτα τῷ τρόπῳ</l>
 						<l n="370">οὐκ ᾐσθόμην ἀγαθὸν τοσουτονὶ λαβών;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ἆρ’ οἶσθα θάνατον ὅτι προεῖφ’ ὁ Ζεὺς ὃς ἂν</l>
 						<l>ταύτην ἀνορύττων εὑρεθῇ;</l>
@@ -1110,7 +1110,7 @@ bring up to P3
 						<l part="Y">νῦν ἆρά με</l>
 						<l>ἅπασ’ ἀνάγκη ’στ’ ἀποθανεῖν;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">εὖ ἴσθ’ ὅτι.</l>
 					</sp>
@@ -1119,7 +1119,7 @@ bring up to P3
 						<l>ἐς χοιρίδιόν μοί νυν δάνεισον τρεῖς δραχμάς·</l>
 						<l n="375">δεῖ γὰρ μυηθῆναί με πρὶν τεθνηκέναι.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ Ζεῦ κεραυνοβρόντα.</l>
 					</sp>
@@ -1128,7 +1128,7 @@ bring up to P3
 						<l part="Y">μὴ πρὸς τῶν θεῶν</l>
 						<l>ἡμῶν κατείπῃς, ἀντιβολῶ σε δέσποτα.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>οὐκ ἂν σιωπήσαιμι.</l>
 					</sp>
@@ -1137,7 +1137,7 @@ bring up to P3
 						<l part="Y">ναὶ πρὸς τῶν κρεῶν,</l>
 						<l>ἁγὼ προθύμως σοι φέρων ἀφικόμην.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l n="380">ἀλλ’ ὦ μέλ’ ὑπὸ τοῦ Διὸς ἀμαλδυνθήσομαι,</l>
 						<l>εἰ μὴ τετορήσω ταῦτα καὶ λακήσομαι.</l>
@@ -1156,7 +1156,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="385">μηδαμῶς ὦ δέσποθ’ Ἑρμῆ, μηδαμῶς, μηδαμῶς,</l>
 						<l>εἴ τι κεχαρισμένον χοιρίδιον οἶσθα παρ’ ἐμοῦ γε κατεδηδοκώς,</l>
@@ -1166,7 +1166,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>οὐκ ἀκούεις οἷα θωπεύουσί σ’ ὦναξ δέσποτα;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="390">†μὴ γένῃ παλίγκοτος ἀντιβολοῦσιν ἡμῖν,†</l>
 						<l>ὥστε τήνδε μὴ λαβεῖν·</l>
@@ -1184,7 +1184,7 @@ bring up to P3
 						<l>καί σοι φράσω τι πρᾶγμα δεινὸν καὶ μέγα,</l>
 						<l>ὃ τοῖς θεοῖς ἅπασιν ἐπιβουλεύεται.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l n="405">ἴθι δὴ κάτειπ’· ἴσως γὰρ ἂν πείσαις ἐμέ.</l>
 					</sp>
@@ -1194,7 +1194,7 @@ bring up to P3
 						<l>ὑμῖν ἐπιβουλεύοντε πολὺν ἤδη χρόνον</l>
 						<l>τοῖς βαρβάροισι προδίδοτον τὴν Ἑλλάδα.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ἵνα δὴ τί τοῦτο δρᾶτον;</l>
 					</sp>
@@ -1206,7 +1206,7 @@ bring up to P3
 						<l>βούλοιντ’ ἂν ἡμᾶς πάντας ἐξολωλέναι,</l>
 						<l>ἵνα τὰς τελετὰς λάβοιεν αὐτοὶ τῶν θεῶν.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ταῦτ’ ἄρα πάλαι τῶν ἡμερῶν παρεκλεπτέτην</l>
 						<l n="415">καὶ τοῦ κύκλου παρέτρωγον ὑφ’ ἁμαρτωλίας.</l>
@@ -1223,19 +1223,19 @@ bring up to P3
 						<l>χἄτερ’ ἔτι πόλλ’ ἕξεις ἀγαθά. πρῶτον δέ σοι</l>
 						<l>δῶρον δίδωμι τήνδ’, ἵνα σπένδειν ἔχῃς.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l n="425">οἴμ’ ὡς ἐλεήμων εἴμ’ ἀεὶ τῶν χρυσίδων.</l>
 						<milestone ed="p" n="426" unit="card"/>
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὑμέτερον ἐντεῦθεν ἔργον ὦνδρες. ἀλλὰ ταῖς ἄμαις</l>
 						<l>εἰσιόντες ὡς τάχιστα τοὺς λίθους ἀφέλκετε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ταῦτα δράσομεν· σὺ δ’ ἡμῖν ὦ θεῶν σοφώτατε</l>
 						<l>ἅττα χρὴ ποιεῖν ἐφεστὼς φράζε δημιουργικῶς·</l>
@@ -1251,7 +1251,7 @@ bring up to P3
 						<l>ἄγε δὴ σὺ ταχέως ὕπεχε τὴν φιάλην, ὅπως</l>
 						<l>ἔργῳ ’φιαλοῦμεν εὐξάμενοι τοῖσιν θεοῖς.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>σπονδὴ σπονδή·</l>
 						<l>εὐφημεῖτε εὐφημεῖτε.</l>
@@ -1263,7 +1263,7 @@ bring up to P3
 						<l>χὤστις προθύμως ξυλλάβοι τῶν σχοινίων,</l>
 						<l>τοῦτον τὸν ἄνδρα μὴ λαβεῖν ποτ’ ἀσπίδα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μὰ Δί’ ἀλλ’ ἐν εἰρήνῃ διαγαγεῖν τὸν βίον,</l>
 						<l n="440">ἔχονθ’ ἑταίραν καὶ σκαλεύοντ’ ἄνθρακας.</l>
@@ -1272,7 +1272,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ὅστις δὲ πόλεμον μᾶλλον εἶναι βούλεται</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδέποτε παύσασθ’ αὐτὸν ὦ Διόνυσ’ ἄναξ</l>
 						<l>ἐκ τῶν ὀλεκράνων ἀκίδας ἐξαιρούμενον.</l>
@@ -1282,7 +1282,7 @@ bring up to P3
 						<l>κεἴ τις ἐπιθυμῶν ταξιαρχεῖν σοὶ φθονεῖ</l>
 						<l n="445">ἐς φῶς ἀνελθεῖν ὦ πότνῑ, ἐν ταῖσιν μάχαις</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάσχοι γε τοιαῦθ’ οἷάπερ Κλεώνυμος.</l>
 					</sp>
@@ -1291,7 +1291,7 @@ bring up to P3
 						<l>κεἴ τις δορυξὸς ἢ κάπηλος ἀσπίδων,</l>
 						<l>ἵν’ ἐμπολᾷ βέλτιον, ἐπιθυμεῖ μαχῶν</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ληφθεὶς ὑπὸ λῃστῶν ἐσθίοι κριθὰς μόνας.</l>
 					</sp>
@@ -1300,7 +1300,7 @@ bring up to P3
 						<l n="450">κεἴ τις στρατηγεῖν βουλόμενος μὴ ξυλλάβοι,</l>
 						<l>ἢ δοῦλος αὐτομολεῖν παρεσκευασμένος</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπὶ τοῦ τροχοῦ γ’ ἕλκοιτο μαστιγούμενος.</l>
 					</sp>
@@ -1308,7 +1308,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἡμῖν δ’ ἀγαθὰ γένοιτ’. ἰὴ παιὼν ἰή.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄφελε τὸ παίειν ἀλλ’ ἰὴ μόνον λέγε.</l>
 					</sp>
@@ -1318,7 +1318,7 @@ bring up to P3
 						<l>Ἑρμῇ Χάρισιν Ὥραισιν Ἀφροδίτῃ Πόθῳ.</l>
 						<l>Ἄρει δέ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">μὴ μή.</l>
 					</sp>
@@ -1326,7 +1326,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">μηδ’ Ἐνυαλίῳ γε;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">μή.</l>
 					</sp>
@@ -1337,23 +1337,23 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ εἶα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="460">εἶα μάλα.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ εἶα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἶα ἔτι μάλα.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ εἶα, ὦ εἶα.</l>
 					</sp>
@@ -1363,7 +1363,7 @@ bring up to P3
 						<l n="465">οὐ ξυλλήψεσθ’; οἷ’ ὀγκύλλεσθ’·</l>
 						<l>οἰμώξεσθ’ οἱ Βοιωτοί.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>εἶά νυν.</l>
 					</sp>
@@ -1371,7 +1371,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>εἶα ὦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>&lt;ἀλλ’&gt; ἄγετε ξυνανέλκετε καὶ σφώ.</l>
 					</sp>
@@ -1380,7 +1380,7 @@ bring up to P3
 						<l n="470">οὔκουν ἕλκω κἀξαρτῶμαι</l>
 						<l>κἀπεμπίπτω καὶ σπουδάζω;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς οὖν οὐ χωρεῖ τοὔργον;</l>
 						<milestone ed="p" n="473" unit="card"/>
@@ -1390,7 +1390,7 @@ bring up to P3
 						<l>ὦ Λάμαχ’ ἀδικεῖς ἐμποδὼν καθήμενος.</l>
 						<l>οὐδὲν δεόμεθ’ ὦνθρωπε τῆς σῆς μορμόνος.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l n="475">οὐδ’ οἵδε γ’ εἷλκον οὐδὲν ἁργεῖοι πάλαι</l>
 						<l>ἀλλ’ ἢ κατεγέλων τῶν ταλαιπωρουμένων,</l>
@@ -1400,12 +1400,12 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἀλλ’ οἱ Λάκωνες ὦγάθ’ ἕλκουσ’ ἀνδρικῶς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆρ’ οἶσθ’ ὅσοι γ’ αὐτῶν ἔχονται τοῦ ξύλου,</l>
 						<l n="480">μόνοι προθυμοῦντ’· ἀλλ’ ὁ χαλκεὺς οὐκ ἐᾷ.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>οὐδ’ οἱ Μεγαρῆς δρῶσ’ οὐδέν· ἕλκουσιν δ’ ὅμως</l>
 						<l>γλισχρότατα σαρκάζοντες ὥσπερ κυνίδια,</l>
@@ -1419,7 +1419,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ εἶα.</l>
 					</sp>
@@ -1427,7 +1427,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>εἶα μάλα.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ εἶα.</l>
 					</sp>
@@ -1435,7 +1435,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>εἶα νὴ Δία.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="490">μικρόν γε κινοῦμεν.</l>
 					</sp>
@@ -1445,7 +1445,7 @@ bring up to P3
 						<l>τοὺς μὲν τείνειν τοὺς δ’ ἀντισπᾶν;</l>
 						<l>πληγὰς λήψεσθ’ ὦργεῖοι.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>εἶά νυν.</l>
 					</sp>
@@ -1453,7 +1453,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="495">εἶα ὦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς κακόνοι τινές εἰσιν ἐν ἡμῖν.</l>
 					</sp>
@@ -1462,12 +1462,12 @@ bring up to P3
 						<l>ὑμεῖς μὲν γοῦν οἱ κιττῶντες</l>
 						<l>τῆς εἰρήνης σπᾶτ’ ἀνδρείως.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ εἴσ’ οἳ κωλύουσιν.</l>
 						<milestone ed="p" n="500" unit="card"/>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l n="500">ἄνδρες Μεγαρῆς οὐκ ἐς κόρακας ἐρρήσετε;</l>
 						<l>μισεῖ γὰρ ὑμᾶς ἡ θεὸς μεμνημένη·</l>
@@ -1478,15 +1478,15 @@ bring up to P3
 						<l>ἀλλ’ εἴπερ ἐπιθυμεῖτε τήνδ’ ἐξελκύσαι,</l>
 						<l>πρὸς τὴν θάλατταν ὀλίγον ὑποχωρήσατε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγ’ ὦνδρες αὐτοὶ δὴ μόνοι λαβώμεθ’ οἱ γεωργοί.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>χωρεῖ γέ τοι τὸ πρᾶγμα πολλῷ μᾶλλον ὦνδρες ὑμῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="510">χωρεῖν τὸ πρᾶγμά φησιν· ἀλλὰ πᾶς ἀνὴρ προθυμοῦ.</l>
 					</sp>
@@ -1497,24 +1497,24 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγε νυν ἄγε πᾶς.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>καὶ μὴν ὁμοῦ ’στιν ἤδη.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μή νυν ἀνῶμεν ἀλλ’ ἐπεντείνωμεν</l>
 						<l n="515">ἀνδρικώτερον.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ἤδη ’στὶ τοῦτ’ ἐκεῖνο.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ εἶα νῦν, ὦ εἶα πᾶς.</l>
 						<l>ὦ εἶα εἶα εἶα εἶα εἶα εἶα.</l>
@@ -1531,7 +1531,7 @@ bring up to P3
 						<l n="525">οἷον δὲ πνεῖς, ὡς ἡδὺ κατὰ τῆς καρδίας,</l>
 						<l>γλυκύτατον ὥσπερ ἀστρατείας καὶ μύρου.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>μῶν οὖν ὅμοιον καὶ γυλιοῦ στρατιωτικοῦ;</l>
 					</sp>
@@ -1543,7 +1543,7 @@ bring up to P3
 						<l>αὐλῶν, τραγῳδῶν, Σοφοκλέους μελῶν, κιχλῶν,</l>
 						<l>ἐπυλλίων Εὐριπίδου—</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">κλαύσἄρα σὺ</l>
 						<l>ταύτης καταψευδόμενος· οὐ γὰρ ἥδεται</l>
@@ -1556,7 +1556,7 @@ bring up to P3
 						<l>δούλης μεθυούσης, ἀνατετραμμένου χοῶς,</l>
 						<l>ἄλλων τε πολλῶν κἀγαθῶν—</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">ἴθι νυν ἄθρει</l>
 						<l>οἷον πρὸς ἀλλήλας λαλοῦσιν αἱ πόλεις</l>
@@ -1569,7 +1569,7 @@ bring up to P3
 						<l>καὶ τῶνδε τοίνυν τῶν θεωμένων σκόπει</l>
 						<l>τὰ πρόσωφ’, ἵνα γνῷς τὰς τέχνας.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">αἰβοῖ τάλας,</l>
 					</sp>
@@ -1578,7 +1578,7 @@ bring up to P3
 						<l n="545">ἐκεινονὶ γοῦν τὸν λοφοποιὸν οὐχ ὁρᾷς</l>
 						<l>τίλλονθ’ ἑαυτόν;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l part="Y">ὁ δέ γε τὰς σμινύας ποιῶν</l>
 						<l>κατέπαρδεν ἄρτι τοῦ ξιφουργοῦ ’κεινουί.</l>
@@ -1588,7 +1588,7 @@ bring up to P3
 						<l>ὁ δὲ δρεπανουργὸς οὐχ ὁρᾷς ὡς ἥδεται,</l>
 						<l>καὶ τὸν δορυξὸν οἷον ἐσκιμάλισεν;</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l n="550">ἴθι νυν ἄνειπε τοὺς γεωργοὺς ἀπιέναι.</l>
 						<milestone ed="p" n="551" unit="card"/>
@@ -1605,7 +1605,7 @@ bring up to P3
 						<l>ὡς ἅπαντ’ ἤδη ’στὶ μεστὰ τἀνθάδ’ εἰρήνης σαπρᾶς.</l>
 						<l n="555">ἀλλὰ πᾶς χώρει πρὸς ἔργον εἰς ἀγρὸν παιωνίσας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ ποθεινὴ τοῖς δικαίοις καὶ γεωργοῖς ἡμέρα,</l>
 						<l>ἄσμενός σ’ ἰδὼν προσειπεῖν βούλομαι τὰς ἀμπέλους,</l>
@@ -1619,7 +1619,7 @@ bring up to P3
 						<l>εἶθ’ ὅπως Λιταργιοῦμεν οἴκαδ’ ἐς τὰ χωρία,</l>
 						<l>ἐμπολήσαντές τι χρηστὸν εἰς ἀγρὸν ταρίχιον.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ Πόσειδον ὡς καλὸν τὸ στῖφος αὐτῶν φαίνεται</l>
 						<l n="565">καὶ πυκνὸν καὶ γοργὸν ὥσπερ μᾶζα καὶ πανδαισία.</l>
@@ -1652,7 +1652,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαῖρε χαῖρ’, ὡς ἀσμένοισιν ἦλθες, ὦ φιλτάτη.</l>
 						<l n="585">σῷ γὰρ ἐδάμην πόθῳ, δαιμόνια βουλόμενος εἰς ἀγρὸν ἀνερπύσαι</l>
@@ -1671,14 +1671,14 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="katakeleusmos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ ποῦ ποτ’ ἦν ἀφ’ ἡμῶν τὸν πολὺν τοῦτον χρόνον</l>
 						<l>ἥδε; τοῦθ’ ἡμᾶς δίδαξον ὦ θεῶν εὐνούστατε.</l>
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>ὦ σοφώτατοι γεωργοί, τἀμὰ δὴ ξυνίετε</l>
 						<l>ῥήματ’, εἰ βούλεσθ’ ἀκοῦσαι τήνδ’ ὅπως ἀπώλετο.</l>
@@ -1698,12 +1698,12 @@ bring up to P3
 						<l n="615">ταῦτα τοίνυν μὰ τὸν Ἀπόλλω ’γὼ ’πεπύσμην οὐδενός,</l>
 						<l>οὐδ’ ὅπως αὐτῇ προσήκοι Φειδίας ἠκηκόη.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδ’ ἔγωγε πλήν γε νυνί. ταῦτ’ ἄρ’ εὐπρόσωπος ἦν,</l>
 						<l>οὖσα συγγενὴς ἐκείνου. πολλά γ’ ἡμᾶς λανθάνει.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>κᾆτ’ ἐπειδὴ ’γνωσαν ὑμᾶς αἱ πόλεις ὧν ἤρχετε</l>
 						<l n="620">ἠγριωμένους ἐπ’ ἀλλήλοισι καὶ σεσηρότας,</l>
@@ -1720,12 +1720,12 @@ bring up to P3
 						<l>ἐν δίκῃ μὲν οὖν, ἐπεί τοι τὴν κορώνεών γέ μου</l>
 						<l>ἐξέκοψαν, ἣν ἐγὼ ’φύτευσα κἀξεθρεψάμην.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="630">νὴ Δί’ ὦ μέλ’ ἐνδίκως &lt;γε&gt; δῆτ’, ἐπεὶ κἀμοῦ λίθον</l>
 						<l>ἐμβαλόντες ἑξμέδιμνον κυψέλην ἀπώλεσαν.</l>
 					</sp>
-					<sp who="#ermes">
+					<sp who="#hermes">
 						<speaker>Ἑρμῆς</speaker>
 						<l>κᾆτα δ’ ὡς ἐκ τῶν ἀγρῶν ξυνῆλθεν οὑργάτης λεώς,</l>
 						<l>τὸν τρόπον πωλούμενος τὸν αὐτὸν οὐκ ἐμάνθανεν,</l>
@@ -1771,7 +1771,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>ἀλλ’ ὅ τι σιωπᾷς ὦ πότνια κάτειπέ μοι.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἀλλ’ οὐκ ἂν εἴποι πρός γε τοὺς θεωμένους·</l>
 					<l>ὀργὴν γὰρ αὐτοῖς ὧν ἔπαθε πολλὴν ἔχει.</l>
@@ -1780,7 +1780,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l n="660">ἡ δ’ ἀλλὰ πρὸς σὲ μικρὸν εἰπάτω μόνον.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>εἴφ’ ὅ τι νοεῖς αὐτοῖσι πρὸς ἔμ’ ὦ φιλτάτη.</l>
 					<l>ἴθ’ ὦ γυναικῶν μισοπορπακιστάτη.</l>
@@ -1795,7 +1795,7 @@ bring up to P3
 					<l>ἡμάρτομεν ταῦτ’· ἀλλὰ συγγνώμην ἔχε·</l>
 					<l>ὁ νοῦς γὰρ ἡμῶν ἦν τότ’ ἐν τοῖς σκύτεσιν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l n="670">ἴθι νυν ἄκουσον οἷον ἄρτι μ’ ἤρετο,</l>
 					<l>ὅστις κακόνους αὐτῇ μάλιστ’ ἦν ἐνθάδε,</l>
@@ -1805,7 +1805,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>εὐνούστατος μὲν ἦν μακρῷ Κλεώνυμος.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ποῖός τις οὖν εἶναι δοκεῖ τὰ πολεμικὰ</l>
 					<l n="675">ὁ Κλεώνυμος;</l>
@@ -1817,7 +1817,7 @@ bring up to P3
 					<l>εἰ γάρ ποτ’ ἐξέλθοι στρατιώτης, εὐθέως</l>
 					<l>ἀποβολιμαῖος τῶν ὅπλων ἐγίγνετο.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἔτι νῦν ἄκουσον οἷον ἄρτι μ’ ἤρετο,</l>
 					<l n="680">ὅστις κρατεῖ νῦν τοῦ λίθου τοῦ ’ν τῇ πυκνί.</l>
@@ -1827,7 +1827,7 @@ bring up to P3
 					<l>Ὑπέρβολος νῦν τοῦτ’ ἔχει τὸ χωρίον.</l>
 					<l>αὕτη τί ποιεῖς; τὴν κεφαλὴν ποῖ περιάγεις;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἀποστρέφεται τὸν δῆμον ἀχθεσθεῖσ’ ὅτι</l>
 					<l>αὑτῷ πονηρὸν προστάτην ἐπεγράψατο.</l>
@@ -1838,7 +1838,7 @@ bring up to P3
 					<l>ἀπορῶν ὁ δῆμος ἐπιτρόπου καὶ γυμνὸς ὢν</l>
 					<l>τοῦτον τέως τὸν ἄνδρα περιεζώσατο.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>πῶς οὖν ξυνοίσει ταῦτ’ ἐρωτᾷ τῇ πόλει.</l>
 				</sp>
@@ -1846,7 +1846,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>εὐβουλότεροι γενησόμεθα.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">τρόπῳ τίνι;</l>
 				</sp>
@@ -1856,7 +1856,7 @@ bring up to P3
 					<l>ἐψηλαφῶμεν ἐν σκότῳ τὰ πράγματα,</l>
 					<l>νυνὶ δ’ ἅπαντα πρὸς λύχνον βουλεύσομεν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ὢ ὤ,</l>
 					<l>οἷά μ’ ἐκέλευσεν ἀναπυθέσθαι σου.</l>
@@ -1865,7 +1865,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l part="Y">τὰ τί;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>πάμπολλα καὶ τἀρχαῖ’ ἃ κατέλιπεν τότε·</l>
 					<l n="695">πρῶτον δ’ ὅ τι πράττει Σοφοκλέης ἀνήρετο.</l>
@@ -1874,7 +1874,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>εὐδαιμονεῖ, πάσχει δὲ θαυμαστόν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">τὸ τί;</l>
 				</sp>
@@ -1882,7 +1882,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>ἐκ τοῦ Σοφοκλέους γίγνεται Σιμωνίδης.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>Σιμωνίδης; πῶς;</l>
 				</sp>
@@ -1892,7 +1892,7 @@ bring up to P3
 					<l>κέρδους ἕκατι κἂν ἐπὶ ῥιπὸς πλέοι.</l>
 					<milestone ed="p" n="700" unit="card"/>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l n="700">τί δαί; Κρατῖνος ὁ σοφὸς ἔστιν;</l>
 				</sp>
@@ -1901,7 +1901,7 @@ bring up to P3
 					<l part="Y">ἀπέθανεν</l>
 					<l>ὅθ’ οἱ Λάκωνες ἐνέβαλον.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">τί παθών;</l>
 				</sp>
@@ -1913,7 +1913,7 @@ bring up to P3
 					<l>χἄτερα πόσ’ ἄττ’ οἴει γεγενῆσθ’ ἐν τῇ πόλει;</l>
 					<l n="705">ὥστ’ οὐδέποτ’ ὦ δέσποιν’ ἀφησόμεσθά σου.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἴθι νυν ἐπὶ τούτοις τὴν Ὀπώραν λάμβανε</l>
 					<l>γυναῖκα σαυτῷ τήνδε· κᾆτ’ ἐν τοῖς ἀγροῖς</l>
@@ -1925,7 +1925,7 @@ bring up to P3
 					<l n="710">ἆρ’ ἂν βλαβῆναι διὰ χρόνου τί σοι δοκῶ</l>
 					<l>ὦ δέσποθ’ Ἑρμῆ τῆς Ὀπώρας κατελάσας;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>οὐκ εἴ γε κυκεῶν’ ἐπιπίοις βληχωνίαν.</l>
 					<l>ἀλλ’ ὡς τάχιστα τήνδε τὴν Θεωρίαν</l>
@@ -1938,7 +1938,7 @@ bring up to P3
 					<l>ὅσας δὲ κατέδει ξόλικας ἑφθὰς καὶ κρέα.</l>
 					<l>ἀλλ’ ὦ φίλ’ Ἑρμῆ χαῖρε πολλά.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">·καὶ σύ γε</l>
 					<l>ὦνθρωπε χαίρων ἄπιθι καὶ μέμνησό μου.</l>
@@ -1947,7 +1947,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l n="720">ὦ κάνθαρ’ οἴκαδ’ οἴκαδ’ ἀποπετώμεθα.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>οὐκ ἐνθάδ’ ὦ τᾶν ἔστι.</l>
 				</sp>
@@ -1955,7 +1955,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l part="Y">ποῖ γὰρ οἴχεται;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ὑφ’ ἅρματ’ ἐλθὼν Ζηνὸς ἀστραπηφορεῖ.</l>
 				</sp>
@@ -1963,7 +1963,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>πόθεν οὖν ὁ τλήμων ἐνθάδ’ ἕξει σιτία;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>τὴν τοῦ Γανυμήδους ἀμβροσίαν σιτήσεται.</l>
 				</sp>
@@ -1971,7 +1971,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l n="725">πῶς δῆτ’ ἐγὼ καταβήσομαι;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">θάρρει, καλῶς·</l>
 					<l>τῃδὶ παρ’ αὐτὴν τὴν θεόν.</l>
@@ -1986,7 +1986,7 @@ bring up to P3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 met="anapests" type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἴθι χαίρων· ἡμεῖς δὲ τέως τάδε τὰ σκεύη παραδόντες</l>
 						<l n="730">τοῖς ἀκολούθοις δῶμεν σῴζειν, ὡς εἰώθασι μάλιστα</l>
@@ -1997,7 +1997,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="parabasis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χρῆν μὲν τύπτειν τοὺς ῥαβδούχους, εἴ τις κωμῳδοποιητὴς</l>
 						<l n="735">αὑτὸν ἐπῄνει πρὸς τὸ θέατρον παραβὰς ἐν τοῖς ἀναπαίστοις·</l>
@@ -2034,7 +2034,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="765">πρὸς ταῦτα χρεὼν εἶναι μετ’ ἐμοῦ</l>
 						<l>καὶ τοὺς ἄνδρας καὶ τοὺς παῖδας·</l>
@@ -2050,7 +2050,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Μοῦσα σὺ μὲν πολέμους ἀπωσαμένη μετ’ ἐμοῦ</l>
 						<l n="775">τοῦ φίλου χόρευσον,</l>
@@ -2069,7 +2069,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="797">τοιάδε χρὴ Χαρίτων δαμώματα καλλικόμων</l>
 						<l>τὸν σοφὸν ποιητὴν</l>
@@ -2211,7 +2211,7 @@ bring up to P3
 					<milestone ed="p" n="856" unit="card"/>
 				</sp>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐδαιμονικῶς γ’ ὁ πρεσβύτης,</l>
 						<l>ὅσα γ’ ὧδ’ ἰδεῖν,</l>
@@ -2221,7 +2221,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>τί δῆτ’ ἐπειδὰν νυμφίον μ’ ὁρᾶτε λαμπρὸν ὄντα;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="860">ζηλωτὸς ἔσει, γέρον,</l>
 						<l>αὖθις νέος ὢν πάλιν,</l>
@@ -2231,7 +2231,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>οἶμαι. τί δῆθ’ ὅταν ξυνὼν τῶν τιτθίων ἔχωμαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐδαιμονέστερος φανεῖ τῶν Καρκίνου στροβίλων.</l>
 					</sp>
@@ -2348,7 +2348,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="910">ἦ χρηστὸς ἀνὴρ πολίτης</l>
 						<l>ἐστὶν ἅπασιν ὅστις</l>
@@ -2358,7 +2358,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ὅταν τρυγᾶτ’, εἴσεσθε πολλῷ μᾶλλον οἷός εἰμι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ νῦν σύ γε δῆλος εἶ·</l>
 						<l>σωτὴρ γὰρ ἅπασιν ἀνθρώποις</l>
@@ -2368,7 +2368,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>φήσεις ἐπειδὰν ἐκπίῃς οἴνου νέου λεπαστήν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ πλήν γε τῶν θεῶν ἀεί σ’ ἡγησόμεσθα πρῶτον.</l>
 					</sp>
@@ -2393,7 +2393,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>τί δ’ ἄλλο γ’ ἢ ταύτην χύτραις ἱδρυτέον;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>χύτραισιν, ὥσπερ μεμφόμενον Ἑρμῄδιον;</l>
 				</sp>
@@ -2401,7 +2401,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l n="925">τί δαὶ δοκεῖ; βούλεσθε λαρινῷ βοΐ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>βοΐ; μηδαμῶς, ἵνα μὴ βοηθεῖν ποι δέῃ.</l>
 				</sp>
@@ -2409,7 +2409,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>ἀλλ’ ὑὶ παχείᾳ καὶ μεγάλῃ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">μὴ μή.</l>
 				</sp>
@@ -2417,7 +2417,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l part="Y">τιή;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἵνα μὴ γένηται Θεογένους ὑηνία.</l>
 				</sp>
@@ -2425,7 +2425,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>τῷ δὴ δοκεῖ σοι δῆτα τῶν λοιπῶν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">ὀί.</l>
 				</sp>
@@ -2433,7 +2433,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l n="930">ὀί;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">ναὶ μὰ Δί’.</l>
 				</sp>
@@ -2442,7 +2442,7 @@ bring up to P3
 					<l part="Y">ἀλλὰ τοῦτό γ’ ἔστ’ Ἰωνικὸν</l>
 					<l>τὸ ῥῆμ’.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">ἐπίτηδές γ’, ἵν’ &lt;ὅταν&gt; ἐν τἠκκλησίᾳ</l>
 					<l>ὡς χρὴ πολεμεῖν λέγῃ τις, οἱ καθήμενοι</l>
@@ -2452,7 +2452,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>εὖ τοι λέγεις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">καὶ τἄλλα γ’ ὦσιν ἤπιοι.</l>
 					<l n="935">ὥστ’ ἐσόμεθ’ ἀλλήλοισιν ἀμνοὶ τοὺς τρόπους</l>
@@ -2465,7 +2465,7 @@ bring up to P3
 					<milestone ed="p" n="939" unit="card"/>
 				</sp>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς πάνθ’ ὅσ’ ἂν θεὸς θέλῃ χἠ τύχη κατορθοῖ,</l>
 						<l n="940">χωρεῖ κατὰ νοῦν, ἕτερον δ’ ἑτέρῳ</l>
@@ -2475,7 +2475,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ὡς ταῦτα δῆλά γ’ ἔσθ’· ὁ γὰρ βωμὸς θύρασι καὶ δή.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπείγετέ νυν ἐν ὅσῳ</l>
 						<l>σοβαρὰ θεόθεν κατέχει</l>
@@ -2488,7 +2488,7 @@ bring up to P3
 						<l>τὸ κανοῦν πάρεστ’ ὀλὰς ἔχον καὶ στέμμα καὶ μάχαιραν,</l>
 						<l>καὶ πῦρ γε τουτί, κοὐδὲν ἴσχει πλὴν τὸ πρόβατον ὑμᾶς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="950">οὔκουν ἁμιλλήσεσθον; ὡς</l>
 						<l>ἢν Χαῖρις ὑμᾶς ἴδῃ,</l>
@@ -2560,7 +2560,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἀλλ’ ὡς τάχιστ’ εὐχώμεθ’.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">εὐχώμεσθα δή.</l>
 						<milestone ed="p" n="974" unit="card"/>
@@ -2574,7 +2574,7 @@ bring up to P3
 						<l>δέσποινα χορῶν, δέσποινα γάμων,</l>
 						<l>δέξαι θυσίαν τὴν ἡμετέραν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δέξαι δῆτ’ ὦ πολυτιμήτη</l>
 						<l>νὴ Δία, καὶ μὴ ποίει γ’ ἅπερ αἱ</l>
@@ -2651,7 +2651,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σέ τοι θύρασι χρὴ . . . μένοντα τοίνυν</l>
 						<l>σχίζας δευρὶ τιθέναι ταχέως</l>
@@ -2661,7 +2661,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>οὔκουν δοκῶ σοι μαντικῶς τὸ φρύγανον τίθεσθαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς δ’ οὐχί; τί γάρ σε πέφευγ’</l>
 						<l>ὅσα χρὴ σοφὸν ἄνδρα; τί δ’ οὐ</l>
@@ -2674,7 +2674,7 @@ bring up to P3
 						<l>ἡ σχίζα γοῦν ἐνημμένη τὸν Στιλβίδην πιέζει,</l>
 						<l>καὶ τὴν τράπεζαν οἴσομαι, καὶ παιδὸς οὐ δεήσει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς οὖν ἂν οὐκ ἐπαινέσειεν</l>
 						<l>ἄνδρα τοιοῦτον, ὅστις</l>
@@ -2736,7 +2736,7 @@ bring up to P3
 						<speaker>Οἰκέτης</speaker>
 						<l part="Y">εὖ λέγεις.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>τίς ἡ θυσία ποθ’ αὑτηὶ καὶ τῷ θεῶν;</l>
 					</sp>
@@ -2744,7 +2744,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ὀπτα σὺ σιγῇ κἄπαγ’ ἀπὸ τῆς ὀσφύος.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>ὅτῳ δὲ θύετ’ οὐ φράσεθ’;</l>
 					</sp>
@@ -2757,7 +2757,7 @@ bring up to P3
 						<speaker>Οἰκέτης</speaker>
 						<l part="Y">καλῶς δῆτ’ ὦ πότνῑ Εἰρήνη φίλη.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>ἄγε νυν ἀπάρχου κᾆτα δὸς τἀπάργματα.</l>
 					</sp>
@@ -2765,7 +2765,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ὀπτᾶν ἄμεινον πρῶτον.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l part="Y">ἀλλὰ ταυταγὶ</l>
 						<l>ἤδη ’στὶν ὀπτά.</l>
@@ -2775,7 +2775,7 @@ bring up to P3
 						<l part="Y">πολλὰ πράττεις, ὅστις εἶ.</l>
 						<l>κατάτεμνε. ποῦ τράπεζα; τὴν σπονδὴν φέρε.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l n="1060">ἡ γλῶττα χωρὶς τέμνεται.</l>
 					</sp>
@@ -2784,7 +2784,7 @@ bring up to P3
 						<l part="Y">μεμνήμεθα.</l>
 						<l>ἀλλ’ οἶσθ’ ὃ δρᾶσον;</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l part="Y">ἢν φράσῃς.</l>
 					</sp>
@@ -2794,7 +2794,7 @@ bring up to P3
 						<l>νῷν μηδέν· Εἰρήνῃ γὰρ ἱερὰ θύομεν.</l>
 						<milestone ed="p" n="1063" unit="card"/>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>ὦ μέλεοι θνητοὶ καὶ νήπιοι,</l>
 					</sp>
@@ -2804,7 +2804,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="dactyls">
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>οἵτινες ἀφραδίῃσι θεῶν νόον οὐκ ἀίοντες</l>
 						<l n="1065">συνθήκας πεποίησθ’ ἄνδρες χαροποῖσι πιθήκοις,</l>
@@ -2813,7 +2813,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>αἰβοιβοῖ.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l part="Y">τί γελᾷς;</l>
 					</sp>
@@ -2821,7 +2821,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">ἥσθην χαροποῖσι πιθήκοις.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>καὶ κέπφοι τρήρωνες ἀλωπεκιδεῦσι πέπεισθε,</l>
 						<l>ὧν δόλιαι ψυχαί, δόλιαι φρένες.</l>
@@ -2831,7 +2831,7 @@ bring up to P3
 						<l part="Y">εἴθε σου εἶναι</l>
 						<l>ὤφελεν ὦλαζὼν οὑτωσὶ θερμὸς ὁ πλεύμων.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l n="1070">εἰ γὰρ μὴ νύμφαι γε θεαὶ Βάκιν ἐξαπάτασκον,</l>
 						<l>μηδὲ Βάκις θνητούς, μηδ’ αὖ νύμφαι Βάκιν αὐτὸν—</l>
@@ -2840,7 +2840,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἐξώλης ἀπόλοῑ, εἰ μὴ παύσαιο βακίζων.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>οὔπω θέσφατον ἦν Εἰρήνης δέσμ’ ἀναλῦσαι,</l>
 						<l>ἀλλὰ τόδε πρότερον—</l>
@@ -2849,7 +2849,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">τοῖσδ’ ἁλσί γε παστέα ταυτί.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l n="1075">οὐ γάρ πω τοῦτ’ ἐστὶ φίλον μακάρεσσι θεοῖσιν,</l>
 						<l>φυλόπιδος λῆξαι, πρίν κεν λύκος οἶν ὑμεναιοῖ.</l>
@@ -2858,7 +2858,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>καὶ πῶς ὦ κατάρατε λύκος ποτ’ ἂν οἶν ὑμεναιοῖ;</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>ὡς ἡ σφονδύλη φεύγουσα πονηρότατον βδεῖ,</l>
 						<l>†χἠ κώδων† ἀκαλανθὶς ἐπειγομένη τυφλὰ τίκτει,</l>
@@ -2870,7 +2870,7 @@ bring up to P3
 						<l>ἢ διακαυνιάσαι πότεροι κλαυσούμεθα μεῖζον,</l>
 						<l>ἐξὸν σπεισαμένοις κοινῇ τῆς Ἑλλάδος ἄρχειν;</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>οὔποτε ποιήσεις τὸν καρκίνον ὀρθὰ βαδίζειν.</l>
 					</sp>
@@ -2879,7 +2879,7 @@ bring up to P3
 						<l>οὔποτε δειπνήσεις ἔτι τοῦ λοιποῦ ν’ πρυτανείῳ,</l>
 						<l n="1085">οὐδ’ ἐπὶ τῷ πραχθέντι ποιήσεις ὕστερον οὐδέν.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>οὐδέποτ’ ἂν θείης λεῖον τὸν τραχὺν ἐχῖνον.</l>
 					</sp>
@@ -2887,7 +2887,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ἆρα φενακίζων ποτ’ Ἀθηναίους ἔτι παύσει;</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>ποῖον γὰρ κατὰ χρησμὸν ἐκαύσατε μῆρα θεοῖσιν;</l>
 					</sp>
@@ -2900,7 +2900,7 @@ bring up to P3
 						<l>ἔσπενδον δεπάεσσιν· ἐγὼ δ’ ὁδὸν ἡγεμόνευον·’</l>
 						<l>χρησμολόγῳ δ’ οὐδεὶς ἐδίδου κώθωνα φαεινόν.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l n="1095">οὐ μετέχω τούτων· οὐ γὰρ ταῦτ’ εἶπε Σίβυλλα.</l>
 					</sp>
@@ -2910,7 +2910,7 @@ bring up to P3
 						<l>‘ἀφρήτωρ ἀθέμιστος ἀνέστιός ἐστιν ἐκεῖνος,</l>
 						<l>ὃς πολέμου ἔραται ἐπιδημίου ὀκρυόεντος.’</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>φράζεο δὴ μή πώς σε δόλῳ φρένας ἐξαπατήσας</l>
 						<l n="1100">ἰκτῖνος μάρψῃ.</l>
@@ -2921,7 +2921,7 @@ bring up to P3
 						<l>ὡς οὗτος φοβερὸς τοῖς σπλάγχνοις ἐστὶν ὁ χρησμός.</l>
 						<l>ἔγχει δὴ σπονδὴν καὶ τῶν σπλάγχνων φέρε δευρί.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>ἀλλ’ εἰ ταῦτα δοκεῖ, κἀγὼ ’μαυτῷ βαλανεύσω.</l>
 					</sp>
@@ -2930,7 +2930,7 @@ bring up to P3
 						<l>σπονδὴ σπονδή.</l>
 						<milestone ed="p" n="1105" unit="card"/>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l n="1105">ἔγχει δὴ κἀμοὶ καὶ σπλάγχνων μοῖραν ὄρεξον.</l>
 					</sp>
@@ -2940,7 +2940,7 @@ bring up to P3
 						<l>ἀλλὰ τόδε πρότερον, σπένδειν ἡμᾶς, σὲ δ’ ἀπελθεῖν.</l>
 						<l>ὦ πότνῑ Εἰρήνη παράμεινον τὸν βίον ἡμῖν.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>πρόσφερε τὴν γλῶτταν.</l>
 					</sp>
@@ -2948,7 +2948,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">σὺ δὲ τὴν σαυτοῦ γ’ ἀπένεγκε.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l n="1110">σπονδή.</l>
 					</sp>
@@ -2956,7 +2956,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">καὶ ταυτὶ μετὰ τῆς σπονδῆς λαβὲ θᾶττον.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>οὐδεὶς προσδώσει τῶν σπλάγχνων;</l>
 					</sp>
@@ -2965,7 +2965,7 @@ bring up to P3
 						<l part="Y">οὐ γὰρ οἷόν τε</l>
 						<l>ἡμῖν προσδιδόναι, πρίν κεν λύκος οἶν ὑμεναιοῖ.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>ναὶ πρὸς τῶν γονάτων.</l>
 					</sp>
@@ -2980,7 +2980,7 @@ bring up to P3
 						<l n="1115">ἄγε δὴ θεαταὶ δεῦρο συσπλαγχνεύετε</l>
 						<l>μετὰ νῷν.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l part="Y">τί δὴ ’γώ;</l>
 					</sp>
@@ -2988,7 +2988,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">τὴν Σίβυλλαν ἔσθιε.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l>οὔτοι μὰ τὴν γῆν ταῦτα κατέδεσθον μόνω,</l>
 						<l>ἀλλ’ ἁρπάσομαι σφῷν αὐτά· κεῖται δ’ ἐν μέσῳ.</l>
@@ -2997,7 +2997,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l>ὦ παῖε τὸν Βάκιν.</l>
 					</sp>
-					<sp who="#ierokles">
+					<sp who="#hierokles">
 						<speaker>Ἱεροκλῆς</speaker>
 						<l part="Y">μαρτύρομαι.</l>
 					</sp>
@@ -3019,7 +3019,7 @@ bring up to P3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἥδομαί γ’ ἥδομαι</l>
 						<l>κράνους ἀπηλλαγμένος</l>
@@ -3038,7 +3038,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1140">οὐ γὰρ ἔσθ’ ἥδιον ἢ τυχεῖν μὲν ἤδη ’σπαρμένα,</l>
 						<l>τὸν θεὸν δ’ ἐπιψακάζειν, καὶ τιν’ εἰπεῖν γείτονα,</l>
@@ -3060,7 +3060,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς ἂν ἐμπίῃ μεθ’ ἡμῶν,</l>
 						<l>εὖ ποιοῦντος κὠφελοῦντος</l>
@@ -3069,7 +3069,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἡνίκ’ ἂν δ’ ἀχέτας</l>
 						<l n="1160">ᾄδῃ τὸν ἡδὺν νόμον,</l>
@@ -3088,7 +3088,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μᾶλλον ἢ θεοῖσιν ἐχθρὸν ταξίαρχον προσβλέπων</l>
 						<l>τρεῖς λόφους ἔχοντα καὶ φοινικίδ’ ὀξεῖαν πάνυ,</l>
@@ -3110,7 +3110,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antipnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλὰ γὰρ δή μ’ ἠδίκησαν,</l>
 						<l>ὄντες οἴκοι μὲν λέοντες</l>
@@ -3129,7 +3129,7 @@ bring up to P3
 					<l n="1195">ἔπειτ’ ἐπιφόρει τοὺς ἀμύλους καὶ τὰς κίχλας</l>
 					<l>καὶ τῶν λαγῴων πολλὰ καὶ τοὺς κολλάβους.</l>
 				</sp>
-				<sp who="#drepanoyrgos">
+				<sp who="#drepanourgos">
 					<speaker>Δρεπανουργός</speaker>
 					<l>ποῦ ποῦ Τρυγαῖός ἐστιν;</l>
 				</sp>
@@ -3137,7 +3137,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l part="Y">ἀναβράττω κίχλας.</l>
 				</sp>
-				<sp who="#drepanoyrgos">
+				<sp who="#drepanourgos">
 					<speaker>Δρεπανουργός</speaker>
 					<l>ὦ φίλτατ’ ὦ Τρυγαἶ ὅσ’ ἡμᾶς τἀγαθὰ</l>
 					<l>δέδρακας εἰρήνην ποιήσας· ὡς πρὸ τοῦ</l>
@@ -3155,7 +3155,7 @@ bring up to P3
 					<l>ἐπὶ δεῖπνον ὡς τάχιστα· καὶ γὰρ οὑτοσὶ</l>
 					<l>ὅπλων κάπηλος ἀχθόμενος προσέρχεται.</l>
 				</sp>
-				<sp who="#lofopoios">
+				<sp who="#lophopoios">
 					<speaker>Λοφοποιός</speaker>
 					<l n="1210">οἴμ’ ὡς προθέλυμνόν μ’ ὦ Τρυγαἶ ἀπώλεσας.</l>
 				</sp>
@@ -3163,7 +3163,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>τί δ’ ἔστιν ὦ κακόδαιμον; οὔτι που λοφᾷς;</l>
 				</sp>
-				<sp who="#lofopoios">
+				<sp who="#lophopoios">
 					<speaker>Λοφοποιός</speaker>
 					<l>ἀπώλεσάς μου τὴν τέχνην καὶ τὸν βίον,</l>
 					<l>καὶ τουτουὶ καὶ τοῦ δορυξοῦ ’κεινονί.</l>
@@ -3172,7 +3172,7 @@ bring up to P3
 					<speaker>Τρυγαῖος</speaker>
 					<l>τί δῆτα τουτοινὶ καταθῶ σοι τοῖν λόφοιν;</l>
 				</sp>
-				<sp who="#lofopoios">
+				<sp who="#lophopoios">
 					<speaker>Λοφοποιός</speaker>
 					<l n="1215">αὐτὸς σὺ τί δίδως;</l>
 				</sp>
@@ -3183,7 +3183,7 @@ bring up to P3
 					<l>δοίην ἂν αὐτοῖν ἰσχάδων τρεῖς χοίνικας.</l>
 					<l>ἵν’ ἀποκαθαίρω τὴν τράπεζαν τουτῳί.</l>
 				</sp>
-				<sp who="#lofopoios">
+				<sp who="#lophopoios">
 					<speaker>Λοφοποιός</speaker>
 					<l>ἔνεγκε τοίνυν εἰσιὼν τὰς ἰσχάδας·</l>
 					<l n="1220">κρεῖττον γὰρ ὦ τᾶν ἐστιν ἢ μηδὲν λαβεῖν.</l>
@@ -3250,7 +3250,7 @@ bring up to P3
 					<l part="Y">ἀλλ’ ὦγαθὲ</l>
 					<l>θλίβει τὸν ὄρρον. ἀπόφερ’, οὐκ ὠνήσομαι.</l>
 				</sp>
-				<sp who="#salpiggopoios">
+				<sp who="#salpingopoios">
 					<speaker>Σαλπιγγοποιός</speaker>
 					<l n="1240">τί δ’ ἆρα τῇ σάλπιγγι τῇδε χρήσομαι,</l>
 					<l>ἣν ἐπριάμην δραχμῶν ποθ’ ἑξήκοντ’ ἐγώ;</l>
@@ -3261,7 +3261,7 @@ bring up to P3
 					<l>ἔπειτ’ ἄνωθεν ῥάβδον ἐνθεὶς ὑπόμακρον,</l>
 					<l>γενήσεταί σοι τῶν κατακτῶν κοττάβων.</l>
 				</sp>
-				<sp who="#salpiggopoios">
+				<sp who="#salpingopoios">
 					<speaker>Σαλπιγγοποιός</speaker>
 					<l n="1245">οἴμοι καταγελᾷς.</l>
 				</sp>
@@ -3334,7 +3334,7 @@ bring up to P3
 					<milestone ed="p" n="1270" unit="card"/>
 				</sp>
 				<div2 type="dactyls">
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l n="1270">νῦν αὖθ’ ὁπλοτέρων ἀνδρῶν ἀρχώμεθα—</l>
 					</sp>
@@ -3344,7 +3344,7 @@ bring up to P3
 						<l>ὁπλοτέρους ᾆδον, καὶ ταῦτ ὦ τρισκακόδαιμον</l>
 						<l>εἰρήνης οὔσης· ἀμαθές γ’ εἶ καὶ κατάρατον.</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l>οἱ δ’ ὅτε δὴ σχεδὸν ἦσαν ἐπ’ ἀλλήλοισιν ἰόντες,</l>
 						<l>σύν ῥ’ ἔβαλον ῥινούς τε καὶ ἀσπίδας ὀμφαλοέσσας.</l>
@@ -3353,7 +3353,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="1275">ἀσπίδας; οὐ παύσει μεμνημένος ἀσπίδος ἡμῖν;</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l>ἔνθα δ’ ἅμ’ οἰμωγή τε καὶ εὐχωλὴ πέλεν ἀνδρῶν.</l>
 					</sp>
@@ -3362,7 +3362,7 @@ bring up to P3
 						<l>ἀνδρῶν οἰμωγή; κλαύσει νὴ τὸν Διόνυσον</l>
 						<l>οἰμωγὰς ᾄδων, καὶ ταύτας ὀμφαλοέσσας.</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l>ἀλλὰ τί δῆτ’ ᾄδω; σὺ γὰρ εἰπέ μοι οἷστισι χαίρεις.</l>
 					</sp>
@@ -3371,7 +3371,7 @@ bring up to P3
 						<l n="1280">ὣς οἱ μὲν δαίνυντο βοῶν κρέα, καὶ τὰ τοιαυτί·</l>
 						<l>ἄριστον προτίθεντο καὶ ἅτθ’ ἥδιστα πάσασθαι.</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l>ὣς οἱ μὲν δαίνυντο βοῶν κρέα, καὐχένας ἵππων</l>
 						<l>ἔκλυον ἱδρώοντας, ἐπεὶ πολέμου ἐκόρεσθεν.</l>
@@ -3383,7 +3383,7 @@ bring up to P3
 						<l>εἶεν; ἐκόρεσθεν τοῦ πολέμου κᾆτ’ ἤσθιον.</l>
 						<l n="1285">ταῦτ’ ᾆδε, ταῦθ’, ὡς ἤσθιον κεκορημένοι.</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l>θωρήσσοντ’ ἄρ’ ὄτειτα πεπαυμένοι—</l>
 					</sp>
@@ -3391,7 +3391,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">ἄσμενοι, οἶμαι.</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l>πύργων δ’ ἐξεχέοντο, βοὴ δ’ ἄσβεστος ὀρώρει.</l>
 					</sp>
@@ -3400,7 +3400,7 @@ bring up to P3
 						<l>κάκιστ’ ἀπόλοιο παιδάριον αὐταῖς μάχαις·</l>
 						<l>οὐδὲν γὰρ ᾄδεις πλὴν πολέμους. τοῦ καί ποτ’ εἶ;</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l n="1290">ἐγώ;</l>
 					</sp>
@@ -3408,7 +3408,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l part="Y">σὺ μέντοι νὴ Δί’.</l>
 					</sp>
-					<sp who="#paislamaxoy">
+					<sp who="#pais_lamachou">
 						<speaker>Παῖς &lt;Λαμάχου&gt;</speaker>
 						<l part="Y">υἱὸς Λαμάχου.</l>
 					</sp>
@@ -3425,7 +3425,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="elegiacs">
-					<sp who="#paiskleonymoy">
+					<sp who="#pais_kleonymou">
 						<speaker>Παῖς &lt;Κλεωνύμου&gt;</speaker>
 						<l>ἀσπίδι μὲν Σαΐων τις ἀγάλλεται, ἣν παρὰ θάμνῳ</l>
 						<l>ἔντος ἀμώμητον κάλλιπον οὐκ ἐθέλων.</l>
@@ -3434,7 +3434,7 @@ bring up to P3
 						<speaker>Τρυγαῖος</speaker>
 						<l n="1300">εἰπέ μοι ὦ πόσθων, ἐς τὸν σαυτοῦ πατέρ’ ᾄδεις;</l>
 					</sp>
-					<sp who="#paiskleonymoy">
+					<sp who="#pais_kleonymou">
 						<speaker>Παῖς &lt;Κλεωνύμου&gt;</speaker>
 						<l>ψυχὴν δ’ ἐξεσάωσα—</l>
 					</sp>
@@ -3462,7 +3462,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἡμῖν μελήσει ταῦτά γ’· εὖ ποιεῖς δὲ καὶ σὺ φράζων.</l>
 					</sp>
@@ -3476,7 +3476,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐφημεῖν χρὴ καὶ τὴν νύμφην ἔξω τινὰ δεῦρο κομίζειν</l>
 						<l>δᾷδάς τε φέρειν, καὶ πάντα λεὼν συγχαίρειν κἀπιχορεύειν.</l>
@@ -3486,7 +3486,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1320">κἀπευξαμένους τοῖσι θεοῖσιν</l>
 						<l>διδόναι πλοῦτον τοῖς Ἕλλησιν,</l>
@@ -3507,46 +3507,46 @@ bring up to P3
 						<l>καλῶς κατακείσει.</l>
 						<l>Ὑμὴν Ὑμέναῑ ὦ.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>ὦ τρὶς μάκαρ ὡς δικαίως</l>
 						<l>τἀγαθὰ νῦν ἔχεις.</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l n="1335">Ὑμὴν Ὑμέναῑ ὦ.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>Ὑμὴν Ὑμέναῑ ὦ.</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>τί δράσομεν αὐτήν;</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>τί δράσομεν αὐτήν;</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>τρυγήσομεν αὐτήν,</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>τρυγήσομεν αὐτήν.</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>ἀλλ’ ἀράμενοι φέρωμεν</l>
 						<l n="1340">οἱ προτεταγμένοι</l>
 						<l>τὸν νυμφίον ὦνδρες.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>Ὑμὴν Ὑμέναῑ ὦ,</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>Ὑμὴν Ὑμέναῑ ὦ,</l>
 					</sp>
@@ -3556,19 +3556,19 @@ bring up to P3
 						<l n="1345">οὐ πράγματ’ ἔχοντες, ἀλλὰ</l>
 						<l>συκολογοῦντες.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>Ὑμὴν Ὑμέναῑ ὦ,</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>Ὑμὴν Ὑμέναῑ ὦ.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>τοῦ μὲν μέγα καὶ παχύ.</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l n="1350">τῆς δ’ ἡδὺ τὸ σῦκον.</l>
 					</sp>
@@ -3577,7 +3577,7 @@ bring up to P3
 						<l>φήσεις γ’ ὅταν ἐσθίῃς</l>
 						<l>οἶνόν τε πίῃς πολύν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ὑμὴν Ὑμέναῑ ὦ,</l>
 						<l>Ὑμὴν Ὑμέναῑ ὦ.</l>

--- a/tei/aristophanes-plutus.xml
+++ b/tei/aristophanes-plutus.xml
@@ -52,13 +52,13 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="grays">
+					<person xml:id="graus">
 						<persName>Γραῦς</persName>
 					</person>
 					<person xml:id="gyne">
 						<persName>Γυνή</persName>
 					</person>
-					<person xml:id="xremylos">
+					<person xml:id="chremylos">
 						<persName>Χρεμύλος</persName>
 					</person>
 					<person xml:id="karion">
@@ -73,22 +73,22 @@
 					<person xml:id="blepsidemos">
 						<persName>Βλεψίδημος</persName>
 					</person>
-					<person xml:id="iereys">
+					<person xml:id="hiereus">
 						<persName>Ἱερεύς</persName>
 					</person>
-					<person xml:id="ploytos">
+					<person xml:id="ploutos">
 						<persName>Πλοῦτος</persName>
 					</person>
 					<person xml:id="neanias">
 						<persName>Νεανίας</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="ermes">
+					<person xml:id="hermes">
 						<persName>Ἑρμῆς</persName>
 					</person>
-					<person xml:id="sykofantes">
+					<person xml:id="sykophantes">
 						<persName>Συκοφάντης</persName>
 					</person>
 				</listPerson>
@@ -194,7 +194,7 @@ bring up to P3
 					<l n="20">ὦ δέσποτ’, ἀλλά σοι παρέξω πράγματα.</l>
 					<l>οὐ γάρ με τυπτήσεις στέφανον ἔχοντά γε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>μὰ Δί’ ἀλλ’ ἀφελὼν τὸν στέφανον, ἢν λυπῇς τί με,</l>
 					<l>ἵνα μᾶλλον ἀλγῇς.</l>
@@ -205,7 +205,7 @@ bring up to P3
 					<l>πρὶν ἂν φράσῃς μοι τίς ποτ’ ἐστὶν οὑτοσί·</l>
 					<l n="25">εὔνους γὰρ ὤν σοι πυνθάνομαι πάνυ σφόδρα.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἀλλ’ οὔ σε κρύψω· τῶν ἐμῶν γὰρ οἰκετῶν</l>
 					<l>πιστότατον ἡγοῦμαί σε καὶ κλεπτίστατον.</l>
@@ -216,7 +216,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">οἶδά τοι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="30">ἕτεροι δ’ ἐπλούτουν ἱερόσυλοι ῥήτορες</l>
 					<l>καὶ συκοφάνται καὶ πονηροί·</l>
@@ -225,7 +225,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">πείθομαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἐπερησόμενος οὖν ᾠχόμην ὡς τὸν θεόν,</l>
 					<l>τὸν ἐμὸν μὲν αὐτοῦ τοῦ ταλαιπώρου σχεδὸν</l>
@@ -239,7 +239,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>τί δῆτα Φοῖβος ἔλακεν ἐκ τῶν στεμμάτων;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="40">πεύσει. σαφῶς γὰρ ὁ θεὸς εἶπέ μοι τοδί·</l>
 					<l>ὅτῳ ξυναντήσαιμι πρῶτον ἐξιών,</l>
@@ -250,7 +250,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>καὶ τῷ ξυναντᾷς δῆτα πρώτῳ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τουτῳί.</l>
 				</sp>
@@ -260,7 +260,7 @@ bring up to P3
 					<l>φράζουσαν ὦ σκαιότατέ σοι σαφέστατα</l>
 					<l>ἀσκεῖν τὸν υἱὸν τὸν ἐπιχώριον τρόπον;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τῷ τοῦτο κρίνεις;</l>
 				</sp>
@@ -271,7 +271,7 @@ bring up to P3
 					<l n="50">τὸ μηδὲν ἀσκεῖν ὑγιὲς ἐν τῷ νῦν χρόνῳ.</l>
 					<milestone ed="p" n="51" unit="card"/>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὐκ ἔσθ’ ὅπως ὁ χρησμὸς ἐς τοῦτο ῥέπει,</l>
 					<l>ἀλλ’ εἰς ἕτερόν τι μεῖζον. ἢν δ’ ἡμῖν φράσῃ</l>
@@ -284,7 +284,7 @@ bring up to P3
 					<l>ἄγε δὴ σὺ πότερον σαυτὸν ὅστις εἶ φράσεις,</l>
 					<l>ἢ τἀπὶ τούτοις δρῶ; λέγειν χρὴ ταχὺ πάνυ.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ἐγὼ μὲν οἰμώζειν λέγω σοι.</l>
 				</sp>
@@ -293,14 +293,14 @@ bring up to P3
 					<l part="Y">μαναθάνεις</l>
 					<l>ὅς φησιν εἶναι;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">σοὶ λέγει τοῦτ’, οὐκ ἐμοί·</l>
 					<l n="60">σκαιῶς γὰρ αὐτοῦ καὶ χαλεπῶς ἐκπυνθάνει.</l>
 					<l>ἀλλ’ εἴ τι χαίρεις ἀνδρὸς εὐόρκου τρόποις,</l>
 					<l>ἐμοὶ φράσον.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">κλάειν ἔγωγέ σοι λέγω.</l>
 				</sp>
@@ -308,7 +308,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>δέχου τὸν ἄνδρα καὶ τὸν ὄρνιν τοῦ θεοῦ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὔ τοι μὰ τὴν Δήμητρα χαιρήσεις ἔτι.</l>
 					<l n="65">εἰ μὴ φράσεις γάρ—</l>
@@ -317,15 +317,15 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ἀπό σ’ ὀλῶ κακὸν κακῶς.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὦ τᾶν—</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">ἀπαλλάχθητον ἀπ’ ἐμοῦ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">πώμαλα.</l>
 				</sp>
@@ -336,42 +336,42 @@ bring up to P3
 					<l>ἀναθεὶς γὰρ ἐπὶ κρημνόν τιν’ αὐτὸν καταλιπων</l>
 					<l n="70">ἄπειμ’, ἵν’ ἐκεῖθεν ἐκτραχηλισθῇ πεσών.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἀλλ’ αἶρε ταχέως.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">μηδαμῶς.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">οὔκουν ἐρεῖς;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ἀλλ’ ἢν πύθησθέ μ’ ὅστις εἴμ’, εὖ οἶδ’ ὅτι</l>
 					<l>κακόν τί μ’ ἐργάσεσθε κοὐκ ἀφήσετον.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>νὴ τοὺς θεοὺς ἡμεῖς γ’, ἐὰν βούλῃ γε σύ.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l n="75">μέθεσθε νῦν μου πρῶτον.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ἤν, μεθίεμεν.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ἀκούετον δή· δεῖ γὰρ ὡς ἔοικέ με</l>
 					<l>λέγειν ἃ κρύπτειν ἦν παρεσκευασμένος.</l>
 					<l>ἐγὼ γάρ εἰμι Πλοῦτος.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ὦ μιαρώτατε</l>
 					<l>ἀνδρῶν ἁπάντων, εἶτ’ ἐσίγας Πλοῦτος ὤν;</l>
@@ -382,33 +382,33 @@ bring up to P3
 					<l>ὦ Φοῖβ’ Ἄπολλον καὶ θεοὶ καὶ δαίμονες</l>
 					<l>καὶ Ζεῦ, τί φῄς; ἐκεῖνος ὄντως εἶ σύ;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">ναί.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἐκεῖνος αὐτός;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">αὐτότατος.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">πόθεν οὖν φράσον</l>
 					<l>αὐχμῶν βαδίζεις;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">ἐκ Πατροκλέους ἔρχομαι,</l>
 					<l n="85">ὃς οὐκ ἐλούσατ’ ἐξ ὅτουπερ ἐγένετο.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τουτὶ δὲ τὸ κακὸν πῶς ἔπαθες; κάτειπέ μοι.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ὁ Ζεύς με ταῦτ’ ἔδρασεν ἀνθρώποις φθονῶν.</l>
 					<l>ἐγὼ γὰρ ὢν μειράκιον ἠπείλησ’ ὅτι</l>
@@ -417,52 +417,52 @@ bring up to P3
 					<l>ἵνα μὴ διαγιγνώσκοιμι τούτων μηδένα.</l>
 					<l>οὕτως ἐκεῖνος τοῖσι χρηστοῖσι φθονεῖ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ μὴν διὰ τοὺς χρηστούς γε τιμᾶται μόνους</l>
 					<l>καὶ τοὺς δικαίους.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">ὁμολογῶ σοι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">φέρε τί οὖν;</l>
 					<l n="95">εἰ πάλιν ἀναβλέψειας ὥσπερ καὶ πρὸ τοῦ,</l>
 					<l>φεύγοις ἂν ἤδη τοὺς πονηρούς;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">φήμ’ ἐγώ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὡς τοὺς δικαίους δ’ ἂν βαδίζοις;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">πάνυ μὲν οὖν·</l>
 					<l>πολλοῦ γὰρ αὐτοὺς οὐχ ἑόρακά πω χρόνου.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ θαῦμά γ’ οὐδέν· οὐδ’ ἐγὼ γὰρ ὁ βλέπων.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l n="100">ἄφετόν με νῦν. ἴστον γὰρ ἤδη τἀπ’ ἐμοῦ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>μὰ Δί’ ἀλλὰ πολλῷ μᾶλλον ἑξόμεσθά σου.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>οὐκ ἠγόρευον ὅτι παρέξειν πράγματα</l>
 					<l>ἐμέλλετόν μοι;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">καὶ σύ γ’ ἀντιβολῶ πιθοῦ,</l>
 					<l>καὶ μή μ’ ἀπολίπῃς· οὐ γὰρ εὑρήσεις ἐμοῦ</l>
@@ -473,17 +473,17 @@ bring up to P3
 					<l>μὰ τὸν Δί’ οὐ γὰρ ἔστιν ἄλλος πλὴν ἐγώ.</l>
 					<milestone ed="p" n="107" unit="card"/>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ταυτὶ λέγουσι πάντες· ἡνίκ’ ἂν δέ μου</l>
 					<l>τύχωσ’ ἀληθῶς καὶ γένωνται πλούσιοι,</l>
 					<l>ἀτεχνῶς ὑπερβάλλουσι τῇ μοχθηρίᾳ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="110">ἔχει μὲν οὕτως, εἰσὶ δ’ οὐ πάντες κακοί.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>μὰ Δί’ ἀλλ’ ἁπαξάπαντες.</l>
 				</sp>
@@ -491,7 +491,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">οἰμώξει μακρά.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>σοὶ δ’ ὡς ἂν εἰδῇς ὅσα παρ’ ἡμῖν ἢν μένῃς</l>
 					<l>γενήσετ’ ἀγαθά, πρόσεχε τὸν νοῦν ἵνα πύθῃ.</l>
@@ -499,12 +499,12 @@ bring up to P3
 					<l n="115">ταύτης ἀπαλλάξειν σε τῆς ὀφθαλμίας</l>
 					<l>βλέψαι ποιήσας.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">μηδαμῶς τοῦτ’ ἐργάσῃ.</l>
 					<l>οὐ βούλομαι γὰρ πάλιν ἀναβλέψαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τί φῄς;</l>
 				</sp>
@@ -512,42 +512,42 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ἅνθρωπος οὗτός ἐστιν ἄθλιος φύσει.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ὁ Ζεὺς † μὲν οὖν εἰδὼς τὰ τούτων μῶρ’ ἔμ’ εἰ†</l>
 					<l n="120">πύθοιτ’ ἂν ἐπιτρίψειε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">νῦν δ’ οὐ τοῦτο δρᾷ,</l>
 					<l>ὅστις σε προσπταίοντα περινοστεῖν ἐᾷ;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>οὐκ οἶδ’· ἐγὼ δ’ ἐκεῖνον ὀρρωδῶ πάνυ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἄληθες ὦ δειλότατε πάντων δαιμόνων;</l>
 					<l>οἴει γὰρ εἶναι τὴν Διὸς τυραννίδα</l>
 					<l n="125">καὶ τοὺς κεραυνοὺς ἀξίους τριωβόλου,</l>
 					<l>ἐὰν ἀναβλέψῃς σὺ κἂν σμικρὸν χρόνον;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ἆ μὴ λέγ’ ὦ πόνηρε ταῦτ’.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ἔχ’ ἥσυχος.</l>
 					<l>ἐγὼ γὰρ ἀποδείξω σε τοῦ Διὸς πολὺ</l>
 					<l>μεῖζον δυνάμενον.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">ἐμὲ σύ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">νὴ τὸν οὐρανόν.</l>
 					<l n="130">αὐτίκα γὰρ ἄρχει διὰ τίν’ ὁ Ζεὺς τῶν θεῶν;</l>
@@ -556,7 +556,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>διὰ τἀργύριον· πλεῖστον γάρ ἐστ’ αὐτῷ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">φέρε</l>
 					<l>τίς οὖν ὁ παρέχων ἐστὶν αὐτῷ τοῦθ’;</l>
@@ -565,7 +565,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ὁδί.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>θύουσι δ’ αὐτῷ διὰ τίν’; οὐ διὰ τουτονί;</l>
 				</sp>
@@ -573,26 +573,26 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>καὶ νὴ Δί’ εὔχονταί γε πλουτεῖν ἄντικρυς.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="135">οὔκουν ὅδ’ ἐστὶν αἴτιος καὶ ῥᾳδίως</l>
 					<l>παύσειεν, εἰ βούλοιτο, ταῦτ’ ἄν;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">ὅτι τί δή;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὅτι οὐδ’ ἂν εἷς θύσειεν ἀνθρώπων ἔτι,</l>
 					<l>οὐ βοῦν ἄν, οὐχὶ ψαιστόν, οὐκ ἄλλ’ οὐδὲ ἕν,</l>
 					<l>μὴ βουλομένου σοῦ.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">πῶς;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ὅπως;</l>
 					<l>οὐκ ἔσθ’ ὅπως</l>
@@ -600,11 +600,11 @@ bring up to P3
 					<l>αὐτὸς διδῷς πἀργύριον· ὥστε τοῦ Διὸς</l>
 					<l>τὴν δύνομιν, ἢν λυπῇ τι, καταλύσεις μόνος.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>τί λέγεις; δῑ ἐμὲ θύουσιν αὐτῷ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">φήμ’ ἐγώ.</l>
 					<l>καὶ νὴ Δί’ εἴ τί γ’ ἔστι λαμπρὸν καὶ καλὸν</l>
@@ -616,7 +616,7 @@ bring up to P3
 					<l>ἔγωγέ τοι διὰ μικρὸν ἀργυρίδιον</l>
 					<l>δοῦλος γεγένημαι, διὰ τὸ μὴ πλουτεῖν ἴσως.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ τάς γ’ ἑταίρας φασὶ τὰς Κορινθίας,</l>
 					<l n="150">ὅταν μὲν αὐτάς τις πένης πειρῶν τύχῃ,</l>
@@ -628,7 +628,7 @@ bring up to P3
 					<l>καὶ τούς γε παῖδάς φασι ταὐτὸ τοῦτο δρᾶν</l>
 					<l>οὐ τῶν ἐραστῶν ἀλλὰ τἀργυρίου χάριν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="155">οὐ τούς γε χρηστούς, ἀλλὰ τοὺς πόρνους· ἐπεὶ</l>
 					<l>αἰτοῦσιν οὐκ ἀργύριον οἱ χρηστοί.</l>
@@ -637,7 +637,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">τί δαί;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὁ μὲν ἵππον ἀγαθόν, ὁ δὲ κύνας θηρευτικάς.</l>
 				</sp>
@@ -646,7 +646,7 @@ bring up to P3
 					<l>αἰσχυνόμενοι γὰρ ἀργύριον αἰτεῖν ἴσως</l>
 					<l>ὀνόματι περιπέττουσι τὴν μοχθηρίαν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="160">τέχναι δὲ πᾶσαι διὰ σὲ καὶ σοφίσματα</l>
 					<l>ἐν τοῖσιν ἀνθρώποισίν ἐσθ’ ηὑρημένα.</l>
@@ -656,7 +656,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ἕτερος δὲ χαλκεύει τις, ὁ δὲ τεκταίνεται·</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὁ δὲ χρυσοχοεῖ γε χρυσίον παρὰ σοῦ λαβών·</l>
 				</sp>
@@ -664,7 +664,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l n="165">ὁ δὲ λωποδυτεῖ γε νὴ Δί’, ὁ δὲ τοιχωρυχεῖ·</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὁ δὲ γναφεύει γ’·</l>
 				</sp>
@@ -672,7 +672,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ὁ δέ γε πλύνει κῴδια·</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὁ δὲ βυρσοδεψεῖ γ’·</l>
 				</sp>
@@ -680,11 +680,11 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ὁ δέ γε πωλεῖ κρόμμυα·</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὁ δ’ ἁλούς γε μοιχὸς διὰ σέ που παρατίλλεται.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>οἴμοι τάλας ταυτί μ’ ἐλάνθανεν πάλαι.</l>
 					<milestone ed="p" n="170" unit="card"/>
@@ -693,7 +693,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l n="170">μέγας δὲ βασιλεὺς οὐχὶ διὰ τοῦτον κομᾷ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἐκκλησία δ’ οὐχὶ διὰ τοῦτον γίγνεται;</l>
 				</sp>
@@ -701,7 +701,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>τί δέ; τὰς τριήρεις οὐ σὺ πληροῖς; εἰπέ μοι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τὸ δ’ ἐν Κορίνθῳ ξενικὸν οὐχ οὗτος τρέφει;</l>
 				</sp>
@@ -709,7 +709,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ὁ Πάμφιλος δ’ οὐχι διὰ τοῦτον κλαύσεται;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="175">ὁ βελονοπώλης δ’ οὐχὶ μετὰ τοῦ Παμφίλου;</l>
 				</sp>
@@ -717,7 +717,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>Ἀγύρριος δ’ οὐχὶ διὰ τοῦτον πέρδεται;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>Φιλέψιος δ’ οὐχ ἕνεκα σοῦ μύθους λέγει;</l>
 				</sp>
@@ -725,7 +725,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ἡ ξυμμαχία δ’ οὐ διὰ σὲ τοῖς Αἰγυπτίοις;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἐρᾷ δὲ Λαῒς οὐ διὰ σὲ Φιλωνίδου;</l>
 				</sp>
@@ -733,7 +733,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l n="180">ὁ Τιμοθέου δὲ πύργος—</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ἐμπέσοι γέ σοι.</l>
 					<l>τὰ δὲ πράγματ’ οὐχὶ διὰ σὲ πάντα πράττεται;</l>
@@ -745,11 +745,11 @@ bring up to P3
 					<l>κρατοῦσι γοῦν κἀν τοῖς πολέμοις ἑκάστοτε,</l>
 					<l n="185">ἐφ’ οἷς οὗτος ἐπικαθέζηται μόνον.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ἐγὼ τοσαῦτα δυνατός εἰμ’ εἷς ὢν ποιεῖν;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ ναὶ μὰ Δία τούτων γε πολλῷ πλείονα·</l>
 					<l>ὥστ’ οὐδὲ μεστὸς σοῦ γέγον’ οὐδεὶς πώποτε.</l>
@@ -760,7 +760,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ἄρτων</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">μουσικῆς</l>
 				</sp>
@@ -768,7 +768,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">τραγημάτων</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τιμῆς</l>
 				</sp>
@@ -776,7 +776,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">πλακούντων</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ἀνδραγαθίας</l>
 				</sp>
@@ -784,7 +784,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ἰσχάδων</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>φιλοτιμίας</l>
 				</sp>
@@ -792,7 +792,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">μάζης</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">στρατηγίας</l>
 				</sp>
@@ -800,7 +800,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">φακῆς·</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>σοῦ δ’ ἐγένετ’ οὐδεὶς μεστὸς οὐδεπώποτε.</l>
 					<l>ἀλλ’ ἢν τάλαντά τις λάβῃ τριακαίδεκα,</l>
@@ -808,26 +808,26 @@ bring up to P3
 					<l>κἂν ταῦτ’ ἀνύσηται, τετταράκοντα βούλεται,</l>
 					<l>ἤ φησιν εἶν ἀβίωτον αὑτῷ τὸν βίον.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>εὖ τοι λέγειν ἔμοιγε φαίνεσθον πάνυ·</l>
 					<l>πλὴν ἓν μόνον δέδοικα.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">φράζε τοῦ πέρι;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l n="200">ὅπως ἐγὼ τὴν δύναμιν ἣν ὑμεῖς φατε</l>
 					<l>ἔχειν με, ταύτης δεσπότης γενήσομαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>νὴ τὸν Δί’ ἀλλὰ καὶ λέγουσι πάντες ὡς</l>
 					<l>δειλότατόν ἐσθ’ ὁ Πλοῦτος.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">ἥκιστ’, ἀλλά με</l>
 					<l>τοιχωρύχος τις διέβαλ’. ἐσδὺς γάρ ποτε</l>
@@ -835,34 +835,34 @@ bring up to P3
 					<l>εὑρὼν ἁπαξάπαντα κατακεκλῃμένα·</l>
 					<l>εἶτ’ ὠνόμασέ μου τὴν πρόνοιαν δειλίαν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>μή νυν μελέτω σοι μηδέν· ὡς ἐὰν γένῃ</l>
 					<l>ἀνὴρ πρόθυμος αὐτὸς ἐς τὰ πράγματα,</l>
 					<l n="210">βλέποντ’ ἀποδείξω σ’ ὀξύτερον τοῦ Λυγκέως.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>πῶς οὖν δυνήσει τοῦτο δρᾶσαι θνητὸς ὤν;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἔχω τιν’ ἀγαθὴν ἐλπίδ’ ἐξ ὧν εἶπέ μοι</l>
 					<l>ὁ Φοῖβος αὐτὸς Πυθικὴν σείσας δάφνην.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>κἀκεῖνος οὖν σύνοιδε ταῦτα;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">φήμ’ ἐγώ.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l n="215">ὁρᾶτε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">μὴ φρόντιζε μηδὲν ὦγαθέ.</l>
 					<l>ἐγὼ γάρ, εὖ τοῦτ’ ἴσθι, κεἰ δεῖ μ’ ἀποθανεῖν,</l>
@@ -872,17 +872,17 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">κἂν βούλῃ γ’, ἐγώ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>πολλοὶ δ’ ἔσονται χἄτεροι νῷν ξύμμαχοι,</l>
 					<l>ὅσοις δικαίοις οὖσιν οὐκ ἦν ἄλφιτα.</l>
 					<milestone ed="p" n="220" unit="card"/>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l n="220">παπαῖ πονηρούς γ’ εἶπας ἡμῖν συμμάχους.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὐκ ἤν γε πλουτήσωσιν ἐξ ἀρχῆς πάλιν.</l>
 					<l>ἀλλ’ ἴθι σὺ μὲν ταχέως δραμών—</l>
@@ -891,7 +891,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">τί δρῶ; λέγε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τοὺς ξυγγεώργους κάλεσον, εὑρήσεις δ’ ἴσως</l>
 					<l>ἐν τοῖς ἀγροῖς αὐτοὺς ταλαιπωρουμένους,</l>
@@ -903,7 +903,7 @@ bring up to P3
 					<l>καὶ δὴ βαδίζω· τουτοδὶ τὸ κρεᾴδιον</l>
 					<l>τῶν ἔνδοθέν τις εἰσενεγκάτω λαβών.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἐμοὶ μελήσει τοῦτό γ’· ἀλλ’ ἀνύσας τρέχε.</l>
 					<l n="230">σὺ δ’ ὦ κράτιστε Πλοῦτε πάντων δαιμόνων</l>
@@ -911,7 +911,7 @@ bring up to P3
 					<l>αὕτη ’στὶν ἣν δεῖ χρημάτων σε τήμερον</l>
 					<l>μεστὴν ποιῆσαι καὶ δικαίως κἀδίκως.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>ἀλλ’ ἄχθομαι μὲν εἰσιὼν νὴ τοὺς θεοὺς</l>
 					<l n="235">εἰς οἰκίαν ἑκάστοτ’ ἀλλοτρίαν πάνυ·</l>
@@ -925,7 +925,7 @@ bring up to P3
 					<l>πόρναισι καὶ κύβοισι παραβεβλημένος</l>
 					<l>γυμνὸς θύραζ’ ἐξέπεσον ἐν ἀκαρεῖ χρόνου.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="245">μετρίου γὰρ ἀνδρὸς οὐκ ἐπέτυχες πώποτε.</l>
 					<l>ἐγὼ δὲ τούτου τοῦ τρόπου πώς εἰμ’ ἀεί,</l>
@@ -935,11 +935,11 @@ bring up to P3
 					<l n="250">καὶ τὴν γυναῖκα καὶ τὸν υἱὸν τὸν μόνον,</l>
 					<l>ὃν ἑγὼ φιλῶ μάλιστα μετὰ σέ.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">πείθομαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τί γὰρ ἄν τις οὐχὶ πρὸς σὲ τἀληθῆ λέγοι;</l>
 					<milestone ed="p" n="253" unit="card"/>
@@ -953,7 +953,7 @@ bring up to P3
 					<l n="255">ἴτ’ ἐγκονεῖτε σπεύδεθ’, ὡς ὁ καιρὸς οὐχὶ μέλλειν,</l>
 					<l>ἀλλ’ ἔστ’ ἐπ’ αὐτῆς τῆς ἀκμῆς, ᾗ δεῖ παρόντ’ ἀμύνειν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὔκουν ὁρᾷς ὁρμωμένους ἡμᾶς πάλαι προθύμως,</l>
 					<l>ὡς εἰκός ἐστιν ἀσθενεῖς γέροντας ἄνδρας ἤδη;</l>
@@ -966,7 +966,7 @@ bring up to P3
 					<l>ὁ δεσπότης γάρ φησιν ὑμᾶς ἡδέως ἅπαντας</l>
 					<l>ψυχροῦ βίου καὶ δυσκόλου ζήσειν ἀπαλλαγέντας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔστιν δὲ δὴ τί καὶ πόθεν τὸ πρᾶγμα τοῦθ’ ὅ φησιν;</l>
 				</sp>
@@ -976,7 +976,7 @@ bring up to P3
 					<l>ῥυπῶντα κυφὸν ἄθλιον ῥυσὸν μαδῶντα νωδόν·</l>
 					<l>οἶμαι δὲ νὴ τὸν οὐρανὸν καὶ ψωλὸν αὐτὸν εἶναι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ χρυσὸν ἀγγείλας ἐπῶν πῶς φῄς; πάλιν φράσον μοι.</l>
 					<l>δηλοῖς γὰρ αὐτὸν σωρὸν ἥκειν χρημάτων ἔχοντα.</l>
@@ -985,7 +985,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l n="270">πρεσβυτικῶν μὲν οὖν κακῶν ἔγωγ’ ἔχοντα σωρόν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μῶν ἀξιοῖς φενακίσας ἔπειτ’ ἀπαλλαγῆναι</l>
 					<l>ἀζήμοις, καὶ ταῦτ’ ἐμοῦ βακτηρίαν ἔχοντος;</l>
@@ -995,7 +995,7 @@ bring up to P3
 					<l>πάντως γὰρ ἄνθρωπον φύσει τοιοῦτον ἐς τὰ πάντα</l>
 					<l>ἡγεῖσθέ μ’ εἶναι κοὐδὲν ἂν νομίζεθ’ ὑγιὲς εἰπεῖν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="275">ὡς σεμνὸς οὑπίτριπτος· αἱ κνῆμαι δέ σου βοῶσιν</l>
 					<l>‘ἰοὺ ἰού,’ τὰς χοίνικας καὶ τὰς πέδας ποθοῦσαι.</l>
@@ -1005,7 +1005,7 @@ bring up to P3
 					<l>ἐν τῇ σορῷ νυνὶ λαχὸν τὸ γράμμα σου δικάζειν,</l>
 					<l>σὺ δ’ οὐ βαδίζεις, ὁ δὲ Χάρων τὸ ξύμβολον δίδωσιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>διαρραγείης, ὡς μόθων εἶ καὶ φύσει κόβαλος,</l>
 					<l n="280">ὅστις φενακίζεις, φράσαι δ’ οὔπω τέτληκας ἡμῖν,</l>
@@ -1017,7 +1017,7 @@ bring up to P3
 					<l>ἀλλ’ οὐκέτ’ ἂν κρύψαιμι. τὸν Πλοῦτον γὰρ ὦνδρες ἥκει</l>
 					<l n="285">ἄγων ὁ δεσπότης, ὃς ὑμᾶς πλουσίους ποιήσει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὄντως γὰρ ἔστι πλουσίοις ἡμῖν ἅπασιν εἶναι;</l>
 				</sp>
@@ -1025,7 +1025,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>νὴ τοὺς θεοὺς Μίδαις μὲν οὖν, ἢν ὦτ’ ὄνου λάβητε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὡς ἥδομαι καὶ τέρπομαι καὶ βούλομαι χορεῦσαι</l>
 					<l>ὑφ’ ἡδονῆς, εἴπερ λέγεις ὄντως σὺ ταῦτ’ ἀληθῆ.</l>
@@ -1046,7 +1046,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἡμεῖς δέ γ’ αὖ ζητήσομεν θρεττανελὸ τὸν Κύκλωπα</l>
 						<l>βληχώμενοι, σὲ τουτονὶ πεινῶντα καταλαβόντες,</l>
@@ -1071,7 +1071,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2a" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκοῦν σε τὴν Κίρκην γε τὴν τὰ φάρμακ’ ἀνακυκῶσαν</l>
 						<l n="310">καὶ μαγγανεύουσαν μολύνουσάν τε τοὺς ἑταίρους</l>
@@ -1098,7 +1098,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>χαίρειν μὲν ὑμᾶς ἐστιν ὦνδρες δημόται</l>
 					<l>ἀρχαῖον ἤδη προσαγορεύειν καὶ σαπρόν·</l>
@@ -1107,14 +1107,14 @@ bring up to P3
 					<l>ὅπως δέ μοι καὶ τἄλλα συμπαραστάται</l>
 					<l>ἔσεσθε καὶ σωτῆρες ὄντως τοῦ θεοῦ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θάρρει· βλέπειν γὰρ ἄντικρυς δόξεις μ’ Ἄρη.</l>
 					<l>δεινὸν γὰρ εἰ τριωβόλου μὲν οὕνεκα</l>
 					<l n="330">ὠστιζόμεσθ’ ἑκάστοτ’ ἐν τἠκκλησίᾳ,</l>
 					<l>αὐτὸν δὲ τὸν Πλοῦτον παρείην τῳ λαβεῖν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ μὴν ὁρῶ καὶ Βλεψίδημον τουτονὶ</l>
 					<l>προσιόντα· δῆλος δ’ ἐστὶν ὅτι τοῦ πράγματος</l>
@@ -1131,7 +1131,7 @@ bring up to P3
 					<l>χρηστόν τι πράττων τοὺς φίλους μεταπέμπεται.</l>
 					<l>οὔκουν ἐπιχώριόν γε πρᾶγμ’ ἐργάζεται.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἀλλ’ οὐδὲν ἀποκρύψας ἐρῶ· νὴ τοὺς θεοὺς</l>
 					<l>ὦ Βλεψίδημ’ ἄμεινον ἢ χθὲς πράττομεν,</l>
@@ -1141,7 +1141,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>γέγονας δ’ ἀληθῶς, ὡς λέγουσι, πλούσιος;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἔσομαι μὲν οὖν αὐτίκα μάλ’, ἢν θεὸς θέλῃ.</l>
 					<l>ἔνι γάρ τις ἔνι κίνδυνος ἐν τῷ πράγματι.</l>
@@ -1150,7 +1150,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>ποῖός τις;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">οἷος;</l>
 				</sp>
@@ -1158,7 +1158,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">λέγ’ ἀνύσας ὅ τι φῄς ποτε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="350">ἢν μὲν κατορθώσωμεν, εὖ πράττειν ἀεί·</l>
 					<l>ἢν δὲ σφαλῶμεν, ἐπιτετρῖφθαι τὸ παράπαν.</l>
@@ -1170,7 +1170,7 @@ bring up to P3
 					<l>οὕτως ὑπερπλουτεῖν τό τ’ αὖ δεδοικέναι</l>
 					<l n="355">πρὸς ἀνδρὸς οὐδὲν ὑγιές ἐστ’ εἰργασμένου.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>πῶς οὐδὲν ὑγιές;</l>
 				</sp>
@@ -1180,7 +1180,7 @@ bring up to P3
 					<l>ἐκεῖθεν ἥκεις ἀργύριον ἢ χρυσίον</l>
 					<l>παρὰ τοῦ θεοῦ, κἄπειτ’ ἴσως σοι μεταμέλει.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>Ἄπολλον ἀποτρόπαιε μὰ Δί’ ἐγὼ μὲν οὔ.</l>
 				</sp>
@@ -1188,7 +1188,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l n="360">παῦσαι φλυαρῶν ὦγάθ’· οῖδα γὰρ σαφῶς.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>σὺ μηδὲν εἰς ἔμ’ ὑπονόει τοιουτονί.</l>
 				</sp>
@@ -1198,7 +1198,7 @@ bring up to P3
 					<l>ὡς οὐδὲν ἀτεχνῶς ὑγιές ἐστιν οὐδενός,</l>
 					<l>ἀλλ’ εἰσὶ τοῦ κέρδους ἅπαντες ἥττονες.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὔ τοι μὰ τὴν Δήμητρ’ ὑγιαίνειν μοι δοκεῖς.</l>
 				</sp>
@@ -1206,7 +1206,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l n="365">ὡς πολὺ μεθέστηχ’ ὧν πρότερον εἶχεν τρόπων.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>μελαγχολᾷς ὦνθρωπε νὴ τὸν οὐρανόν.</l>
 				</sp>
@@ -1215,7 +1215,7 @@ bring up to P3
 					<l>ἀλλ’ οὐδὲ τὸ βλέμμ’ αὐτὸ κατὰ χώραν ἔχει,</l>
 					<l>ἀλλ’ ἐστὶν ἐπίδηλόν τι πεπανουργηκότι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>σὺ μὲν οἶδ’ ὃ κρώζεις· ὡς ἐμοῦ τι κεκλοφότος</l>
 					<l n="370">ζητεῖς μεταλαβεῖν.</l>
@@ -1224,7 +1224,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">μεταλαβεῖν ζητῶ; τίνος;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τὸ δ’ ἐστὶν οὐ τοιοῦτον ἀλλ’ ἑτέρως ἔχον.</l>
 				</sp>
@@ -1232,7 +1232,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>μῶν οὐ κέκλοφας ἀλλ’ ἥρπακας;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">κακοδαιμονᾷς.</l>
 				</sp>
@@ -1240,7 +1240,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>ἀλλ’ οὐδὲ μὴν ἀπεστέρηκάς γ’ οὐδένα;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οῡ δῆτ’ ἔγωγ’.</l>
 				</sp>
@@ -1249,7 +1249,7 @@ bring up to P3
 					<l part="Y">ὦ Ἡράκλεις, φέρε ποῖ τις ἂν</l>
 					<l n="375">τράποιτο; τἀληθὲς γὰρ οὐκ ἐθέλει φράσαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>κατηγορεῖς γὰρ πρὶν μαθεῖν τὸ πρᾶγμά μου.</l>
 					<milestone ed="p" n="377" unit="card"/>
@@ -1260,7 +1260,7 @@ bring up to P3
 					<l>ἐθέλω διαπρᾶξαι πρὶν πυθέσθαι τὴν πόλιν,</l>
 					<l>τὸ στόμ’ ἐπιβύσας κέρμασιν τῶν ῥητόρων.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="380">καὶ μὴν φίλως γ’ ἄν μοι δοκεῖς νὴ τοὺς θεοὺς</l>
 					<l>τρεῖς μνᾶς ἀναλώσας λογίσασθαι δώδεκα.</l>
@@ -1272,7 +1272,7 @@ bring up to P3
 					<l>καὶ τῆς γυναικός, κοῡ διοίσοντ’ ἄντικρυς</l>
 					<l n="385">τῶν Ἡρακλειδῶν οὐδ’ ὁτιοῦν τῶν Παμφίλου.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὒκ ὦ κακόδαιμον, ἀλλὰ τοὺς χρηστοὺς μόνους</l>
 					<l>ἔγωγε καὶ τοὺς δεξιοὺς καὶ σώφρονας</l>
@@ -1283,7 +1283,7 @@ bring up to P3
 					<l part="Y">τί σὺ λέγεις;</l>
 					<l>οὕτω πάνυ πολλὰ κέκλοφας;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">οἴμοι τῶν κακῶν,</l>
 					<l n="390">ἀπολεῖς.</l>
@@ -1292,7 +1292,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">σὺ μὲν οὖν σεαυτόν, ὥς γ’ ἐμοὶ δοκεῖς.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οῡ δῆτ’, ἐπεὶ τὸν Πλοῦτον ὦ μόχθηρε σὺ</l>
 					<l>ἔχω.</l>
@@ -1301,7 +1301,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">σὺ Πλοῦτον; ποῖον;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">αὐτὸν τὸν θεόν.</l>
 				</sp>
@@ -1309,7 +1309,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>καὶ ποῦ ’στιν;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ἔνδον.</l>
 				</sp>
@@ -1317,7 +1317,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">ποῦ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">παρ’</l>
 					<l>ἐμοί.</l>
@@ -1326,7 +1326,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">παρὰ σοί;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">πάνυ.</l>
 				</sp>
@@ -1334,7 +1334,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>οὐκ ἐς κόρακας; Πλοῦτος παρὰ σοί;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">νὴ τοὺς θεούς.</l>
 				</sp>
@@ -1342,7 +1342,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l n="395">λὲγεις ἀληθῆ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">φημί.</l>
 				</sp>
@@ -1350,7 +1350,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">πρὸς τῆς Ἑστίας;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>νὴ τὸν Ποσειδῶ.</l>
 				</sp>
@@ -1358,7 +1358,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">τὸν θαλάττιον λέγεις;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>εἰ δ’ ἔστιν ἕτερός τις Ποσειδῶν, τὸν ἕτερον.</l>
 				</sp>
@@ -1366,7 +1366,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>εἶτ’ οὐ διαπέμπεις καὶ πρὸς ἡμᾶς τοὺς φίλους;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὐκ ἔστι πω τὰ πράγματ’ ἐν τούτῳ.</l>
 				</sp>
@@ -1375,7 +1375,7 @@ bring up to P3
 					<l part="Y">τί φῄς;</l>
 					<l n="400">οὐ τῷ μεταδοῦναι;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">μὰ Δία. δεῖ γὰρ πρῶτα</l>
 				</sp>
@@ -1383,7 +1383,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">τί;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>βλέψαι ποιῆσαι νώ—</l>
 				</sp>
@@ -1391,7 +1391,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">τίνα βλέψαι; φράσον.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τὸν Πλοῦτον ὥσπερ πρότερον ἑνί γέ τῳ τρόπῳ.</l>
 				</sp>
@@ -1399,7 +1399,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>τυφλὸς γὰρ ὄντως ἐστί;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">νὴ τὸν οὐρανόν.</l>
 				</sp>
@@ -1407,7 +1407,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>οὐκ ἐτὸς ἄρ’ ὡς ἔμ’ ἦλθεν οὐδεπώποτε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="405">ἀλλ’ ἢν θεοὶ θέλωσι, νῦν ἀφίξεται.</l>
 				</sp>
@@ -1415,7 +1415,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>οὔκουν ἰατρὸν εἰσάγειν ἐχρῆν τινά;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τίς δῆτ’ ἰατρός ἐστι νῦν ἐν τῇ πόλει;</l>
 					<l>οὔτε γὰρ ὁ μισθὸς οὐδὲν ἔστ’ οὔθ’ ἡ τέχνη.</l>
@@ -1424,7 +1424,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>σκοπῶμεν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ἀλλ’ οὐκ ἔστιν.</l>
 				</sp>
@@ -1432,7 +1432,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">οὐδ ἐμοὶ δοκεῖ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="410">μὰ Δί’ ἀλλ’ ὅπερ πάλαι παρεσκευαζόμην</l>
 					<l>ἐγώ, κατακλίνειν αὐτὸν εἰς Ἀσκληπιοῦ</l>
@@ -1443,7 +1443,7 @@ bring up to P3
 					<l part="Y">πολὺ μὲν οὖν νὴ τοὺς θεούς.</l>
 					<l>μή νυν διάτριβ’ ἀλλ’ ἄνυε πράττων ἕν γέ τι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ δὴ βαδίζω.</l>
 				</sp>
@@ -1451,7 +1451,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">σπεῦδέ νυν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τοῦτ’ αὐτὸ δρῶ.</l>
 				</sp>
@@ -1473,7 +1473,7 @@ bring up to P3
 					<l n="420">ἀλλ’ οἷον οὐδεὶς ἄλλος οὐδεπώποτε</l>
 					<l>οὔτε θεὸς οὔτ’ ἄνθρωπος· ὥστ’ ἀπολώλατον.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>σὺ δ’ εἶ τίς; ὠχρὰ μὲν γὰρ εἶναί μοι δοκεῖς.</l>
 				</sp>
@@ -1482,7 +1482,7 @@ bring up to P3
 					<l>ἴσως Ἐρινύς ἐστιν ἐκ τραγῳδίας·</l>
 					<l>βλέπει γέ τοι μανικόν τι καὶ τραγῳδικόν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="425">ἀλλ’ οὐκ ἔχει γὰρ δᾷδας.</l>
 				</sp>
@@ -1494,7 +1494,7 @@ bring up to P3
 					<speaker>Πενία</speaker>
 					<l>ὄιεσθε δ’ εἶναι τίνα με;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">πανδοκεύτριαν</l>
 					<l>ἢ λεκιθόπωλιν. οὐ γὰρ ἂν τοσουτονὶ</l>
@@ -1505,7 +1505,7 @@ bring up to P3
 					<l>ἄληθες; οὐ γὰρ δεινότατα δεδράκατον</l>
 					<l n="430">ζητοῦντες ἐκ πάσης με χώρας ἐκβαλεῖν;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὔκουν ὑπόλοιπον τὸ βάραθρόν σοι γίγνεται;</l>
 					<l>ἀλλ’ ἥτις εἶ λέγειν σ’ ἐχρῆν αὐτίκα μάλα.</l>
@@ -1528,7 +1528,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l>ἄναξ Ἄπολλον καὶ θεοί, ποῖ τις φύγῃ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὗτος τί δρᾷς; ὦ δειλότατον σὺ θηρίον·</l>
 					<l n="440">οὐ παραμενεῖς;</l>
@@ -1537,7 +1537,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">ἥκιστα πάντων.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">οὐ μενεῖς;</l>
 					<l>ἀλλ’ ἄνδρε δύο γυναῖκα φεύγομεν μίαν;</l>
@@ -1547,7 +1547,7 @@ bring up to P3
 					<l>Πενία γάρ ἐστιν ὦ πόνηρ’, ἧς οὐδαμοῦ</l>
 					<l>οὐδὲν πέφυκε ζῷον ἐξωλέστερον.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>στῆθ’, ἀντιβολῶ σε, στῆθι.</l>
 				</sp>
@@ -1555,7 +1555,7 @@ bring up to P3
 					<speaker>Βλεψίδημος</speaker>
 					<l part="Y">μὰ Δί’ ἐγὼ μὲν οὔ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="445">καὶ μὴν λέγω, δεινότατον ἔργον παρὰ πολὺ</l>
 					<l>ἔργων ἁπάντων ἐργασόμεθ’, εἰ τὸν θεὸν</l>
@@ -1568,7 +1568,7 @@ bring up to P3
 					<l n="450">ποῖον γὰρ οὐ θώρακα, ποίαν δ’ ἀσπίδα</l>
 					<l>οὐκ ἐνέχυρον τίθησιν ἡ μιαρωτάτη;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>θάρρει· μόνος γὰρ ὁ θεὸς οὗτος οἶδ’ ὅτι</l>
 					<l>τροπαῖον ἂν στήσαιτο τῶν ταύτης τρόπων.</l>
@@ -1578,7 +1578,7 @@ bring up to P3
 					<l>γρύζειν δὲ καὶ τολμᾶτον ὦ καθάρματε,</l>
 					<l n="455">ἐπ’ αὐτοφώρῳ δεινὰ δρῶντ’ εἰλημμένω;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>σὺ δ’ ὦ κάκιστ’ ἀπολουμένη τί λοιδορεῖ</l>
 					<l>ἡμῖν προσελθοῦσ’ οὐδ’ ὁτιοῦν ἀδικουμένη;</l>
@@ -1589,7 +1589,7 @@ bring up to P3
 					<l>ἀδικεῖν με τὸν Πλοῦτον ποιεῖν πειρωμένω</l>
 					<l n="460">βλέψαι πάλιν;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τί οὖν ἀδικοῦμεν τοῦτό σε,</l>
 					<l>εἰ πᾶσιν ἀνθρώποισιν ἐκπορίζομεν</l>
@@ -1599,7 +1599,7 @@ bring up to P3
 					<speaker>Πενία</speaker>
 					<l part="Y">τί δ’ ἂν ὑμεῖς ἀγαθὸν ἐξεύροιθ’;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ὅ τι;</l>
 					<l>σὲ πρῶτον ἐκβαλόντες ἐκ τῆς Ἑλλάδος.</l>
@@ -1609,7 +1609,7 @@ bring up to P3
 					<l>ἔμ’ ἐκβαλόντες; καὶ τί ἂν νομίζετον</l>
 					<l n="465">κακὸν ἐργάσασθαι μεῖζον ἀνθρώπους;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ὅ τι;</l>
 					<l>εἰ τοῦτο δρᾶν μέλλοντες ἐπιλαθοίμεθα.</l>
@@ -1623,7 +1623,7 @@ bring up to P3
 					<l n="470">ὑμῖν δῑ ἐμέ τε ζῶντας ὑμᾶς· εἰ δὲ μή,</l>
 					<l>ποιεῖτον ἤδη τοῦθ’ ὅ τι ἂν ὑμῖν δοκῇ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ταυτὶ σὺ τολμᾷς ὦ μιαρωτάτη λέγειν;</l>
 				</sp>
@@ -1633,7 +1633,7 @@ bring up to P3
 					<l>ἅπανθ’ ἁμαρτάνοντά σ’ ἀποδείξειν ἐγώ,</l>
 					<l n="475">εἰ τοὺς δικαίους φὴ|ς ποιήσειν πλουσίους.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὦ τύμπανα καὶ κύφωνες οὐκ ἀρήξετε;</l>
 				</sp>
@@ -1641,7 +1641,7 @@ bring up to P3
 					<speaker>Πενία</speaker>
 					<l>οὐ δεῖ σχετλιάζειν καὶ βοᾶν πρὶν ἂν μάθῃς.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ τίς δύναιτ’ ἂν μὴ βοᾶν ‘ἰοὺ ἰοὺ’</l>
 					<l>τοιαῦτ’ ἀκούων;</l>
@@ -1650,7 +1650,7 @@ bring up to P3
 					<speaker>Πενία</speaker>
 					<l part="Y">ὅστις ἐστὶν εὖ φρονῶν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="480">τί δῆτά σοι τίμημ’ ἐπιγράψω τῇ δίκῃ,</l>
 					<l>ἐὰν ἁλῷς;</l>
@@ -1659,7 +1659,7 @@ bring up to P3
 					<speaker>Πενία</speaker>
 					<l part="Y">ὅ τι σοι δοκεῖ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">καλῶς λέγεις.</l>
 				</sp>
@@ -1667,7 +1667,7 @@ bring up to P3
 					<speaker>Πενία</speaker>
 					<l>τὸ γὰρ αὔτ’, ἐὰν ἡττᾶσθε, καὶ σφὼ δεῖ παθεῖν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἱκανοὺς νομίζεις δῆτα θανάτους εἴκοσιν;</l>
 				</sp>
@@ -1684,7 +1684,7 @@ bring up to P3
 			</div1>
 			<div1 type="Agon">
 				<div2 met="anapests" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="487">ἀλλ’ ἤδη χρῆν τι λέγειν ὑμᾶς σοφὸν ᾧ νικήσετε τηνδὶ</l>
 						<l>ἐν τοῖσι λόγοις ἀντιλέγοντες, μαλακὸν δ’ ἐνδώσετε μηδέν.</l>
@@ -1692,7 +1692,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="epirrheme">
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>φανερὸν μὲν ἔγωγ’ οἶμαι γνῶναι τοῦτ’ εἶναι πᾶσιν ὁμοίως,</l>
 						<l n="490">ὅτι τοὺς χρηστοὺς τῶν ἀνθρώπων εὖ πράττειν ἐστὶ δίκαιον,</l>
@@ -1709,7 +1709,7 @@ bring up to P3
 						<speaker>Βλεψίδημος</speaker>
 						<l>οὐδείς· τούτου μάρτυς ἐγώ σοι· μηδὲν ταύτην γ’ ἀνερώτα.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l n="500">ὡς μὲν γὰρ νῦν ἡμῖν ὁ βίος τοῖς ἀνθρώποις διάκειται,</l>
 						<l>τίς ἂν οὐχ ἡγοῖτ’ εἶναι μανίαν κακοδαιμονίαν τ’ ἔτι μᾶλλον;</l>
@@ -1732,7 +1732,7 @@ bring up to P3
 						<l n="515">ἢ γῆς ἀρότροις ῥήξας δάπεδον καρπὸν Δηοῦς θερίσασθαι,</l>
 						<l>ἢν ἐξῇ ζῆν ἀργοῖς ὑμῖν πάντων ἀμελοῦσιν;</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>λῆρον ληρεῖς. ταῦτα γὰρ ἡμῖν πάνθ’ ὅσα νῦν δὴ κατέλεξας</l>
 						<l>οἱ θεράποντες μοχθήσουσιν.</l>
@@ -1741,7 +1741,7 @@ bring up to P3
 						<speaker>Πενία</speaker>
 						<l part="Y">πόθεν οὖν ἕξεις θεράποντας;</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>ὠνησόμεθ’ ἀργυρίου δήπου.</l>
 					</sp>
@@ -1750,7 +1750,7 @@ bring up to P3
 						<l part="Y">τίς δ’ ἔσται πρῶτον ὁ πωλῶν,</l>
 						<l n="520">ὅταν ἀργύριον κἀκεῖνος ἔχῃ;</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l part="Y">κερδαίνειν βουλόμενός τις</l>
 						<l>ἔμπορος ἥκων ἐκ Θετταλίας παρὰ πλείστων ἀνδραποδιστῶν.</l>
@@ -1763,7 +1763,7 @@ bring up to P3
 						<l n="525">ὥστ’ αὐτὸς ἀροῦν ἐπαναγκασθεὶς καὶ σκάπτειν τἄλλα τε μοχθεῖν</l>
 						<l>ὀδυνηρότερον τρίψεις βίοτον πολὺ τοῦ νῦν.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l part="Y">ἐς κεφαλὴν σοί.</l>
 					</sp>
@@ -1779,7 +1779,7 @@ bring up to P3
 						<l>διὰ τὴν χρείαν καὶ τὴν πενίαν ζητεῖν ὁπόθεν βίον ἕξει.</l>
 						<milestone ed="p" n="535" unit="card"/>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l n="535">σὺ γὰρ ἂν πορίσαι τί δύναῑ ἀγαθὸν φῴδων ἐκ βαλανείου</l>
 						<l>καὶ παιδαρίων ὑποπεινώντων καὶ γραι·δίων κολοσυρτόν;</l>
@@ -1799,7 +1799,7 @@ bring up to P3
 						<speaker>Πενία</speaker>
 						<l>σὺ μὲν οὐ τὸν ἐμὸν βίον εἴρηκας, τὸν τῶν πτωχῶν δ’ ὑπεκρούσω.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>οὐκοῦν δήπου τῆς Πτωχείας Πενίαν φαμὲν εἶναι ἀδελφήν.</l>
 					</sp>
@@ -1811,7 +1811,7 @@ bring up to P3
 						<l>τοῦ δὲ πένητος ζῆν φειδόμενον καὶ τοῖς ἔργοις προς έχοντα,</l>
 						<l>περιγίγνεσθαι δ’ αὐτῷ μηδέν, μὴ μέντοι μηδ’ ἐπιλείπειν.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l n="555">ὡς μακαρίτην ὦ Δάματερ τὸν βίον αὐτοῦ κατέλεξας,</l>
 						<l>εἰ φεισάμενος καὶ μοχθήσας καταλείψει μηδὲ ταφῆναι.</l>
@@ -1824,7 +1824,7 @@ bring up to P3
 						<l n="560">καὶ γαστρώδεις καὶ παχύκνημοι καὶ πίονές εἰσιν ἀσελγῶς,</l>
 						<l>παρ’ ἐμοὶ δ’ ἰσχνοὶ καὶ σφηκώδεις καὶ τοῖς ἐχθροῖς ἀνιαροί.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>ἀπὸ τοῦ λιμοῦ γὰρ ἴσως αὐτοῖς τὸ σφηκῶδες σὺ πορίζεις.</l>
 					</sp>
@@ -1833,7 +1833,7 @@ bring up to P3
 						<l>περὶ σωφροσύνης ἤδη τοίνυν περανῶ σφῷν κἀναδιδάξω</l>
 						<l>ὅτι κοσμιότης οἰκεῖ μετ’ ἐμοῦ, τοῦ Πλούτου δ’ ἐστὶι ὑβρίζειν.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l n="565">πάνυ γοῦν κλέπτειν κόσμιόν ἐστιν καὶ τοὺς τοίχους διορύττειν.</l>
 					</sp>
@@ -1848,7 +1848,7 @@ bring up to P3
 						<l>πλουτήσαντες δ’ ἀπὸ τῶν κοινῶν παραχρῆμ’ ἄδικοι γεγένηνται,</l>
 						<l n="570">ἐπιβουλεύουσί τε τῷ πλήθει καὶ τῷ δήμῳ πολεμοῦσιν.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>ἀλλ’ οὐ ψεύδει τούτων γ’ οὐδέν, καίπερ σφόδρα βάσκανος οὖσα.</l>
 						<l>ἀτὰρ οὐχ ἧττόν γ’ οὐδὲν κλαύσει, μηδὲν ταύτῃ γε κομήσῃς,</l>
@@ -1860,7 +1860,7 @@ bring up to P3
 						<l part="Y">καὶ σύ γ’ ἐλέγξαι μ’ οὔπω δύνασαι περὶ τούτου,</l>
 						<l n="575">ἀλλὰ φλυαρεῖς καὶ πτερυγίζεις.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l part="Y">καὶ πῶς φεύγουσί σ’ ἅπαντες;</l>
 					</sp>
@@ -1870,7 +1870,7 @@ bring up to P3
 						<l>ἀπὸ τῶν παίδων· τοὺς γὰρ πατέρας φεύγουσι φρονοῦντας ἄριστα</l>
 						<l>αὐτοῖς. οὕτω διαγιγνώσκειν χαλεπὸν πρᾶγμ’ ἐστὶ δίκαιον.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>τὸν Δία φήσεις ἆρ’ οὐκ ὀρθῶς διαγιγνώσκειν τὸ κράτιστον·</l>
 						<l n="580">κἀκεῖνος γὰρ τὸν Πλοῦτον ἔχει.</l>
@@ -1888,7 +1888,7 @@ bring up to P3
 						<l n="585">ἀνεκήρυττεν τῶν ἀσκητῶν τοὺς νικῶντας στεφανώσας</l>
 						<l>κοτίνου στεφάνῳ; καίτοι χρυσῷ μᾶλλον ἐχρῆν, εἴπερ ἐπλούτει.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>οὐκοῦν τούτῳ δήπου δηλοῖ τιμῶν τὸν Πλοῦτον ἐκεῖνος·</l>
 						<l>φειδόμενος γὰρ καὶ βουλόμενος τούτου μηδὲν δαπανᾶσθαι,</l>
@@ -1899,7 +1899,7 @@ bring up to P3
 						<l n="590">πολὺ τῆς Πενίας πρᾶγμ’ αἴσχιον ζητεῖς αὐτῷ περιάψαι,</l>
 						<l>εἰ πλούσιος ὢν ἀνελεύθερός ἐσθ’ οὑτωσὶ καὶ φιλοκερδής.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>ἀλλὰ σέ γ’ ὁ Ζεὺς ἐξολέσειεν κοτίνου στεφάνῳ στεφανώσας.</l>
 					</sp>
@@ -1908,7 +1908,7 @@ bring up to P3
 						<l>τὸ γὰρ ἀντιλέγειν τολμᾶν ὑμᾶς ὡς οὐ πάντ’ ἔστ’ ἀγάθ’ ὑμῖν</l>
 						<l>διὰ τὴν Πενίαν.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l part="Y">παρὰ τῆς Ἑκάτης ἔξεστιν τοῦτο πυθέσθαι,</l>
 						<l n="595">εἴτε τὸ πλουτεῖν εἴτε τὸ πεινῆν βέλτιον. φησὶ γὰρ αὕτη</l>
@@ -1918,7 +1918,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="pnigos">
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>ἀλλὰ φθείρου καὶ μὴ γρύξῃς</l>
 						<l>ἔτι μηδ’ ὁτιοῦν.</l>
@@ -1928,7 +1928,7 @@ bring up to P3
 						<speaker>Πενία</speaker>
 						<l>ὦ πόλις Ἄργους, κλύεθ’ οἷα λέγει.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>Παύσωνα κάλει τὸν ξύσσιτον.</l>
 					</sp>
@@ -1936,7 +1936,7 @@ bring up to P3
 						<speaker>Πενία</speaker>
 						<l>τί πάθω τλήμων;</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>ἔρρ’ ἐς κόρακας θᾶττον ἀφ’ ἡμῶν.</l>
 					</sp>
@@ -1944,7 +1944,7 @@ bring up to P3
 						<speaker>Πενία</speaker>
 						<l n="605">εἶμι δὲ ποῖ γῆς;</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l>ἐς τὸν κύφων’· ἀλλ’ οὐ μέλλειν</l>
 						<l>χρῆν σ’, ἀλλ’ ἀνύειν.</l>
@@ -1954,7 +1954,7 @@ bring up to P3
 						<l>ἦ μὴν ὑμεῖς γ’ ἔτι μ’ ἐνταυθοῖ</l>
 						<l>μεταπέμψεσθον.</l>
 					</sp>
-					<sp who="#xremylos">
+					<sp who="#chremylos">
 						<speaker>Χρεμύλος</speaker>
 						<l n="610">τότε νοστήσεις· νῦν δὲ φθείρου.</l>
 						<l>κρεῖττον γάρ μοι πλουτεῖν ἐστίν,</l>
@@ -1972,7 +1972,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>αὕτη μὲν ἡμῖν ἡπίτριπτος οἴχεται.</l>
 					<l n="620">ἐγὼ δὲ καὶ σύ γ’ ὡς τάχιοτα τὸν θεὸν</l>
@@ -1983,7 +1983,7 @@ bring up to P3
 					<l>καὶ μὴ διατρίβωμέν γε, μὴ πάλιν τις αὖ</l>
 					<l>ἐλθὼν διακωλύσῃ τι τῶν προὔργου ποιεῖν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>παῖ Καρίων τὰ στρώματ’ ἐκφέρειν σ’ ἐχρῆν</l>
 					<l n="625">αὐτόν τ’ ἄγειν τὸν Πλοῦτον, ὡς νομίζεται,</l>
@@ -2000,7 +2000,7 @@ bring up to P3
 					<l>ὡς εὐτυχεῖθ’, ὡς μακαρίως πεπράγατε,</l>
 					<l n="630">ἄλλοι θ’ ὅσοις μέτεστι τοῦ χρηστοῦ τρόπου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἔστιν ὦ βέλτιστε τῶν σαυτοῦ φίλων;</l>
 					<l>φαίνει γὰρ ἥκειν ἄγγελος χρηστοῦ τινος.</l>
@@ -2012,7 +2012,7 @@ bring up to P3
 					<l n="635">ἐξωμμάτωται καὶ λελάμπρυνται κόρας,</l>
 					<l>Ἀσκληπιοῦ παιῶνος εὐμενοῦς τυχών.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>λέγεις μοι χαράν, λέγεις μοι βοάν.</l>
 				</sp>
@@ -2020,7 +2020,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>πάρεστι χαίρειν, ἤν τε βούλησθ’ ἤν τε μή.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀναβοάσομαι τὸν εὔπαιδα καὶ</l>
 					<l n="640">μέγα βροτοῖσι φέγγος Ἀσκληπιόν.</l>
@@ -2294,7 +2294,7 @@ bring up to P3
 				<stage>Κομμάτιον Χοροῦ</stage>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l>καὶ προσκυνῶ γε πρῶτα μὲν τὸν ἥλιον,</l>
 					<l>ἔπειτα σεμνῆς Παλλάδος κλεινὸν πέδον</l>
@@ -2308,7 +2308,7 @@ bring up to P3
 					<l n="780">δείξω τὸ λοιπὸν πᾶσιν ἀνθρώποις ὅτι</l>
 					<l>ἄκων ἐμαυτὸν τοῖς πονηροῖς ἐπεδίδουν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>βάλλ’ ἐς κόρακας· ὡς χαλεπόν εἰσιν οἱ φίλοι</l>
 					<l>οἱ φαινόμενοι παραχρῆμ’ ὅταν πράττῃ τις εὖ.</l>
@@ -2323,7 +2323,7 @@ bring up to P3
 					<l>φέρε νυν, νόμος γάρ ἐστι, τὰ καταχύσματα</l>
 					<l n="790">ταυτὶ καταχέω σου λαβοῦσα.</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l part="Y">μηδαμῶς.</l>
 					<l>ἐμοῦ γὰρ εἰσιόντος ἐς τὴν οἰκίαν</l>
@@ -2334,7 +2334,7 @@ bring up to P3
 					<speaker>Γυνή</speaker>
 					<l>εἶτ’ οὐχὶ δέξει δῆτα τὰ καταχύσματα;</l>
 				</sp>
-				<sp who="#ploytos">
+				<sp who="#ploutos">
 					<speaker>Πλοῦτος</speaker>
 					<l n="795">ἔνδον γε παρὰ τὴν ἑστίαν, ὥσπερ νόμος·</l>
 					<l>ἔπειτα καὶ τὸν φόρτον ἐκφύγοιμεν ἄν.</l>
@@ -2484,7 +2484,7 @@ bring up to P3
 					<l>χαρίεντά γ’ ἥκεις δῶρα τῷ θεῷ φέρων.</l>
 					<milestone ed="p" n="850" unit="card"/>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l n="850">οἴμοι κακοδαίμων, ὡς ἀπόλωλα δείλαιος,</l>
 					<l>καὶ κακοδαίμων καὶ τετράκις καὶ πεντάκις</l>
@@ -2496,7 +2496,7 @@ bring up to P3
 					<l>Ἄπολλον ἀποτρόπαιε καὶ θεοὶ φίλοι,</l>
 					<l n="855">τί ποτ’ ἐστὶν ὅ τι πέπονθεν ἅνθρωπος κακόν;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>οὐ γὰρ σχέτλια πέπονθα νυνὶ πράγματα,</l>
 					<l>ἀπολωλεκὼς ἅπαντα τἀκ τῆς οἰκίας</l>
@@ -2513,7 +2513,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>νὴ Δία καλῶς τοίνυν ποιῶν ἀπόλλυται.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>ποῦ ποῦ ’σθ’ ὁ μόνος ἅπαντας ἡμᾶς πλουσίους</l>
 					<l n="865">ὑποσχόμενος οὗτος ποιήσειν εὐθέως,</l>
@@ -2524,7 +2524,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>καὶ τίνα δέδρακε δῆτα τοῦτ’;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">ἐμὲ τουτονί.</l>
 				</sp>
@@ -2532,7 +2532,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ἦ τῶν πονηρῶν ἦσθα καὶ τοιχωούχων;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l n="870">μὰ Δί’ οὐ μὲν οὖν ἔσθ’ ὑγιὲς ὑμῶν οὐδενός,</l>
 					<l>κοὐκ ἔσθ’ ὅπως οὐκ ἔχετέ μου τὰ χρήματα.</l>
@@ -2542,7 +2542,7 @@ bring up to P3
 					<l>ὡς σοβαρὸς ὦ Δάματερ εἰσελήλυθεν</l>
 					<l>ὁ συκοφάντης. δῆλον ὅτι βουλιμιᾷ.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>σὺ μὲν εἰς ἀγορὰν ἰὼν ταχέως οὐκ ἂν φθάνοις·</l>
 					<l n="875">ἐπὶ τοῦ τροχοῦ γὰρ δεῖ σ’ ἐκεῖ στρεβλούμενον</l>
@@ -2558,7 +2558,7 @@ bring up to P3
 					<l>ἅπασι τοῖς Ἕλλησιν ὁ θεός ἐσθ’ ὅτι</l>
 					<l>τοὺς συκοφάντας ἐξολεῖ κακοὺς κακῶς.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l n="880">οἴμοι τάλας· μῶν καὶ σὺ μετέχων καταγελᾷς;</l>
 					<l>ἐπεὶ πόθεν θοἰμάτιον εἴληφας τοδί;</l>
@@ -2573,7 +2573,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l n="885">† ἀλλ’ οὐκ ἔνεστι συκοφάντου δήγματος.†</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>ἆρ’ οὐχ ὕβρις ταῦτ’ ἐστὶ πολλή; σκώπτετον,</l>
 					<l>ὅ τι δὲ ποιεῖτον ἐνθάδ’ οὐκ εἰρήκατον.</l>
@@ -2583,7 +2583,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>μὰ τὸν Δί’ οὔκουν τῷ γε σῷ, σάφ’ ἴσθ’ ὅτι.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l n="890">ἀπὸ τῶν ἐμῶν γὰρ ναὶ μὰ Δία δειπνήσετον.</l>
 				</sp>
@@ -2592,7 +2592,7 @@ bring up to P3
 					<l>ὡς δὴ ’π’ ἀληθείᾳ σὺ μετὰ τοῦ μάρτυρος</l>
 					<l>διαρραγείης μηδενός γ’ ἐμπλήμενος.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>ἀρνεῖσθον; ἔνδον ἐστὶν ὦ μιαρωτάτω</l>
 					<l>πολὺ χρῆμα τεμαχῶν καὶ κρεῶν ὠπτημένων.</l>
@@ -2607,7 +2607,7 @@ bring up to P3
 					<l part="Y">τοῦ ψύχους γ’ ἴσως</l>
 					<l>ἐπεὶ τοιοῦτόν γ’ ἀμπέχεται τριβώνιον.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>ταῦτ’ οὖν ἀνασχέτ’ ἐστὶν ὦ Ζεῦ καὶ θεοί,</l>
 					<l>τούτους ὑβρίζειν εἰς ἔμ’; οἴμ’ ὡς ἄχθομαι</l>
@@ -2618,7 +2618,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>σὺ φιλόπολις καὶ χρηστός;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">ὡς οὐδείς γ’ ἀνήρ.</l>
 				</sp>
@@ -2626,7 +2626,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>καὶ μὴν ἐπερωτηθεὶς ἀπόκριναί μοι.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">τὸ τί;</l>
 				</sp>
@@ -2634,7 +2634,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>γεωργὸς εἶ;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">μελαγχολᾶν μ’ οὕτως οἴει;</l>
 				</sp>
@@ -2642,7 +2642,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>ἀλλ’ ἔμπορος;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">ναί, σκήπτομαί γ’, ὅταν τύχω.</l>
 				</sp>
@@ -2650,7 +2650,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l n="905">τί δαί; τέχνην τιν’ ἔμαθες;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">οὐ μὰ τὸν Δία.</l>
 				</sp>
@@ -2658,7 +2658,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>πῶς οὖν διέζης ἢ πόθεν μηδὲν ποιῶν;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>τῶν τῆς πόλεώς εἰμ’ ἐπιμελητὴς πραγμάτων</l>
 					<l>καὶ τῶν ἰδίων πάντων.</l>
@@ -2667,7 +2667,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l part="Y">σύ; τί μαθών;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">βούλομαι.</l>
 				</sp>
@@ -2676,7 +2676,7 @@ bring up to P3
 					<l>πῶς οὖν ἂν εἴης χρηστὸς ὦ τοιχωρύχε,</l>
 					<l n="910">εἴ σοι προσῆκον μηδὲν εἶτ’ ἀπεχθάνει;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>οὐ γὰρ προσήκει τὴν ἐμαυτοῦ μοι πόλιν</l>
 					<l>εὐεργετεῖν ὦ κέπφε καθ’ ὅσον ἂν σθένω;</l>
@@ -2685,7 +2685,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>εὐεργετεῖν οὖν ἐστι τὸ πολυπραγμονεῖν;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>τὸ μὲν οὖν βοηθεῖν τοῖς νόμοις τοῖς κειμένοις</l>
 					<l n="915">καὶ μὴ ’πιτρέπειν ἐάν τις ἐξαμαρτάνῃ.</l>
@@ -2695,7 +2695,7 @@ bring up to P3
 					<l>οὔκουν δικαστὰς ἐξεπίτηδες ἡ πόλις</l>
 					<l>ἄρχειν καθίστησιν;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">κατηγορεῖ δὲ τίς;</l>
 				</sp>
@@ -2703,7 +2703,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>ὁ βουλόμενος.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">οὐκοῦν ἐκεῖνός εἰμ’ ἐγώ,</l>
 					<l>ὥστ’ εἰς ἔμ’ ἥκει τῆς πόλεως τὰ πράγματα.</l>
@@ -2714,7 +2714,7 @@ bring up to P3
 					<l>ἐκεῖνο δ’ οὐ βούλοῑ ἄν, ἡσυχίαν ἔχων</l>
 					<l>ζῆν ἀργός;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">ἀλλὰ προβατίου βίον λέγεις,</l>
 					<l>εἰ μὴ φανεῖται διατριβή τις τῷ βίῳ.</l>
@@ -2723,7 +2723,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>οὐδ’ ἂν μεταμάθοις;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l part="Y">οὐδ’ ἂν εἰ δοίης γέ μοι</l>
 					<l n="925">τὸν Πλοῦτον αὐτὸν καὶ τὸ Βάττου σίλφιον.</l>
@@ -2744,7 +2744,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ταῦτα πάντα σοὶ λέγει.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>καὶ μὴν προσελθέτω πρὸς ἔμ’ ὑμῶν ἐνθαδὶ</l>
 					<l>ὁ βουλόμενος.</l>
@@ -2753,7 +2753,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">οὐκοῦν ἐκεῖνός εἰμ’ ἐγώ.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l n="930">οἴμοι τάλας ἀποδύομαι μεθ’ ἡμέραν.</l>
 				</sp>
@@ -2761,7 +2761,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>σὺ γὰρ ἀξιοῖς τἀλλότρια πράττων ἐσθίειν.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>ὁρᾷς ἃ ποιεῖς; ταῦτ’ ἐγὼ μαρτύρομαι.</l>
 				</sp>
@@ -2769,7 +2769,7 @@ bring up to P3
 					<speaker>Δίκαιος</speaker>
 					<l>ἀλλ’ οἴχεται φεύγων ὃν ἦγες μάρτυρα.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>οἴμοι περιείλημμαι μόνος.</l>
 				</sp>
@@ -2777,7 +2777,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">νυνὶ βοᾷς;</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l n="935">οἴμοι μάλ’ αὖθις.</l>
 				</sp>
@@ -2805,7 +2805,7 @@ bring up to P3
 					<l>καὶ ταῦτα πρὸς τὸ μέτωπον αὐτίκα δὴ μάλα</l>
 					<l>ὥσπερ κοτίνῳ προσπατταλεύσω τουτῳί.</l>
 				</sp>
-				<sp who="#sykofantes">
+				<sp who="#sykophantes">
 					<speaker>Συκοφάντης</speaker>
 					<l>ἄπειμι· γιγνώσκω γὰρ ἥττων ὢν πολὺ</l>
 					<l n="945">ὑμῶν· ἐὰν δὲ σύζυγον λάβω τινὰ</l>
@@ -2833,54 +2833,54 @@ bring up to P3
 				<stage>Χοροῦ</stage>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἆρ’ ὦ φίλοι γέροντες ἐπὶ τὴν οἰκίαν</l>
 					<l n="960">ἀφίγμεθ’ ὄντως τοῦ νέου τούτου θεοῦ,</l>
 					<l>ἢ τῆς ὁδοῦ τὸ παράπαν ἡμαρτήκαμεν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἴσθ’ ἐπ’ αὐτὰς τὰς θύρας ἀφιγμένη</l>
 					<l>ὦ μειρακίσκη· πυνθάνει γὰρ ὡρικῶς.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>φέρε νυν ἐγὼ τῶν ἔνδοθεν καλέσω τινά.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="965">μὴ δῆτ’· ἐγὼ γὰρ αὐτὸς ἐξελήλυθα.</l>
 					<l>ἀλλ’ ὅ τι μάλιστ’ ἐλήλυθας λέγειν σ’ ἐχρῆν.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>πέπονθα δεινὰ καὶ παράνομ’ ὦ φίλτατε·</l>
 					<l>ἀφ’ οὗ γὰρ ὁ θεὸς οὗτος ἤρξατο βλέπειν,</l>
 					<l>ἀβίωτον εἶναί μοι πεποίηκε τὸν βίον.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="970">τί δ’ ἔστιν; ἦ που καὶ σὺ συκοφάντρια</l>
 					<l>εν ταῖς γυναιξὶν ἦσθα;</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l part="Y">μὰ Δί’ ἐγὼ μὲν οὔ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἀλλ’ οὐ λαχοῦσ’ ἔπινες ἐν τῷ γράμματι;</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>σκώπτεις· ἐγὼ δὲ κατακέκνισμαι δειλάκρα.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὔκουν ἐρεῖς ἀνύσασα τὸν κνισμὸν τίνα;</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l n="975">ἄκουέ νυν. ἦν μοί τι μειράκιον φίλον,</l>
 					<l>πενιχρὸν μέν, ἄλλως δ’ εὐπρόσωπον καὶ καλὸν</l>
@@ -2888,11 +2888,11 @@ bring up to P3
 					<l>ἅπαντ’ ἐποίει κοσμίως μοι καὶ καλῶς·</l>
 					<l>ἐγὼ δ’ ἐκείνῳ πάντα ταῦθ’ ὑπηρέτουν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="980">τί δ’ ἦν ὅ τι σου μάλιστ’ ἐδεῖθ’ ἑκάστοτε;</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>οὐ πολλά· καὶ γὰρ ἐκνομίως μ’ ᾐσχύνετο.</l>
 					<l>ἀλλ’ ἀργυρίου δραχμὰς ἂν ᾔτησ’ εἴκοσιν</l>
@@ -2901,22 +2901,22 @@ bring up to P3
 					<l n="985">ἐκέλευσεν ἂν τῇ μητρί θ’ ἱματίδιον·</l>
 					<l>πυρῶν τ’ ἂν ἐδεήθη μεδίμνων τεττάρων.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὐ πολλὰ τοίνυν μὰ τὸν Ἀπόλλω ταῦτά γε</l>
 					<l>εἴρηκας, ἀλλὰ δῆλον ὅτι σ’ ᾐχύνετο.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>καὶ ταῦτα τοίνυν οὐχ ἕνεκα μισητίας</l>
 					<l n="990">αἰτεῖν μ’ ἔφασκεν, ἀλλὰ φιλίας οὕνεκα,</l>
 					<l>ἵνα τοὐμὸν ἱμάτιον φορῶν μεμνῇτό μου.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>λέγεις ἐρῶντ’ ἄνθρωπον ἐκνομιώτατα.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἀλλ’ οὐχὶ νῦν ὁ βδελυρὸς ἔτι τὸν νοῦν ἔχει</l>
 					<l>τὸν αὐτόν, ἀλλὰ πολὺ μεθέστηκεν πάνυ.</l>
@@ -2925,11 +2925,11 @@ bring up to P3
 					<l>ἐπόντα πεμψάσης ὑπειπούσης θ’ ὅτι</l>
 					<l>εἰς ἑσπέραν ἥξοιμι—</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τί σ’ ἔδρασ’; εἰπέ μοι.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἄμητα προσαπέπεμψεν ἡμῖν τουτονί,</l>
 					<l n="1000">ἐφ’ ᾧ τ’ ἐκεῖσε μηδέποτέ μ’ ἐλθεῖν ἔτι,</l>
@@ -2937,125 +2937,125 @@ bring up to P3
 					<l>‘ πάλαι ποτ’ ἦσαν ἄλκιμοι Μιλήσιοι.’</l>
 					<milestone ed="p" n="1003" unit="card"/>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>δῆλον ὅτι τοὺς τρόπους τις οὐ μοχθηρὸς ἦν,</l>
 					<l>ἔπειτα πλουτῶν οὐκέθ’ ἥδεται φακῇ·</l>
 					<l n="1005">πρὸ τοῦ δ’ ὑπὸ τῆς πενίας ἅπανθ’ ὑπήσθιεν.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>καὶ μὴν πρὸ τοῦ γ’ ὁσημέραι νὴ τὼ θεὼ</l>
 					<l>ἐπὶ τὴν θύραν ἐβάδιζεν ἀεὶ τὴν ἐμήν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἐπ’ ἐκφοράν;</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l part="Y">μὰ Δί’ ἀλλὰ τῆς φωνῆς μόνον</l>
 					<l>ἐρῶν ἀκοῦσαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τοῦ λαβεῖν μὲν οὖν χάριν.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l n="1010">καὶ νὴ Δί’ εἰ λυπουμένην γ’ αἴσθοιτό με,</l>
 					<l>νηττάριον ἂν καὶ φάττιον ὑπεκορίζετο.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἔπειτ’ ἴσως ᾔτει σ’ ἂν εἰς ὑποδήματα.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>μυστηρίοις δὲ τοῖς μεγάλοις ὀχουμένην</l>
 					<l>ἐπὶ τῆς ἁμάξης ὅτι προσέβλεψέν μέ τις,</l>
 					<l n="1015">ἐτυπτόμην διὰ τοῦθ’ ὅλην τὴν ἡμέραν.</l>
 					<l>οὕτω σφόδρα ζηλότυπος ὁ νεανίσκος ἦν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>μόνος γὰρ ἥδεθ’, ὡς ἔοικεν, ἐσθίων.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>καὶ τάς γε χεῖρας παγκάλας ἔχειν μ’ ἔθη.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὁπότε προτείνοιέν γε δραχμὰς εἴκοσιν.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l n="1020">ὄζειν τε τῆς χρόας ἔφασκεν ἡδύ μου.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>εἰ Θάσιον ἐνέχεις, εἰκότως γε νὴ Δία.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>τὸ βλέμμα θ’ ὡς ἔχοιμι μαλακὸν καὶ καλόν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὐ σκαιὸς ἦν ἄνθρωπος, ἀλλ’ ἠπίστατο</l>
 					<l>γραὸς καπρώσης τἀφόδια κατεσθίειν.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l n="1025">ταῦτ’ οὖν ὁ θεὸς ὦ φίλ’ ἄνερ οὐκ ὀρθῶς ποιεῖ,</l>
 					<l>φάσκων βοηθεῖν τοῖς ἀδικουμένοις ἀεί.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τί γὰρ ποιήσει; φράζε, καὶ πεπράξεται.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἀναγκάσαι δίκαιόν ἐστι νὴ Δία</l>
 					<l>τὸν εὖ παθόνθ’ ὑπ’ ἐμοῦ πάλιν μ’ ἀντευποιεῖν,</l>
 					<l n="1030">ἢ μηδ’ ὁτιοῦν ἀγαθὸν δίκαιόν ἐστ’ ἔχειν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὔκουν καθ’ ἑκάστην ἀπεδίδου τὴν νύκτα σοι;</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἀλλ’ οὐδέποτέ με ζῶσαν ἀπολείψειν ἔφη.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὀρθῶς γε· νῦν δέ γ’ οὐκέτι ζῆν σ’ οἴεται.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ὑπὸ τοῦ γὰρ ἄλγους κατατέτηκ’ ὦ φίλτατε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="1035">οὐκ ἀλλὰ κατασέσηπας, ὥς γ’ ἐμοὶ δοκεῖς.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>διὰ δακτυλίου μὲν οὖν ἔμεγ’ ἂν διελκύσαις.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>εἰ τυγχάνοι γ’ ὁ δακτύλιος ὢν τηλία.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>καὶ μὴν τὸ μειράκιον τοδὶ προσέρχεται,</l>
 					<l>οὗπερ πάλαι κατηγοροῦσα τυγχάνω·</l>
 					<l n="1040">ἔοικε δ’ ἐπὶ κῶμον βαδίζειν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">φαίνεται.</l>
 					<l>στέφανόν γέ τοι καὶ δᾷδ’ ἔχων πορεύεται.</l>
@@ -3064,7 +3064,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>ἀσπάζομαί σε.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l part="Y">τί φησιν;</l>
 				</sp>
@@ -3073,24 +3073,24 @@ bring up to P3
 					<l part="Y">ἀρχαία φίλη,</l>
 					<l>πολιὰ γεγένησαι ταχύ γε νὴ τὸν οὐρανόν.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>τάλαιν’ ἐγὼ τῆς ὕβρεος ἧς ὑβρίζομαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="1045">ἔοικε διὰ πολλοῦ χρόνου σ’ ἑορακέναι.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ποίου χρόνου ταλάνταθ’, ὃς παρ’ ἐμοὶ χθὲς ἦν;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τοὐναντίον πέπονθε τοῖς πολλοῖς ἄρα·</l>
 					<l>μεθύων γάρ, ὡς ἔικεν, ὀξύτερον βλέπει.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>οὔκ, ἀλλ’ ἀκόλαστός ἐστιν ἀεὶ τοὺς τρόπους.</l>
 				</sp>
@@ -3100,12 +3100,12 @@ bring up to P3
 					<l>ἐν τῷ προσώπῳ τῶν ῥυτίδων ὅσας ἔχει.</l>
 					<milestone ed="p" n="1052" unit="card"/>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἆ ἆ,</l>
 					<l>τὴν δᾷδα μή μοι πρόσφερ’.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">εὖ μέντοι λέγει.</l>
 					<l>ἐὰν γὰρ αὐτὴν εἷς μόνος σπινθὴρ λάβῃ</l>
@@ -3115,7 +3115,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l n="1055">βούλει διὰ χρόνου πρός με παῖσαι;</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l part="Y">ποῖ τάλαν;</l>
 				</sp>
@@ -3123,7 +3123,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>αὐτοῦ, λαβοῦσα κάρνα.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l part="Y">παιδιὰν τίνα;</l>
 				</sp>
@@ -3131,7 +3131,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>πόσους ἔχεις ὀδόντας.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">ἀλλὰ γνώσομαι</l>
 					<l>κἄγωγ’· ἔχει γὰρ τρεῖς ἴσως ἢ τέτταρας.</l>
@@ -3140,7 +3140,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>ἀπότεισον· ἕνα γὰρ γόμφιον μόνον φορεῖ.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l n="1060">ταλάντατ’ ἀνδρῶν οὐχ ὑγιαίνειν μοι δοκεῖς,</l>
 					<l>πλυνόν με ποιῶν ἐν τοσούτοις ἀνδράσιν.</l>
@@ -3149,13 +3149,13 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>ὄναιο μέντἄν, εἴ τις ἐκπλύνειέ σε.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὐ δῆτ’, ἐπεὶ νῦν μὲν καπηλικῶς ἔχει,</l>
 					<l>εἰ δ’ ἐκπλυνεῖται τοῦτο τὸ ψιμύθιον,</l>
 					<l n="1065">ὄψει κατάδηλα τοῦ προσώπου τὰ ῥάκη.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>γέρων ἀνὴρ ὢν οὐχ ὑγιαίνειν μοι δοκεῖς.</l>
 				</sp>
@@ -3164,11 +3164,11 @@ bring up to P3
 					<l>πειρᾷ μὲν οὖν ἴσως σε καὶ τῶν τιτθίων</l>
 					<l>ἐφάπτεταί σου λανθάνειν δοκῶν ἐμέ.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>μὰ τὴν Ἀφροδίτην οὐκ ἐμοῦ γ’ ὦ βδελυρὲ σύ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="1070">μὰ τὴν Ἑκάτην οὐ δῆτα· μαινοίμην γὰρ ἄν.</l>
 					<l>ἀλλ’ ὦ νεανίσκ’ οὐκ ἐῶ τὴν μείρακα</l>
@@ -3178,7 +3178,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l part="Y">ἀλλ’ ἔγωγ’ ὑπερφιλῶ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ μὴν κατηγορεῖ γέ σου.</l>
 				</sp>
@@ -3186,7 +3186,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l part="Y">τί κατηγορεῖ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>εἶναί σ’ ὑβριστήν φησι καὶ λέγειν ὅτι</l>
 					<l n="1075"> ‘ πάλαι ποτ’ ἦσαν ἄλκιμοι Μιλήσιοι.’</l>
@@ -3195,7 +3195,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>ἐγὼ περὶ ταύτης οὐ μαχοῦμαί σοι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τὸ τί;</l>
 				</sp>
@@ -3205,12 +3205,12 @@ bring up to P3
 					<l>οὐκ ἄν ποτ’ ἄλλῳ τοῦτ’ ἐπέτρεψ’ ἐγὼ ποιεῖν·</l>
 					<l>νῦν δ’ ἄπιθι χαίρων συλλαβὼν τὴν μείρακα.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="1080">οἶδ’ οἶδα τὸν νοῦν· οὐκέτ’ ἀξιοῖς ἴσως</l>
 					<l>εἶναι μετ’ αὐτῆς.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l part="Y">ὁ δ’ ἐπιτρέψων ἐστὶ τίς;</l>
 				</sp>
@@ -3219,7 +3219,7 @@ bring up to P3
 					<l>οὐκ ἂν διαλεχθείην διεσπλεκωμένῃ</l>
 					<l>ὑπὸ μυρίων ἐτῶν γε καὶ τρισχιλίων.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ὅμως δ’ ἐπειδὴ καὶ τὸν οἶνον ἠξίους</l>
 					<l n="1085">πίνειν, συνεκποτέ’ ἐστί σοι καὶ τὴν τρύγα.</l>
@@ -3228,7 +3228,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>ἀλλ’ ἔστι κομιδῇ τρὺξ παλαιὰ καὶ σαπρά.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>οὐκοῦν τρύγοιπος ταῦτα πάντ’ ἰάσεται.</l>
 				</sp>
@@ -3237,7 +3237,7 @@ bring up to P3
 					<l>ἀλλ’ εἴσιθ’ εἴσω· τῷ θεῷ γὰρ βούλομαι</l>
 					<l>ἐλθὼν ἀναθεῖναι τοὺς στεφάνους τούσδ’ οὓς ἔχω.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l n="1090">ἐγὼ δέ γ’ αὐτῷ καὶ φράσαι τι βούλομαι.</l>
 				</sp>
@@ -3245,7 +3245,7 @@ bring up to P3
 					<speaker>Νεανίας</speaker>
 					<l>ἐγὼ δέ γ’ οὐκ εἴσειμι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">θάρρει, μὴ φοβοῦ.</l>
 					<l>οὐ γὰρ βιάσεται.</l>
@@ -3255,11 +3255,11 @@ bring up to P3
 					<l part="Y">πάνυ καλῶς τοίνυν λέγεις.</l>
 					<l>ἱκανὸν γὰρ αὐτὴν πρότερον ὑπεπίττουν χρόνον.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>βάδιζ’· ἐγὼ δέ σου κατόπιν εἰσέρχομαι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="1095">ὡς εὐτόνως ὦ Ζεῦ βασιλεῦ τὸ γρᾴδιον</l>
 					<l>ὥσπερ λεπὰς τῷ μειρακίῳ προσείχετο.</l>
@@ -3274,7 +3274,7 @@ bring up to P3
 					<l>οὐδεὶς ἔοικεν· ἀλλὰ δῆτα τὸ θύριον</l>
 					<l>φθεγγόμενον ἄλλως κλαυσιᾷ.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>σέ τοι λέγω,</l>
 					<l n="1100">ὁ Καρίων, ἀνάμεινον.</l>
@@ -3284,7 +3284,7 @@ bring up to P3
 					<l part="Y">οὗτος εἰπέ μοι,</l>
 					<l>σὺ τὴν θύραν ἔκοπτες οὑτωσὶ σφόδρα;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>μὰ Δί’ ἀλλ’ ἔμελλον· εἶτ’ ἀνέῳξάς με φθάσας.</l>
 					<l>ἀλλ’ ἐκκάλει τὸν δεσπότην τρέχων ταχύ,</l>
@@ -3297,7 +3297,7 @@ bring up to P3
 					<l part="Y">εἰπέ μοι,</l>
 					<l>τί δ’ ἔστιν;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">ὁ Ζεὺς ὦ πόνηρε βούλεται</l>
 					<l>ἐς ταὐτὸν ὑμᾶς συγκυκήσας τρύβλιον</l>
@@ -3309,7 +3309,7 @@ bring up to P3
 					<l>ἀτὰρ διὰ τί δὴ ταῦτ’ ἐπιβουλεύει ποιεῖν</l>
 					<l>ἡμᾶς;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">ὁτιὴ δεινότατα πάντων πραγμάτων</l>
 					<l>εἴργασθ’. ἀφ’ οὗ γὰρ ἤρξατ’ ἐξ ἀρχῆς βλέπειν</l>
@@ -3322,7 +3322,7 @@ bring up to P3
 					<l part="Y">μὰ Δί’ οὐδέ γε</l>
 					<l>θύσει. κακῶς γὰρ ἐπεμελεῖσθ’ ἡμῶν τότε.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>καὶ τῶν μὲν ἄλλων μοι θεῶν ἧττον μέλει,</l>
 					<l>ἐγὼ δ’ ἀπόλωλα κἀπιτέτριμμαι.</l>
@@ -3331,7 +3331,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">σωφρονεῖς.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l n="1120">πρότερον γὰρ εἶχον μὲν παρὰ ταῖς καπηλίσιν</l>
 					<l>πάντ’ ἀγάθ’ ἕωθεν εὐθύς, οἰνοῦτταν μέλι</l>
@@ -3343,7 +3343,7 @@ bring up to P3
 					<l>οὔκουν δικαίως, ὅστις ἐποίεις ζημίαν</l>
 					<l n="1125">ἐνίοτε τοιαῦτ’ ἀγάθ’ ἔχων;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l part="Y">οἴμοι τάλας,</l>
 					<l>οἴμοι πλακοῦντος τοῦ ν’ τετράδι πεπεμμένου.</l>
@@ -3352,7 +3352,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ποθεῖς τὸν οὐ παρόντα καὶ μάτην καλεῖς.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>οἴμοι δὲ κωλῆς ἣν ἐγὼ κατήσθιον.</l>
 				</sp>
@@ -3360,7 +3360,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ἀσκωλίαζ’ ἐνταῦθα πρὸς τὴν αἰθρίαν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l n="1130">σπλάγχνων τε θερμῶν ὧν ἐγὼ κατήσθιον.</l>
 				</sp>
@@ -3368,7 +3368,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ὀδύνη σε περὶ τὰ σπλάγχν’ ἔοικέ τι στρέφειν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>οἴμοι δὲ κύλικος ἴσον ἴσῳ κεκραμένης.</l>
 				</sp>
@@ -3376,7 +3376,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ταύτην ἐπιπιὼν ἀποτρέχων οὐκ ἂν φθάνοις.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἆρ’ ὠφελήσαις ἄν τι τὸν σαυτοῦ φίλον;</l>
 					<milestone ed="p" n="1135" unit="card"/>
@@ -3385,7 +3385,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l n="1135">εἴ του δέει γ’ ὧν δυνατός εἰμί σ’ ὠφελεῖν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>εἴ μοι πορίσας ἄρτον τιν’ εὖ πεπεμμένον</l>
 					<l>δοίης καταφαγεῖν καὶ κρέας νεανικὸν</l>
@@ -3395,7 +3395,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l part="Y">ἀλλ’ οὐκ ἐκφορά.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>καὶ μὴν ὁπότε τι σκευάριον τοῦ δεσπότου</l>
 					<l n="1140">ὑφέλοῑ, ἐγώ σε λανθάνειν ἐποίουν ἀεί.</l>
@@ -3405,7 +3405,7 @@ bring up to P3
 					<l>ἐφ’ ᾧ τε μετέχειν καὐτὸς ὦ τοιχωρύχε.</l>
 					<l>ἧκεν γὰρ ἄν σοι ναστὸς εὖ πεπεμμένος.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἔπειτα τοῦτόν γ’ αὐτὸς ἂν κατήσθιες.</l>
 				</sp>
@@ -3414,7 +3414,7 @@ bring up to P3
 					<l>οὐ γὰρ μετεῖχες τὰς ἴσας πληγὰς ἐμοί,</l>
 					<l n="1145">ὁπότε τι ληφθείην πανουργήσας ἐγώ.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>μὴ μνησικακήσῃς, εἰ σὺ Φυλὴν κατέλαβες.</l>
 					<l>ἀλλὰ ξύνοικον πρὸς θεῶν δέξασθέ με.</l>
@@ -3423,7 +3423,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>ἔπειτ’ ἀπολιπὼν τοὺς θεοὺς ἐνθάδε μενεῖς;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>τὰ γὰρ παρ’ ὑμῖν ἐστι βελτίω πολύ.</l>
 				</sp>
@@ -3431,7 +3431,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l n="1150">τί δέ; ταὐτομολεῖν ἀστεῖον εἶναί σοι δοκεῖ;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>πατρὶς γάρ ἐστι πᾶσ’ ἵν’ ἂν πράττῃ τις εὖ.</l>
 				</sp>
@@ -3439,7 +3439,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>τί δῆτ’ ἂν εἴης ὄφελος ἡμῖν ἐνθάδ’ ὤν;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>παρὰ τὴν θύραν στροφαῖον ἱδρύσασθέ με.</l>
 				</sp>
@@ -3447,7 +3447,7 @@ bring up to P3
 					<speaker>Καρίων</speaker>
 					<l>στροφαῖον; ἀλλ’ οὐκ ἔργον ἔστ’ οὐδὲν στροφῶν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l n="1155">ἀλλ’ ἐμπολαῖον.</l>
 				</sp>
@@ -3456,7 +3456,7 @@ bring up to P3
 					<l part="Y">ἀλλὰ πλουτοῦμεν· τί οὖν</l>
 					<l>Ἑρμῆν παλιγκάπηλον ἡμᾶς δεῖ τρέφειν;</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἀλλὰ δόλιον τοίνυν.</l>
 				</sp>
@@ -3465,7 +3465,7 @@ bring up to P3
 					<l part="Y">δόλιον; ἥκιστά γε·</l>
 					<l>οὐ γὰρ δόλου νῦν ἔργον, ἀλλ’ ἁπλῶν τρόπων.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἀλλ’ ἡγεμόνιον.</l>
 				</sp>
@@ -3474,7 +3474,7 @@ bring up to P3
 					<l part="Y">ἀλλ’ ὁ θεὸς ἤδη βλέπει,</l>
 					<l n="1160">ὥσθ’ ἡγεμόνος οὐδὲν δεησόμεσθ’ ἔτι.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>ἐναγώνιος τοίνυν ἔσομαι. τί δῆτ’ ἐρεῖς;</l>
 					<l>Πλούτῳ γάρ ἐστι τοῦτο συμφορώτατον</l>
@@ -3487,7 +3487,7 @@ bring up to P3
 					<l>οὐκ ἐτὸς ἅπαντες οἱ δικάζοντες θαμὰ</l>
 					<l>σπεύδουσιν ἐν πολλοῖς γεγράφθαι γράμμασιν.</l>
 				</sp>
-				<sp who="#ermes">
+				<sp who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>οὐκοῦν ἐπὶ τούτοις εἰσίω;</l>
 				</sp>
@@ -3501,34 +3501,34 @@ bring up to P3
 				<stage>&lt;Χοροῦ&gt;</stage>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>τίς ἂν φράσειε ποῦ ’στι Χρεμύλος μοι σαφῶς;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>τί δ’ ἔστιν ὦ βέλτιστε;</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l part="Y">τί γὰρ ἀλλ’ ἢ κακῶς;</l>
 					<l>ἀφ’ οὗ γὰρ ὁ Πλοῦτος οὗτος ἤρξατο βλέπειν,</l>
 					<l>ἀπόλωλ’ ὑπὸ λιμοῦ. καταφαγεῖν γὰρ οὐκ ἔχω,</l>
 					<l n="1175">καὶ ταῦτα τοῦ σωτῆρος ἱερεὺς ὢν Διός.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἡ δ’ αἰτία τίς ἐστιν ὦ πρὸς τῶν θεῶν;</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>θύειν ἔτ’ οὐδεὶς ἀξιοῖ.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τίνος οὕνεκα;</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>ὅτι πάντες εἰσὶ πλούσιοι· καίτοι τότε,</l>
 					<l>ὅτ’ εἶχον οὐδέν, ὁ μὲν ἂν ἥκων ἔμπορος</l>
@@ -3538,26 +3538,26 @@ bring up to P3
 					<l>θύει τὸ παράπαν οὐδὲν οὐδ’ εἰσέρχεται,</l>
 					<l>πλὴν ἀποπατησόμενοί γε πλεῖν ἢ μύριοι.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l n="1185">οὔκουν τὰ νομιζόμενα σὺ τούτων λαμβάνεις;</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>τὸν οὖν Δία τὸν σωτῆρα καὐτός μοι δοκῶ</l>
 					<l>χαίρειν ἐάσας ἐνθάδ’ αὐτοῦ καταμένειν.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>θάρρει· καλῶς ἔσται γάρ, ἢν θεὸς θέλῃ.</l>
 					<l>ὁ Ζεὺς ὁ σωτὴρ γὰρ πάρεστιν ἐνθάδε,</l>
 					<l n="1190">αὐτόματος ἥκων.</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l part="Y">πάντ’ ἀγαθὰ τοίνυν λέγεις.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>ἱδρυσόμεθ’ οὖν αὐτίκα μάλ’, ἀλλὰ περίμενε</l>
 					<l>τὸν Πλοῦτον, οὗπερ πρότερον ἦν ἱδρυμένος</l>
@@ -3565,40 +3565,40 @@ bring up to P3
 					<l>ἀλλ’ ἐκδότω τις δεῦρο δᾷδας ἡμμένας,</l>
 					<l n="1195">ἵν’ ἔχων προηγῇ τῷ θεῷ σύ.</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l part="Y">πάνυ μὲν οὖν</l>
 					<l>δρᾶν ταῦτα χρή.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τὸν Πλοῦτον ἔξω τις κάλει.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἐγὼ δὲ τί ποιῶ;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">τὰς χύτρας, αἷς τὸν θεὸν</l>
 					<l>ἱδρυσόμεθα, λαβοῦσ’ ἐπὶ τῆς κεφαλῆς φέρε</l>
 					<l>σεμνῶς· ἔχουσα δ’ ἦλθες αὐτὴ ποικίλα.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l n="1200">ὧν δ’ οὕνεκ’ ἦλθον;</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l part="Y">πάντα σοι πεπράξεται.</l>
 					<l>ἥξει γὰρ ὁ νεανίσκος ὡς σ’ εἰς ἑσπέραν.</l>
 				</sp>
-				<sp who="#grays">
+				<sp who="#graus">
 					<speaker>Γραῦς</speaker>
 					<l>ἀλλ’ εἴ γε μέντοι νὴ Δί’ ἐγγυᾷ σύ μοι</l>
 					<l>ἥξειν ἐκεῖνον ὡς ἔμ’, οἴσω τὰς χύτρας.</l>
 				</sp>
-				<sp who="#xremylos">
+				<sp who="#chremylos">
 					<speaker>Χρεμύλος</speaker>
 					<l>καὶ μὴν πολὺ τῶν ἄλλων χυτρῶν τἀναντία</l>
 					<l n="1205">αὗται ποιοῦσι· ταῖς μὲν ἄλλαις γὰρ χύτραις</l>
@@ -3608,7 +3608,7 @@ bring up to P3
 			</div1>
 			<div1 type="Exodus">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἔτι τοίνυν εἰκὸς μέλλειν οὐδ’ ἡμᾶς, ἀλλ’ ἀναχωρεῖν</l>
 						<l>ἐς τοὔπισθεν· δεῖ γὰρ κατόπιν τούτων ᾄδοντας ἕπεσθαι.</l>

--- a/tei/aristophanes-thesmophoriazusae.xml
+++ b/tei/aristophanes-thesmophoriazusae.xml
@@ -55,7 +55,7 @@
 					<personGrp xml:id="xorosagathonos">
 						<name>Χορὸς Ἀγάθωνος</name>
 					</personGrp>
-					<person xml:id="gyneb">
+					<person xml:id="gyne_b">
 						<persName>Γυνὴ Β</persName>
 					</person>
 					<person xml:id="kerykaina">
@@ -64,13 +64,13 @@
 					<person xml:id="prytanis">
 						<persName>Πρύτανις</persName>
 					</person>
-					<person xml:id="eyripides">
+					<person xml:id="euripides">
 						<persName>Εὐριπίδης</persName>
 					</person>
 					<person xml:id="toksotes">
 						<persName>Τοξότης</persName>
 					</person>
-					<person xml:id="mnesiloxos">
+					<person xml:id="mnesilochos">
 						<persName>Μνησίλοχος</persName>
 					</person>
 					<person xml:id="kleisthenes">
@@ -79,16 +79,16 @@
 					<person xml:id="therapon">
 						<persName>Θεράπων</persName>
 					</person>
-					<person xml:id="gynea">
+					<person xml:id="gyne_a">
 						<persName>Γυνὴ Α</persName>
 					</person>
 					<person xml:id="agathon">
 						<persName>Ἀγάθων</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="gyneg">
+					<person xml:id="gyne_g">
 						<persName>Γυνὴ Γ</persName>
 					</person>
 				</listPerson>
@@ -184,57 +184,57 @@ bring up to P3
 		<body>
 			<div1 type="Prologue">
 				<milestone n="1" unit="card"/>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ὦ Ζεῦ χελιδὼν ἆρά ποτε φανήσεται;</l>
 					<l>ἀπολεῖ μ’ ἀλοῶν ἅνθρωπος ἐξ ἑωθινοῦ.</l>
 					<l>οἷόν τε, πρὶν τὸν σπλῆνα κομιδῇ μ’ ἐκβαλεῖν,</l>
 					<l>παρὰ σοῦ πυφέσθαι ποῖ μ’ ἄγεις ωὖριπίδη;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="5">ἀλλ’ οὐκ ἀκούειν δεῖ σε πάνθ’ ὅσ’ αὐτίκα</l>
 					<l>ὄψει παρεστώς.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">πῶς λέγεις; αὖθις φράσον.</l>
 					<l>οὐ δεῖ μ’ ἀκούειν;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">οὐχ ἅ γ’ ἂν μέλλῃς ὁρᾶν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>οὐδ’ ἆρ’ ὁρᾶν δεῖ μ’;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">οὐχ ἅ γ’ ἂν ἀκούειν δέῃ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>πῶς μοι παραινεῖς; δεξιῶς μέντοι λέγεις.</l>
 					<l n="10">οὐ φὴ|ς σὺ χρῆναί μ’ οὔτ’ ἀκούειν οὔθ’ ὁρᾶν;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>χωρὶς γὰρ αὐτοῖν ἑκατέρου ’στὶν ἡ φύσις.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>τοῦ μήτ’ ἀκούειν μήθ’ ὁρᾶν;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">εὖ ἴσθ’ ὅτι.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>πῶς χωρίς;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">οὕτω ταῦτα διεκρίθη τότε.</l>
 					<l>αἰθὴρ γὰρ ὅτε τὰ πρῶτα διεχωρίζετο</l>
@@ -243,89 +243,89 @@ bring up to P3
 					<l>ὀφθαλμὸν ἀντίμιμον ἡλίου τροχῷ,</l>
 					<l>ἀκοῇ δὲ χοάνην ὦτα διετετρήνατο.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>διὰ τὴν χοάνην οὖν μήτ’ ἀκούω μήθ’ ὁρῶ;</l>
 					<l n="20">νὴ τὸν Δί’ ἥδομαί γε τουτὶ προσμαθών.</l>
 					<l>οἷόν γέ που ’στιν αἱ σοφαὶ ξυνουσίαι.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>πόλλ’ ἂν μάθοις τοιαῦτα παρ’ ἐμοῦ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">πῶς ἂν οὖν</l>
 					<l>πρὸς τοῖς ἀγαθοῖς τούτοισιν ἐξεύροιμ’ ὅπως</l>
 					<l>ἔτι προσμάθοιμι χωλὸς εἶναι τὼ σκέλει;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="25">βάδιζε δευρὶ καὶ πρόσεχε τὸν νοῦν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ἰδού.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ὁρᾷς τὸ θύριον τοῦτο;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">νὴ τὸν Ἡρακλέα</l>
 					<l>οἶμαί γε.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">σίγα νυν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">σιωπῶ τὸ θύριον;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἄκοῡ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ἀκούω καὶ σιωπῶ τὸ θύριον;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἐνταῦθ’ Ἀγάθων ὁ κλεινὸς οἰκῶν τυγχάνει</l>
 					<l n="30">ὁ τραγῳδοποιός.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ποῖος οὗτος Ἁγάθων;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἔστιν τις Ἀγάθων—</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">μῶν ὁ μέλας ὁ καρτερός;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>οὔκ, ἀλλ’ ἕτερός τις· οὐχ ἑόρακας πώποτε;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>μῶν ὁ δασυπώγων;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">οὐχ ἑόρακας πώποτε;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>μὰ τὸν Δί’ οὔτοι γ’ ὥστε καί μέ γ’ εἰδέναι.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="35">καὶ μὴν βεβίνηκας σύ γ’, ἀλλ’ οὐκ οἶσθ’ ἴσως.</l>
 					<l>ἀλλ’ ἐκποδὼν πτήξωμεν, ὡς ἐξέρχεται</l>
@@ -343,15 +343,15 @@ bring up to P3
 						<l>κῦμα δὲ πόντου μὴ κελαδείτω</l>
 						<l n="45">γλαυκόν·</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">βομβάξ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">σίγα.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">τι λέγει;</l>
 					</sp>
@@ -361,7 +361,7 @@ bring up to P3
 						<l>θηρῶν τ’ ἀγρίων πόδες ὑλοδρόμων</l>
 						<l>μὴ λυέσθων.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">βομβαλοβομβάξ.</l>
 					</sp>
@@ -370,7 +370,7 @@ bring up to P3
 						<l>μέλλει γὰρ ὁ καλλιεπὴς Ἀγάθων</l>
 						<l n="50">πρόμος ἡμέτερος—</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">μῶν βινεῖσθαι;</l>
 					</sp>
@@ -378,7 +378,7 @@ bring up to P3
 						<speaker>Θεράπων</speaker>
 						<l>τίς ὁ φωνήσας;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">νήνεμος αἰθήρ.</l>
 						<milestone ed="p" n="52" unit="card"/>
@@ -392,7 +392,7 @@ bring up to P3
 						<l>καὶ κηροχυτεῖ καὶ γογγύλλει</l>
 						<l>καὶ χοανεύει.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">καὶ λαικάζει.</l>
 					</sp>
@@ -400,7 +400,7 @@ bring up to P3
 						<speaker>Θεράπων</speaker>
 						<l>τίς ἀγροιώτας πελάθει θριγκοῖς;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὃς ἕτοιμος σοῦ τοῦ τε ποιητοῦ</l>
 						<l n="60">τοῦ καλλιεποῦς κατὰ τοῦ θριγκοῦ</l>
@@ -413,7 +413,7 @@ bring up to P3
 						<speaker>Θεράπων</speaker>
 						<l>ἦ που νέος γ’ ὢν ἦσθ’ ὑβριστὴς ὦ γέρον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὦ δαιμόνιε τοῦτον μὲν ἔα χαίρειν, σὺ δὲ</l>
 						<l n="65">Ἀγάθωνά μοι δεῦρ’ ἐκκάλεσον πάσῃ τέχνῃ.</l>
@@ -425,7 +425,7 @@ bring up to P3
 						<l>ὄντος κατακάμπτειν τὰς στροφὰς οὐ ῥᾴδιον,</l>
 						<l>ἢν μὴ προίῃ θύρασι πρὸς τὸν ἥλιον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="70">τί οὖν ἐγὼ δρῶ;</l>
 					</sp>
@@ -433,112 +433,112 @@ bring up to P3
 						<speaker>Θεράπων</speaker>
 						<l part="Y">περίμεν’, ὡς ἐξερχεται.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὦ Ζεῦ τί δρᾶσαι διανοεῖ με τήμερον;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>νὴ τοὺς θεοὺς ἐγὼ πυθέσθαι βούλομαι</l>
 						<l>τί τὸ πρᾶγμα τουτί. τί στένεις; τί δυσφορεῖς;</l>
 						<l>οὐ χρῆν σε κρύπτειν ὄντα κηδεστὴν ἐμόν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="75">ἔστιν κακόν μοι μέγα τι προπεφυραμένον.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ποῖόν τι;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τῇδε θἠμέρᾳ κριθήσεται</l>
 						<l>εἴτ’ ἔστ’ ἔτι ζῶν εἴτ’ ἀπόλωλ’ Εὐριπίδης.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>καὶ πῶς; ἐπεὶ νῦν γ’ οὔτε τὰ δικαστήρια</l>
 						<l>μέλλει δικάζειν οὔτε βουλῆς ἐσθ’ ἕδρα,</l>
 						<l n="80">ἐπεὶ τρίτη ’στὶ Θεσμοφορίων ἡ μέση.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τοῦτ’ αὐτὸ γὰρ τοι κἀπολεῖν με προσδοκῶ.</l>
 						<l>αἱ γὰρ γυναῖκες ἐπιβεβουλεύκασί μοι</l>
 						<l>κἀν Θεσμοφόροιν μέλλουσι περί μου τήμερον</l>
 						<l>ἐκκλησιάζειν ἐπ’ ὀλέθρῳ.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">τιὴ τί δή;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="85">ὁτιὴ τραγῳδῶ καὶ κακῶς αὐτὰς λέγω.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>νὴ τὸν Ποσειδῶ καὶ δίκαιά &lt;γ’&gt; ἂν πάθοις.</l>
 						<l>ἀτὰρ τίν’ ἐκ τούτων σὺ μηχανὴν ἔχεις;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>Ἀγάθωνα πεῖσαι τὸν τραγῳδοδιδάσκαλον</l>
 						<l>ἐς Θεσμοφόροιν ἐλθεῖν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">τί δράσοντ’; εἰπέ μοι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="90">ἐκκλησιάσοντ’ ἐν ταῖς γυναιξὶ κἂν δέῃ</l>
 						<l>λέξονθ’ ὑπὲρ ἐμοῦ.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">πότερα φανερῶς ἢ λάθρᾳ;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>λάθρᾳ, στολὴν γυναικὸς ἠμφιεσμένον.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>τὸ πρᾶγμα κομψὸν καὶ σφόδρ’ ἐκ τοῦ σοῦ τρόπου·</l>
 						<l>τοῦ γὰρ τεχνάζειν ἡμέτερος ὁ πυραμοῦς.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="95">σίγα.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">τί δ’ ἔστιν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">Ἁγάθων ἐξέρχεται.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>καὶ ποῖός ἐστιν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">οὗτος οὑκκυκλούμενος.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἀλλ’ ἢ τυφλὸς μέν εἰμ’· ἐγὼ γὰρ οὐχ ὁρῶ</l>
 						<l>ἄνδρ’ οὐδέν’ ἐνθάδ’ ὄντα, Κυρήνην δ’ ὁρῶ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>σίγα· μελῳδεῖν γὰρ παρασκευάζεται.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="100">μύρμηκος ἀτραπούς, ἢ τί διαμινύρεται;</l>
 						<milestone ed="p" n="101" unit="card"/>
@@ -600,7 +600,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="130">ὡς ἡδὺ τὸ μέλος ὦ πότνιαι Γενετυλλίδες</l>
 						<l>καὶ θηλυδριῶδες καὶ κατεγλωττισμένον</l>
@@ -630,7 +630,7 @@ bring up to P3
 						<l>μετουσίαν δεῖ τῶν τρόπων τὸ σῶμ’ ἔχειν.</l>
 						<milestone ed="p" n="153" unit="card"/>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>οὐκοῦν κελητίζεις, ὅταν Φαίδραν ποιῇς;</l>
 					</sp>
@@ -640,7 +640,7 @@ bring up to P3
 						<l n="155">ἔνεσθ’ ὑπάρχον τοῦθ’. ἃ δ’ οὐ κεκτήμεθα,</l>
 						<l>μίμησις ἤδη ταῦτα συνθηρεύεται.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὅταν σατύρους τοίνυν ποιῇς, καλεῖν ἐμέ,</l>
 						<l>ἵνα συμποιῶ σοὔπισθεν ἐστυκὼς ἐγώ.</l>
@@ -657,7 +657,7 @@ bring up to P3
 						<l>διὰ τοῦτ’ ἄρ’ αὐτοῦ καὶ κάλ’ ἦν τὰ δράματα.</l>
 						<l>ὅμοια γὰρ ποιεῖν ἀνάγκη τῇ φύσει.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ταῦτ’ ἄρ’ ὁ Φιλοκλέης αἰσχρὸς ὢν αἰσχρῶς ποιεῖ,</l>
 						<l>ὁ δ’ αὖ Ξενοκλέης ὢν κακὸς κακῶς ποιεῖ,</l>
@@ -668,20 +668,20 @@ bring up to P3
 						<l>ἅπασ’ ἀνάγκη· ταῦτα γάρ τοι γνοὺς ἐγὼ</l>
 						<l>ἐμαυτὸν ἐθεράπευσα.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">πῶς πρὸς τῶν θεῶν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>παῦσαι βαΰζων· καὶ γὰρ ἐγὼ τοιοῦτος ἦν</l>
 						<l>ὢν τηλικοῦτος, ἡνίκ’ ἠρχόμην ποιεῖν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="175">μὰ τὸν Δί’ οὐ ζηλῶ σε τῆς παιδεύσεως.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀλλ’ ὧνπερ οὕνεκ’ ἦλθον, ἔα μ’ εἰπεῖν.</l>
 					</sp>
@@ -689,7 +689,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l part="Y">λέγε.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>Ἀγάθων, σοφοῦ πρὸς ἀνδρός, ὅστις ἐν βραχεῖ</l>
 						<l>πολλοὺς καλῶς οἷός τε συντέμνειν λόγους.</l>
@@ -700,7 +700,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l part="Y">τοῦ χρείαν ἔχων;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>μέλλουσί μ’ αἱ γυναῖκες ἀπολεῖν τήμερον</l>
 						<l>τοῖς Θεσμοφορίοις, ὅτι κακῶς αὐτὰς λέγω.</l>
@@ -709,7 +709,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l>τίς οὖν παρ’ ἡμῶν ἐστιν ὠφέλειά σοι;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἡ πᾶσ’· ἐὰν γὰρ ἐγκαθεζόμενος λάθρᾳ</l>
 						<l n="185">ἐν ταῖς γυναιξίν, ὡς δοκῶν εἶναι γυνή,</l>
@@ -720,7 +720,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l>ἔπειτα πῶς οὐκ αὐτὸς ἀπολογεῖ παρών;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἐγὼ φράσω σοι. πρῶτα μὲν γιγνώσκομαι·</l>
 						<l n="190">ἔπειτα πολιός εἰμι καὶ πώγων’ ἔχω,</l>
@@ -731,7 +731,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l>Εὐριπίδη—</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τί ἔστιν;</l>
 					</sp>
@@ -740,7 +740,7 @@ bring up to P3
 						<l part="Y">ἐποίησάς ποτε,</l>
 						<l>‘χαίρεις ὁρῶν φῶς, πατέρα δ’ οὐ χαίρειν δοκεῖς;’</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="195">ἔγωγε.</l>
 					</sp>
@@ -752,12 +752,12 @@ bring up to P3
 						<l>τὰς συμφορὰς γὰρ οὐχὶ τοῖς τεχνάσμασιν</l>
 						<l>φέρειν δίκαιον ἀλλὰ τοῖς παθήμασιν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="200">καὶ μὴν ού γ’ ὦ κατάπυγον εὐρύπρωκτος εἶ</l>
 						<l>οὐ τοῖς λόγοισιν ἀλλὰ τοῖς παθήμασιν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τί δ’ ἔστιν ὅτι δέδοικας ἐλθεῖν αὐτόσε;</l>
 					</sp>
@@ -765,7 +765,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l>κάκιον ἀπολοίμην ἂν ἢ σύ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">πῶς;</l>
 					</sp>
@@ -776,12 +776,12 @@ bring up to P3
 						<l n="205">κλέπτειν ὑφαρπάζειν τε θήλειαν Κύπριν.</l>
 						<milestone ed="p" n="206" unit="card"/>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἰδού γε κλέπτειν· νὴ Δία βινεῖσθαι μὲν οὖν.</l>
 						<l>ἀτὰρ ἡ πρόφασίς γε νὴ Δί’ εἰκότως ἔχει.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τί οὖν; ποιήσεις ταῦτα;</l>
 					</sp>
@@ -789,44 +789,44 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l part="Y">μὴ δόκει γε σύ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὦ τρισκακοδαίμων ὡς ἀπόλωλ’ Εὐριπίδης.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="210">ὦ φίλτατ’ ὦ κηδεστὰ μὴ σαυτὸν προδῷς.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>πῶς οὖν ποιήσω δῆτα;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">τοῦτον μὲν μακρὰ</l>
 						<l>κλάειν κέλεῡ, ἐμοὶ δ’ ὅ τι βούλει χρῶ λαβών.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἄγε νυν ἐπειδὴ σαυτὸν ἐπιδίδως ἐμοί,</l>
 						<l>ἀπόδυθι τουτὶ θοἰμάτιον.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">καὶ δὴ χαμαί.</l>
 						<l n="215">ἀτὰρ τί μέλλεις δρᾶν μ’;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ἀποξυρεῖν ταδί,</l>
 						<l>τὰ κάτω δ’ ἀφεύειν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">ἀλλὰ πρᾶττ’, εἴ σοι δοκεῖ.</l>
 						<l>ἢ μὴ’ πιδοῦν’ ἐμαυτὸν ὤφελόν ποτε.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>Ἀγάθων σὺ μέντοι ξυροφορεῖς ἑκάστοτε,</l>
 						<l>χρῆσόν τί νυν ἡμῖν ξυρόν.</l>
@@ -836,131 +836,131 @@ bring up to P3
 						<l part="Y">αὐτὸς λάμβανε</l>
 						<l n="220">ἐντεῦθεν ἐκ τῆς ξυροδόκης.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">γενναῖος εἶ.</l>
 						<l>κάθιξε· φύσα τὴν γνάθον τὴν δεξιάν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὤμοι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τί κέκραγας; ἐμβαλῶ σοι πάτταλον,</l>
 						<l>ἢν μὴ σιωπᾷς.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">ἀτταταῖ ἰατταταῖ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>οὗτος σὺ ποῖ θεῖς;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">ἐς τὸ τῶν σεμνῶν</l>
 						<l n="225">θεῶν· οὐ γὰρ μὰ τὴν Δήμητρά γ’ ἐνταυθοῖ μενῶ</l>
 						<l>τεμνόμενος.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">οὔκουν καταγέλαστος δῆτ’ ἔσει</l>
 						<l>τὴν ἡμίκραιραν τὴν ἑτέραν ψιλὴν ἔχων;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὀλίγον μέλει μοι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">μηδαμῶς πρὸς τῶν θεῶν</l>
 						<l>προδῷς με· χώρει δεῦρο.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">κακοδαίμων ἐγώ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="230">ἔχ’ ἀτρέμα σαυτὸν κἀνάκυπτε· ποῖ στρέφει;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>μυμῦ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τί μύξεις; πάντα πεποίηται καλῶς.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>οἴμοι κακοδαίμων, ψιλὸς αὖ στρατεύσομαι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>μὴ φροντίσῃ· ὡς εὐπρεπὴς φανεῖ πάνυ.</l>
 						<l>βούλει θεᾶσθαι σαυτόν;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">εἰ δοκεῖ, φέρε.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="235">ὁρᾷς σεαυτόν;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">οὐ μὰ Δί’ ἀλλὰ Κλεισθένη.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀνίστασ’, ἵν’ ἀφεύσω σε, κἀγκύψας ἔχε.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>οἴμοι κακοδαίμων δελφάκιον γενήσομαι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἐνεγκάτω τις ἔνδοθεν δᾷδ’ ἢ λύχνον.</l>
 						<l>ἐπίκυπτε· τὴν κέρκον φυλάττου νυν ἄκραν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="240">ἐμοὶ μελήσει νὴ Δία, πλήν γ’ ὅτι κάομαι.</l>
 						<l>οἴμοι τάλας. ὕδωρ ὕδωρ ὦ γείτονες.</l>
 						<l>πρὶν ἀντιλαβέσθαι †πρωκτὸν τῆς φλογός.†</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>θάρρει.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">τί θαρρῶ καταπεπυρπολημένος;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἀλλ’ οὐκ ἔτ’ οἰδὲν πρᾶγμά σοι· τὰ πλεῖστα γὰρ</l>
 						<l n="245">ἀποπεπόνηκας.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">φῦ ἰοὺ τῆς ἀσβόλου.</l>
 						<l>αἰθὸς γεγένημαι πάντα τὰ περὶ τὴν τράμιν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>μὴ φροντίσῃς· ἕτερος γὰρ αὐτὰ σφογγιεῖ.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>οἰμώξετἄρ’ εἴ τις τὸν ἐμὸν πρωκτὸν πλυνεῖ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>Ἀγάθων, ἐπειδὴ σαυτὸν ἐπιδοῦναι φθονεῖς,</l>
 						<l n="250">ἀλλ’ ἱμάτιον γοῦν χρῆσον ἡμῖν τουτῳὶ</l>
@@ -970,7 +970,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l>λαμβάνετε καὶ χρῆσθ’· οὐ φθονῶ.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">τί οὖν λάβω;</l>
 					</sp>
@@ -978,20 +978,20 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l part="Y">ὅ τι; τὸν κροκωτὸν πρῶτον ἐνδύου λαβών.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">νὴ τὴν Ἀφροδίτην ἡδύ γ’ ὄζει ποσθίου.</l>
 						<l n="255">σύζωσον ἀνύσας. αἶρε νῦν στρόφιον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ἰδού.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἴθι νυν κατάστειλόν με τὰ περὶ τὼ σκέλει.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>κεκρυφάλου δεῖ καὶ μίτρας.</l>
 					</sp>
@@ -1000,15 +1000,15 @@ bring up to P3
 						<l part="Y">ἡδὶ μὲν οὖν</l>
 						<l>κεφαλὴ περίθετος, ἣν ἐγὼ νύκτωρ φορῶ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>νὴ τὸν Δί’ ἀλλὰ κἀπιτηδεία πάνυ.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="260">ἆρ’ ἁρμόσει μοι;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">νὴ Δί’ ἀλλ’ ἄριστ’ ἔχει.</l>
 						<l>φέρ’ ἔγκυκλον·</l>
@@ -1017,7 +1017,7 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l part="Y">τουτὶ λάβ’ ἀπὸ τῆς κλινίδος.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὑποδημάτων δεῖ.</l>
 					</sp>
@@ -1025,11 +1025,11 @@ bring up to P3
 						<speaker>Ἀγάθων</speaker>
 						<l part="Y">τἀμὰ ταυτὶ λάμβανε.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἆρ’ ἁρμόσει μοι;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">χαλαρὰ γοῦν χαίρεις φορῶν.</l>
 					</sp>
@@ -1039,58 +1039,58 @@ bring up to P3
 						<l n="265">εἴσω τις ὡς τάχιστά μ’ ἐσκυκλησάτω.</l>
 						<milestone ed="p" n="266" unit="card"/>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἁνὴρ μὲν ἡμῖν οὑτοσὶ καὶ δὴ γυνὴ</l>
 						<l>τό γ’ εἶδος· ἢν λαλῇς δ’, ὅπως τῷ φθέγματι</l>
 						<l>γυναικιεῖς εὖ καὶ πιθανῶς.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">πειράσομαι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>βάδιζε τοίνυν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">μὰ τὸν Ἀπόλλω οὔκ, ἤν γε μὴ</l>
 						<l n="270">ὀμόσῃς ἐμοί—</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τί χρῆμα;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">συσσώσειν ἐμὲ</l>
 						<l>πάσαις τέχναις, ἤν μοί τι περιπίπτῃ κακόν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὄμνυμι τοίνυν αἰθέρ’ οἴκησιν Διός.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>τί μᾶλλον ἢ τὴν Ἱπποκράτους ξυνοικίαν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὄμνυμι τοίνυν πάντας ἄρδην τοὺς θεούς.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="275">μέμνησο τοίνυν ταῦθ’, ὅτι ἡ φρὴν ὤμοσεν,</l>
 						<l>ἡ γλῶττα δ’ οὐκ ὀμώμοκ’· οὐδ’ ὥρκωσ’ ἐγώ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἔκσπευδε ταχέως· ὡς τὸ τῆς ἐκκλησίας</l>
 						<l>σημεῖον ἐν τῷ Θεσμοφορείῳ φαίνεται.</l>
 						<l>ἐγὼ δ’ ἄπειμι.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">δεῦρό νυν ὦ Θρᾷτθ’ ἕπου.</l>
 						<l n="280">ὦ Θρᾷττα θέασαι, καομένων τῶν λαμπάδων</l>
@@ -1131,7 +1131,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεχόμεθα καὶ θεῶν γένος</l>
 						<l>λιτόμεθα ταῖσδ’ ἐπ’ εὐχαῖς</l>
@@ -1180,7 +1180,7 @@ bring up to P3
 						<l>εὔχεσθε πάσαις πολλὰ δοῦναι κἀγαθά.</l>
 						<milestone ed="p" n="352" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ξυνευχόμεσθα τέλεα μὲν</l>
 						<l>πόλει τέλεα δὲ δήμῳ</l>
@@ -1217,7 +1217,7 @@ bring up to P3
 					<l>ὅ τι χρὴ παθεῖν ἐκεῖνον· ἀδικεῖν γὰρ δοκεῖ</l>
 					<l>ἡμῖν ἁπάσαις. τίς ἀγορεύειν βούλεται;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="380">ἐγώ.</l>
 				</sp>
@@ -1225,12 +1225,12 @@ bring up to P3
 					<speaker>Κηρύκαινα</speaker>
 					<l part="Y">περίθου νυν τόνδε πρῶτον πρὶν λέγειν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σίγα σιώπα, πρόσεχε τὸν νοῦν· χρέμπτεται γὰρ ἤδη</l>
 					<l>ὅπερ ποιοῦσ’ οἱ ῥήτορες. μακρὰν ἔοικε λέξειν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>φιλοτιμίᾳ μὲν οὐδεμιᾷ μὰ τὼ θεὼ</l>
 					<l>λέξουσ’ ἀνέστην ὦ γυναῖκες· ἀλλὰ γὰρ</l>
@@ -1285,7 +1285,7 @@ bring up to P3
 					<milestone ed="p" n="434" unit="card"/>
 				</sp>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔπω ταύτης ἤκουσα</l>
 						<l n="435">πολυπλοκωτέρας γυναικὸς</l>
@@ -1302,7 +1302,7 @@ bring up to P3
 						<l n="442b">ἄντικρυς μηδὲν λέγειν.</l>
 						<milestone ed="p" n="443" unit="card"/>
 					</sp>
-					<sp who="#gyneb">
+					<sp who="#gyne_b">
 						<speaker>Γυνὴ Β</speaker>
 						<l>ὀλίγων ἕνεκα καὐτὴ παρῆλθον ῥημάτων.</l>
 						<l>τὰ μὲν γὰρ ἄλλ’ αὕτη κατηγόρηκεν εὖ·</l>
@@ -1324,7 +1324,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἕτερον αὖ τι λῆμα τοῦτο</l>
 						<l n="460">κομψότερον ἔτ’ ἢ τὸ πρότερον</l>
@@ -1338,7 +1338,7 @@ bring up to P3
 						<l n="465c">περιφανῶς δοῦναι δίκην.</l>
 						<milestone ed="p" n="466" unit="card"/>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="466">τὸ μὲν ὦ γυναῖκες ὀξυθυμεῖσθαι σφόδρα</l>
 						<l>Εὐριπίδῃ, τοιαῦτ’ ἀκουούσας κακά,</l>
@@ -1398,7 +1398,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="520">τουτὶ μέντοι θαυμαστόν,</l>
 						<l>ὁπόθεν ηὑρέθη τὸ χρῆμα,</l>
@@ -1417,7 +1417,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ οὐ γάρ ἐστι τῶν ἀναισχύτων φύσει γυναικῶν</l>
 						<l>οὐδὲν κάκιον εἰς ἄπαντα πλὴν ἄρ’ εἰ γυναῖκες.</l>
@@ -1425,7 +1425,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="epirrheme">
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l>οὔ τοι μὰ τὴν Ἄγλαυρον ὦ γυναῖκες εὖ φρονεῖτε,</l>
 						<l>ἀλλ’ ἢ πεφάρμαχθ’ ἢ κακόν τι μέγα πεπόνθατ’ ἄλλο,</l>
@@ -1435,14 +1435,14 @@ bring up to P3
 						<l>ταύτης ἀποψιλώσομεν τὸν χοῖρον, ἵνα διδαχθῇ</l>
 						<l>γυνὴ γυναῖκας οὖσα μὴ κακῶς λέγειν τὸ λοιπόν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="540">μὴ δῆτα τόν γε χοῖρον ὦ γυναῖκες. εἰ γὰρ οὔσης</l>
 						<l>παρρησίας κἀξὸν λέγειν ὅσαι πάρεσμεν ἀσταί,</l>
 						<l>εἶτ’ εἶπον ἁγίγνωσκον ὑπὲρ Εὐριπίδου δίκαια,</l>
 						<l>διὰ τοῦτο τιλλομένην με δεῖ δοῦναι δίκην ὑφ’ ὑμῶν;</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l>οὐ γάρ σε δεῖ δοῦναι δίκην; ἥτις μόνη τέτληκας</l>
 						<l n="545">ὑπὲρ ἀνδρὸς ἀντειπεῖν, ὃς ἡμᾶς πολλὰ κακὰ δέδρακεν</l>
@@ -1450,101 +1450,101 @@ bring up to P3
 						<l>ἐγένετο, Μελανίππας ποιῶν Φαίδρας τε· Πηνελόπην δὲ</l>
 						<l>οὐπώποτ’ ἐποίησ’, ὅτι γυνὴ σώφρων ἔδοξεν εἶναι.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἐγὼ γὰρ οἶδα ταἴτιον. Μίαν γὰρ οὐκ ἂν εἴποις</l>
 						<l n="550">τῶν νῦν γυναικῶν Πηνελόπην, Παίδρας δ’ ἁπαξαπάσας.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l>ἀκούετ’ ὦ γυναῖκες οἷ’ εἴρηκεν ἡ πανοῦργος</l>
 						<l>ἡμᾶς ἁπάσας αὖθις αὖ.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">καὶ νὴ Δί’ οὐδέπω γε</l>
 						<l>εἴρηχ’ ὅσα ξύνοιδ’· ἐπεὶ βούλεσθε πλείον’ εἴπω;</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l>ἀλλ’ οὐκ ἂν ἔτ’ ἔχοις· ὅσα γὰρ ᾔδησθ’ ἐξέχεας ἅπαντα.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="555">μὰ Δί’ οὐδέπω τὴν μυριοστὴν μοῖραν ὧν ποιοῦμεν.</l>
 						<l>ἐπεὶ τάδ’ οὐκ εἴρηχ’, ὁρᾷς, ὡς στλεγγίδας λαβοῦσαι</l>
 						<l>ἔπειτα σιφωνίζομεν τὸν οἶνον.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l part="Y">ἐπιτριβείης.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὥς τ’ αὖ τὰ κρέ’ ἐξ Ἀπατουρίων ταῖς μαστροποῖς διδοῦσαι</l>
 						<l>ἔπειτα τὴν γαλῆν φαμεν—</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l part="Y">τάλαιν’ ἐγώ· φλυαρεῖς.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="560">οὐδ’ ὡς τὸν ἄνδρα τῷ πελέκει γυνὴ κατεσπόδησεν,</l>
 						<l>οὐκ εἶπον· οὐδ’ ὡς φαρμάκοις ἑτέρα τὸν ἄνδρ’ ἔμηνεν,</l>
 						<l>οὐδ’ ὡς ὑπὸ τῇ πυέλῳ κατώρυξέν ποτ’—</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l part="Y">ἐξόλοιο.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἁχαρνικὴ τὸν πατέρα.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l part="Y">ταυτὶ δῆτ’ ἀνέκτ’ ἀκούειν;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="565">οὐδ’ ὡς σὺ τῆς δούλης τεκούσης ἄρρεν εἶτα σαυτῇ</l>
 						<l>τοῦθ’ ὑπεβάλου, τὸ σὸν δὲ θυγάτριον παρῆκας αὐτῇ.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l>οὔ τοι μὰ τὼ θεὼ σὺ καταπροίξει λέγουσα ταυτί,</l>
 						<l>ἀλλ’ ἐκποκιῶ σου τὰς ποκάδας.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">οὐ δὴ μὰ Δία σύ γ’ ἅψει.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l>καὶ μὴν ἰδού.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">καὶ μὴν ἰδού.</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l part="Y">λαβὲ θοἰμάτιον Φιλίστη.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>πρόσθες μόνον, κἀγώ σε νὴ τὴν Ἄρτεμιν—</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l part="Y">τί δράσεις;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="570">τὸν σησαμοῦνθ’ ὃν κατέφαγες, τοῦτον χεσεῖν ποιήσω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παύσασθε λοιδορούμεναι· καὶ γὰρ γυνή τις ἡμῖν</l>
 						<l>ἐσπουδακυῖα προστρέχει. πρὶν οὖν ὁμοῦ γενέσθαι,</l>
@@ -1565,7 +1565,7 @@ bring up to P3
 					<l n="580">σκοπῆτε καὶ τηρῆτε μὴ καὶ προσπέσῃ</l>
 					<l>ὑμῖν ἀφάρκτοις πρᾶγμα δεινὸν καὶ μέγα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἔστιν ὦ παῖ; παῖδα γάρ σ’ εἰκὸς καλεῖν,</l>
 					<l>ἕως ἂν οὕτως τὰς γνάθους ψιλὰς ἔχῃς.</l>
@@ -1575,7 +1575,7 @@ bring up to P3
 					<l>Εὐριπίδην φάσ’ ἄνδρα κηδεστήν τινα</l>
 					<l n="585">αὑτοῦ γέροντα δεῦρ’ ἀναπέμψαι τήμερον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πρὸς ποῖον ἔργον ἢ τίνος γνώμης χάριν;</l>
 				</sp>
@@ -1584,7 +1584,7 @@ bring up to P3
 					<l>ἵν’ ἅττα βουλεύοισθε καὶ μέλλοιτε δρᾶν,</l>
 					<l>ἐκεῖνος εἴη τῶν λόγων κατάσκοπος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ πῶς λέληθεν ἐν γυναιξὶν ὢν ἀνήρ;</l>
 				</sp>
@@ -1593,7 +1593,7 @@ bring up to P3
 					<l n="590">ἀφηῦσεν αὐτὸν κἀπέτιλ’ Εὐριπίδης</l>
 					<l>καὶ τἄλλ’ ἅπανθ’ ὥσπερ γυναῖκ’ ἐσκεύασεν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>πείθεσθε τούτῳ ταῦτα; τίς δ’ οὕτως ἀνὴρ</l>
 					<l>ἠλίθιος ὅστις τιλλόμενος ἠνείχετο;</l>
@@ -1604,7 +1604,7 @@ bring up to P3
 					<l n="595">ληρεῖς· ἐγὼ γὰρ οὐκ ἂν ἦλθον ἀγγελῶν,</l>
 					<l>εἰ μὴ ’πεπύσμην ταῦτα τῶν σάφ’ εἰδότων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τὸ πρᾶγμα τουτὶ δεινὸν εἰσαγγέλλεται.</l>
 					<l>ἀλλ’ ὦ γυναῖκες οὐκ ἐλινύειν ἐχρῆν,</l>
@@ -1617,7 +1617,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>φέρ’ ἴδω· τίς ἡ πρώτη σύ;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ποῖ τις τρέψεται;</l>
 				</sp>
@@ -1625,11 +1625,11 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>ζητητέαι γάρ ἐστε.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">κακοδαίμων ἐγώ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l n="605">ἔμ’ ἥτις &lt;εἴμ’&gt; ἤρου; Κλεωνύμου γυνή.</l>
 				</sp>
@@ -1637,7 +1637,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>γιγνώσκεθ’ ὑμεῖς ἥτις ἔσθ’ ἥδ’ ἡ γυνή;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>γιγνώσκομεν δῆτ’. ἀλλὰ τὰς ἄλλας ἄθρει.</l>
 				</sp>
@@ -1646,11 +1646,11 @@ bring up to P3
 					<l>ἡδὶ δὲ δὴ τίς ἐστιν ἡ τὸ παιδίον</l>
 					<l>ἔχουσα;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">τίτθη νὴ Δί’ ἐμή.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">διοίχομαι.</l>
 				</sp>
@@ -1658,7 +1658,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l n="610">αὕτη σὺ ποῖ στρέφει; μέν’ αὐτοῦ. τί τὸ κακόν;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ἔασον οὐρῆσαί μ’.</l>
 				</sp>
@@ -1667,7 +1667,7 @@ bring up to P3
 					<l part="Y">ἀναίσχυντός &lt;τις&gt; εἶ.</l>
 					<l>σὺ δ’ οὖν ποίει τοῦτ’. ἀναμενῶ γὰρ ἐνθάδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀνάμενε δῆτα καὶ σκόπει γ’ αὐτὴν σφόδρα·</l>
 					<l>μόνην γὰρ αὐτὴν ὦνερ οὐ γιγνώσκομεν.</l>
@@ -1676,7 +1676,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l n="615">πολύν γε χρόνον οὐρεῖς σύ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">νὴ Δί’ ὦ μέλε·</l>
 					<l>στραγγουριῶ γάρ· ἐχθὲς ἔφαγον κάρδαμα.</l>
@@ -1685,7 +1685,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>τί καρδαμίζεις; οὐ βαδιεῖ δεῦρ’ ὡς ἐμέ;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>τί δῆτά μ’ ἕλκεις ἀσθενοῦσαν;</l>
 				</sp>
@@ -1694,7 +1694,7 @@ bring up to P3
 					<l part="Y">εἰπέ μοι,</l>
 					<l>τίς ἔστ’ ἀνήρ σοι;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">τὸν ἐμὸν ἄνδρα πυνθάνει;</l>
 					<l n="620">τὸν δεῖνα γιγνώσκεις, τὸν ἐκ Κοθωκιδῶν;</l>
@@ -1703,7 +1703,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>τὸν δεῖνα; ποῖον;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ἔσθ’ ὁ δεῖν’, ὃς καί ποτε</l>
 					<l>τὸν δεῖνα τὸν τοῦ δεῖνα—</l>
@@ -1713,7 +1713,7 @@ bring up to P3
 					<l part="Y">ληρεῖν μοι δοκεῖς.</l>
 					<l>ἀνῆλθες ἤδη δεῦρο πρότερον;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">νὴ Δία</l>
 					<l>ὁσέτη γε.</l>
@@ -1722,7 +1722,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l part="Y">καὶ τίς σοὐστὶ συσκηνήτρια;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="625">ἡ δεῖν’ ἔμοιγ’.</l>
 				</sp>
@@ -1731,34 +1731,34 @@ bring up to P3
 					<l part="Y">οἴμοι τάλας, οὐδὲν λέγεις.</l>
 					<milestone ed="p" n="626" unit="card"/>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἄπελθ’. ἐγὼ γὰρ βασανιῶ ταύτην καλῶς</l>
 					<l>ἐκ τῶν ἱερῶν τῶν πέρυσι· σὺ δ’ ἀπόστηθί μοι,</l>
 					<l>ἵνα μὴ ’πακούσῃς ὢν ἀνήρ. σὺ δ’ εἰπέ μοι</l>
 					<l>ὅ τι πρῶτον ἡμῖν τῶν ἱερῶν ἐδείκνυτο.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="630">φέρ’ ἴδω, τί μέντοι πρῶτον ἦν; ἐπίνομεν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>τί δὲ μετὰ τοῦτο δεύτερον;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">προὐπίνομεν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ταυτὶ μὲν ἤκουσάς τινος· τί δαὶ τρίτον;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>σκάφιον Ξένυλλ’ ᾔτησεν· οὐ γὰρ ἦν ἀμίς.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>οὐδὲν λέγεις. δεῦρ’ ἐλθὲ δεῦρ’ ὦ Κλείσθενες·</l>
 					<l n="635">ὅδ’ ἐστὶν ἁνὴρ ὃν λέγεις.</l>
@@ -1767,11 +1767,11 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l part="Y">τί οὖν ποιῶ;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἀπόδυσον αὐτόν· οὐδὲν ὑγιὲς γὰρ λέγει.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>κἄπειτ’ ἀποδύσετ’ ἐννέα παίδων μητέρα;</l>
 				</sp>
@@ -1779,16 +1779,16 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>χάλα ταχέως τὸ στρόφιον ὦναίσχυντε σύ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ὡς καὶ στιβαρά τις φαίνεται καὶ καρτερά·</l>
 					<l n="640">καὶ νὴ Δία τιτθούς γ’ ὥσπερ ἡμεῖς οὐκ ἔχει.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>στερίφη γάρ εἰμι κοὐκ ἐκύησα πώποτε.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>νῦν· τότε δὲ μήτηρ ἦσθα παίδων ἐννέα.</l>
 				</sp>
@@ -1796,7 +1796,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>ἀνίστασ’ ὀρθός. ποῖ τὸ πέος ὠθεῖς κάτω;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>τοδὶ διέκυψε καὶ μάλ’ εὔχρων ὦ τάλαν.</l>
 				</sp>
@@ -1804,7 +1804,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l n="645">καὶ ποῦ ’στιν;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">αὖθις ἐς τὸ πρόσθεν οἴχεται.</l>
 				</sp>
@@ -1812,7 +1812,7 @@ bring up to P3
 					<speaker>Κλεισθένης</speaker>
 					<l>οὐκ ἐνγεταυθί.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">μἀλλὰ δεῦρ’ ἥκει πάλιν.</l>
 				</sp>
@@ -1821,17 +1821,17 @@ bring up to P3
 					<l>ἰσθμόν τιν’ ἔχεις ὦνθρωπ’· ἄνω τε καὶ κάτω</l>
 					<l>τὸ πέος διέλκεις πυκνότερον Κορινθίων.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ὦ μιαρὸς οὗτος· ταῦτ’ ἄρ’ ὑπὲρ Εὐριπίδου</l>
 					<l n="650">ἡμῖν ἐλοιδορεῖτο.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">κακοδαίμων ἐγώ,</l>
 					<l>εἰς οἷ’ ἐμαυτὸν εἰσεκύλισα πράγματα.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἄγε δὴ τί δρῶμεν;</l>
 				</sp>
@@ -1845,7 +1845,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="655">ἡμᾶς τοίνυν μετὰ τοῦτ’ ἤδη τὰς λαμπάδας ἁψαμένας χρὴ</l>
 						<l>ξυζωσαμένας εὖ κἀνδρείως τῶν θ’ ἱματίων ἀποδύσας</l>
@@ -1855,7 +1855,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἶα δὴ πρώτιστα μὲν χρὴ κοῦφον ἐξορμᾶν πόδα</l>
 						<l n="660">καὶ διασκοπεῖν σιωπῇ πανταχῇ· μόνον δὲ χρὴ</l>
@@ -1863,7 +1863,7 @@ bring up to P3
 						<l>ἀλλὰ τὴν πρώτην τρέχειν χρῆν ὡς τάχιστ’ ἤδη κύκλῳ.</l>
 						<milestone ed="p" n="663" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἶά νυν ἴχνευε καὶ μάτευε ταχὺ πάντ’,</l>
 						<l>εἴ τις ἐν τόποις ἑδραῖος</l>
@@ -1875,7 +1875,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἢν γάρ με λάθῃ δράσας ἀνόσια,</l>
 						<l>δώσει τε δίκην καὶ πρὸς τούτῳ</l>
@@ -1901,20 +1901,20 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἆ ποῖ σὺ φεύγεις; οὗτος οὗτος οὐ μενεῖς;</l>
 					<l n="690">τάλαιν’ ἐγὼ τάλαινα, καὶ τὸ παιδίον</l>
 					<l>ἐξαρπάσας μοι φροῦδος ἀπὸ τοῦ τιτθίου.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>κέκραχθι· τοῦτο δ’ οὐδέποτε σὺ ψωμιεῖς,</l>
 					<l>ἢν μή μ’ ἀφῆτ’· ἀλλ’ ἐνθάδ’ ἐπὶ τῶν μηρίων</l>
 					<l>πληγὲν μαχαίρᾳ τῇδε φοινίας φλέβας</l>
 					<l n="695">καθαιματώσει βωμόν.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">ὦ τάλαιν’ ἐγώ.</l>
 					<l>γυναῖκες, οὐκ ἀρήξετ’; οὐ πολλὴν βοὴν</l>
@@ -1925,7 +1925,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔα ἔα.</l>
 						<l n="700">ὦ πότνιαι Μοῖραι τί τόδε δέρκομαι</l>
@@ -1935,51 +1935,51 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>οἷον ὑμῶν ἐξαράξω τὴν ἄγαν αὐθαδίαν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="705">ταῦτα δῆτ’ οὐ δεινὰ πράγματ’ ἐστὶ καὶ περαιτέρω;</l>
 					</sp>
-					<sp who="#gynea">
+					<sp who="#gyne_a">
 						<speaker>Γυνὴ Α</speaker>
 						<l>δεινὰ δῆθ’, ὅστις γ’ ἔχει μου ’ξαρπάσας τὸ παιδίον.</l>
 						<milestone ed="p" n="707" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί ἂν οὖν εἴποι πρὸς ταῦτά τις, ὅτε</l>
 						<l>τοιαῦτα ποιῶν ὅδ’ ἀναισχυντεῖ;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>κοὔπω μέντοι γε πέπαυμαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="710">a)ll' ou)=n h(/keis g' o(/qen ou) fau/lws g'</l>
 						<l>ἀποδρὰς λέξεις</l>
 						<l>οἷον δράσας διέδυς ἔργον,</l>
 						<l>λήψει δὲ κακόν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>τοῦτο μέντοι μὴ γένοιτο μηδαμῶς, ἀπεύχομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="715">τίς οὖν σοι, τίς ἂν σύμμαχος ἐκ θεῶν</l>
 						<l>ἀθανάτων ἔλθοι ξὺν ἀδίκοις ἔργοις;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>μάτην λαλεῖτε· τὴν δ’ ἐγὼ οὐκ ἀφήσω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ οὐ μὰ τὼ θεὼ τάχ’ οὐ χαίρων ἴσως</l>
 						<l n="720">ἐνυβριεῖς λόγους λέξεις τ’ ἀνοσίους</l>
@@ -1994,12 +1994,12 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἴωμεν ἐπὶ τὰς κληματίδας ὦ Μανία.</l>
 					<l>κἀγώ σ’ ἀποδείξω θυμάλωπα τήμερον.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="730">ὕφαπτε καὶ κάταιθε· σὺ δὲ τὸ Κρητικὸν</l>
 					<l>ἀπόδυθι ταχέως· τοῦ θανάτου δ’ ὦ παιδίον</l>
@@ -2011,115 +2011,115 @@ bring up to P3
 					<l>ὦ μέγα καπήλοις ἀγαθὸν ἡμῖν δ’ αὖ κακόν,</l>
 					<l>κακὸν δὲ καὶ τοῖς σκευαρίοις καὶ τῇ κρόκῃ.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>παράβαλλε πολλὰς κληματίδας ὦ Μανία.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="740">παράβαλλε δῆτα· σὺ δ’ ἀπόκριναί μοι τοδί,</l>
 					<l>τουτὶ τεκεῖν φῄς;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">&lt;καὶ&gt; δέκα μῆνας αὔτ’ ἐγὼ</l>
 					<l>ἤνεγκον.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ἤνεγκας σύ;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">νὴ τὴν Ἄρτεμιν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>πρικότυλον ἢ πῶς; εἰπέ μοι.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">τί μ’ ἠργάσω;</l>
 					<l>ἀπέδυσας ὦναίσχυντέ μου τὸ παιδίον</l>
 					<l n="745">τυννοῦτον ὄν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">τυννοῦτο;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l part="Y">μικρὸν νὴ Δία.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>πόσ’ ἔτη δὲ γέγονε; τρεῖς Χοᾶς ἢ τέτταρας;</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>σχεδὸν τοσοῦτον χὤσον ἐκ Διονυσίων.</l>
 					<l>ἀλλ’ ἀπόδος αὐτό.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">μὰ τὸν Ἀπόλλω τουτονί.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ἐμπρήσομεν τοίνυν σε.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">πάνυ γ’ ἐμπίμπρατε·</l>
 					<l n="750">αὕτη δ’ ἀποσφαγήσεται μάλ’ αὐτίκα.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>μὴ δῆθ’, ἱκετεύω σ’· ἀλλ’ ἔμ’ ὅ τι χρῄζεις ποίει</l>
 					<l>ὑπέρ γε τούτου.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">φιλότεκνός τις εἶ φύσει.</l>
 					<l>ἀλλ’ οὐδὲν ἧττον ἥδ’ ἀποσφαγήσεται</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>οἴμοι τέκνον. δός μοι σφαγεῖον Μανία,</l>
 					<l n="755">ἵν’ οὖν τό γ’ αἷμα τοῦ τέκνου τοὐμοῦ λάβω.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ὕπεχ’ αὐτό, χαριοῦμαι γὰρ ἕν γε τοῦτό σοι.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>κακῶς ἀπόλοῑ, ὡς φθονερὸς εἶ καὶ δυσμενής.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>τουτὶ τὸ δέρμα τῆς ἱερείας γίγνεται.</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>τί τῆς ἱερείας γίγνεται;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">τουτί. λαβέ.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l n="760">ταλαντάτη Μίκκα τίς ἐξεκόρησέ σε;</l>
 					<l>[τίς τὴν ἀγαπητὴν παῖδά σοὐξῃρήσατο;]</l>
 				</sp>
-				<sp who="#gynea">
+				<sp who="#gyne_a">
 					<speaker>Γυνὴ Α</speaker>
 					<l>ὁ πανοῦργος οὗτος. ἀλλ’ ἐπειδήπερ πάρει,</l>
 					<l>φύλαξον αὐτόν, ἵνα λαβοῦσα Κλεισθένη</l>
 					<l>τοῖσιν πρυτάνεσιν ἃ πεποίηχ’ οὗτος φράσω.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="765">ἄγε δὴ τίς ἔσται μηχανὴ σωτηρίας;</l>
 					<l>τίς πεῖρα, τίς ἐπίνοῑ; ὁ μὲν γὰρ αἴτιος</l>
@@ -2135,7 +2135,7 @@ bring up to P3
 					<milestone ed="p" n="776" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὦ χεῖρες ἐμαὶ</l>
 						<l>ἐγχειρεῖν χρῆν ἔργῳ πορίμῳ.</l>
@@ -2152,7 +2152,7 @@ bring up to P3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 met="anapests" type="parabasis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="785">ἡμεῖς τοίνυν ἡμᾶς αὐτὰς εὖ λέξωμεν παραβᾶσαι,</l>
 						<l>καίτοι πᾶς τις τὸ γυναικεῖον φῦλον κακὰ πόλλ’ ἀγορεύει,</l>
@@ -2187,7 +2187,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἡμεῖς ἂν πολλοὺς τούτων</l>
 						<l n="815">ἀποδείξαιμεν ταῦτα ποιοῦντας.</l>
@@ -2209,7 +2209,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="830">πόλλ’ ἂν αἱ γυναῖκες ἡμεῖς ἐν δίκῃ μεμψαίμεθ’ ἂν</l>
 						<l>τοῖσιν ἀνδράσιν δικαίως, ἓν δ’ ὑπερφυέστατον.</l>
@@ -2232,7 +2232,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ἰλλὸς γεγένημαι προσδοκῶν· ὁ δ’ οὐδέπω.</l>
 					<l>τί δῆτ’ ἂν εἴη τοὐμποδών; οὐκ ἔσθ’ ὅπως</l>
@@ -2241,241 +2241,241 @@ bring up to P3
 					<l n="850">ἐγᾦδα· τὴν καινὴν Ἑλένην μιμήσομαι.</l>
 					<l>πάντως ὑπάρχει μοι γυναικεία στολή.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>τί αὖ σὺ κυρκανᾷς; τί κοικύλλεις ἔχων;</l>
 					<l>πικρὰν Ἑλένην ὄψει τάχ’, εἰ μὴ κοσμίως</l>
 					<l>ἕξεις, ἕως ἂν τῶν πρυτάνεών τις φανῇ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="855">Νείλου μὲν αἵδε καλλιπάρθενοι ῥοαί,</l>
 					<l>ὃς ἀντὶ δίας ψακάδος Αἰγύπτου πέδον</l>
 					<l>λευκῆς νοτίζει μελανοσυρμαῖον λεών.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>πανοῦργος εἶ νὴ τὴν Ἑκάτην τὴν φωσφόρον.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ἐμοὶ δὲ γῆ μὲν πατρὶς οὐκ ἀνώνυμος</l>
 					<l n="860">Σπάρτη, πατὴρ δὲ Τυνδάρεως.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">σοί γ’ ὦλεθρε</l>
 					<l>πατὴρ ἐκεῖνός ἐστι; Φρυνώνδας μὲν οὖν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>Ἑλένη δ’ ἐκλήθην.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">αὖθις αὖ γίγνει γυνή,</l>
 					<l>πρὶν τῆς ἑτέρας δοῦναι γυναικίσεως δίκην;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ψυχαὶ δὲ πολλαὶ δῑ ἔμ’ ἐπὶ Σκαμανδρίαις</l>
 					<l n="865">ῥοαῖσιν ἔθανον.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">ὤφελες δὲ καὶ σύ γε.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>κἀγὼ μὲν ἐνθάδ’ εἴμ’· ὁ δ’ ἄθλιος πόσις</l>
 					<l>οὑμὸς Μενέλαος οὐδέπω προσέρχεται.</l>
 					<l>τί οὖν ἔτι ζῶ;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">τῶν κοράκων πονηρίᾳ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ἀλλ’ ὥσπερ αἰκάλλει τι καρδίαν ἐμήν.</l>
 					<l n="870">μὴ ψεῦσον ὦ Ζεῦ τῆς ἐπιούσης ἐλπίδος.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>τίς τῶνδ’ ἐρυμνῶν δωμάτων ἔχει κράτος,</l>
 					<l>ὅστις ξένους δέξαιτο ποντίῳ σάλῳ</l>
 					<l>κάμνοντας ἐν χειμῶνι καὶ ναυαγίαις;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>Πρωτέως τάδ’ ἐστὶ μέλαθρα.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">ποίου Πρωτέως;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l n="875">ὦ τρισκακόδαιμον, ψεύδεται νὴ τὼ θεώ,</l>
 					<l>ἐπεὶ τέθνηκε Πρωτέας ἔτη δέκα.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ποίαν δὲ χώραν εἰσεκέλσαμεν σκάφει;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">Αἴγυπτον.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">ὦ δύστηνος οἷ πεπλώκαμεν.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>πείθει τι &lt;τούτῳ&gt; τῷ κακῶς ἀπολουμένῳ</l>
 					<l n="880">ληροῦντι λῆρον; Θεσμοφορεῖον τουτογί.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>αὐτὸς δὲ Πρωτεὺς ἔνδον ἔστ’ ἢ ’ξώπιος;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>οὐκ ἔσθ’ ὅπως οὐ ναυτιᾷς ἔτ’ ὦ ξένε,</l>
 					<l>ὅστις &lt;γ’&gt; ἀκούσας ὅτι τέθνηκε Πρωτέας</l>
 					<l>ἔπειτ’ ἐρωτᾷς ‘ἔνδον ἔστ’ ἢ ’ξώπιος;’</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="885">αἰαῖ τέθνηκε. ποῦ δ’ ἐτυμβεύθη τάφῳ;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>τόδ’ ἐστὶν αὐτοῦ σῆμ’, ἐφ’ ᾧ καθήμεθα.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>κακῶς τ’ ἄρ’ ἐξόλοιο κἀξολεῖ γέ τοι,</l>
 					<l>ὅστις γε τολμᾷς σῆμα τὸν βωμὸν καλεῖν.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>τί δὴ σὺ θάσσεις τάσδε τυμβήρεις ἕδρας</l>
 					<l n="890">φάρει καλυπτὸς ὦ ξένη;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">βιάζομαι</l>
 					<l>γάμοισι Πρωτέως παιδὶ συμμεῖξαι λέχος.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l>τί ὦ κακόδαιμον ἐξαπατᾷς αὖ τὸν ξένον;</l>
 					<l>οὗτος πανουργῶν δεῦρ’ ἀνῆλθεν ὦ ξένε</l>
 					<l>ὡς τὰς γυναῖκας ἐπὶ κλοπῇ τοῦ χρυσίου.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="895">βάυζε τοὐμὸν σῶμα βάλλουσα ψόγῳ.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ξένη τίς ἡ γραῦς ἡ κακορροθοῦσά σε;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>αὕτη Θεονόη Πρωτέως.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">μὰ τὼ θεὼ</l>
 					<l>εἰ μὴ Κρίτυλλά γ’ Ἀντιθέου Γαργηττόθεν·</l>
 					<l>σὺ δ’ εἶ πανοῦργος.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ὁπόσα τοι βούλει λέγε.</l>
 					<l n="900">οὐ γὰρ γαμοῦμαι σῷ κασιγνήτῳ ποτὲ</l>
 					<l>προδοῦσα Μενέλεων τὸν ἐμὸν ἐν Τροίᾳ πόσιν.</l>
 					<milestone ed="p" n="902" unit="card"/>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>γύναι τί εἶπας; στρέψον ἀνταυγεῖς κόρας.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>αἰσχύνομαί σε τὰς γνάθους ὑβρισμένη.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>τουτὶ τί ἔστιν; ἀφασία τίς τοί μ’ ἔχει.</l>
 					<l n="905">ὦ θεοὶ τίν’ ὄψιν εἰσορῶ; τίς εἶ γύναι;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>σὺ δ’ εἶ τίς; αὑτὸς γὰρ σὲ κἄμ’ ἔχει λόγος.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>Ἑλληνὶς εἶ τις ἢ ’πιχωρία γυνή;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>Ἑλληνίς. ἀλλὰ καὶ τὸ σὸν θέλω μαθεῖν.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>Ἑλένῃ σ’ ὁμοίαν δὴ μάλιστ’ εἶδον γύναι.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="910">ἐγὼ δὲ Μενελάῳ σ’ ὅσα γ’ ἐκ τῶν ἰφύων.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἔγνως ἄρ’ ὀρθῶς ἄνδρα δυστυχέστατον.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ὦ χρόνιος ἐλθὼν σῆς δάμαρτος ἐσχάρας</l>
 					<l>λαβέ με λαβέ με πόσι, περίβαλε δὲ χέρας.</l>
 					<l n="915">φέρε σὲ κύσω. ἄπαγέ μ’ ἄπαγ’ ἄπαγέ με</l>
 					<l>λαβὼν ταχὺ πάνυ.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">κλαύσετ’ ἄρα νὴ τὼ θεὼ</l>
 					<l>ὅστις σ’ ἀπάξει τυπτόμενος τῇ λαμπάδι.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>σὺ τὴν ἐμὴν γυναῖκα κωλύεις ἐμέ,</l>
 					<l>τὴν Τυνδάρειον παῖδ’, ἐπὶ Σπάρτην ἄγειν;</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l n="920">οἴμ’ ὡς πανοῦργος καὐτὸς εἶναί μοι δοκεῖς</l>
 					<l>καὶ τοῦδέ τις ξύμβουλος. οὐκ ἐτὸς πάλαι</l>
 					<l>ᾐγυπτιάζετ’. ἀλλ’ ὅδε μὲν δώσει δίκην.</l>
 					<l>προσέρχεται γὰρ ὁ πρύτανις χὠ τοξότης.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>τουτὶ πονηρόν· ἀλλ’ ὑπαποκινητέον.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="925">ἐγὼ δ’ ὁ κακοδαίμων τί δρῶ;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">μέν’ ἥσυχος.</l>
 					<l>οὐ γὰρ προδώσω σ’ οὐδέποτ’, ἤνπερ ἐμπνέω,</l>
 					<l>ἢν μὴ προλίπωσ’ αἱ μυρίαι με μηχαναί.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>αὕτη μὲν ἡ μήρινθος οὐδὲν ἔσπασεν.</l>
 				</sp>
@@ -2488,12 +2488,12 @@ bring up to P3
 					<l>ἔα πρὸς αὐτόν, ἀλλὰ τὴν μάστιγ’ ἔχων</l>
 					<l>παῖ’ ἢν προσίῃ τις.</l>
 				</sp>
-				<sp who="#gyneg">
+				<sp who="#gyne_g">
 					<speaker>Γυνὴ Γ</speaker>
 					<l part="Y">νὴ Δί’ ὡς νῦν δή γ’ ἀνὴρ</l>
 					<l n="935">ὀλίγου μ’ ἀφείλετ’ αὐτὸν ἱστιορράφος.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ὦ πρύτανι πρὸς τῆς δεξιᾶς, ἥνπερ φιλεῖς</l>
 					<l>κοίλην προτείνειν ἀργύριον ἤν τις διδῷ,</l>
@@ -2503,7 +2503,7 @@ bring up to P3
 					<speaker>Πρύτανις</speaker>
 					<l>τί σοι χαρίσωμαι;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">γυμνὸν ἀποδύσαντά με</l>
 					<l n="940">κέλευε πρὸς τῇ σανίδι δεῖν τὸν τοξότην,</l>
@@ -2515,7 +2515,7 @@ bring up to P3
 					<l>ἔχοντα ταῦτ’ ἔδοξε τῇ βουλῇ σε δεῖν,</l>
 					<l>ἵνα τοῖς παριοῦσι δῆλος ᾖς πανοῦργος ὤν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l n="945">ἰαππαπαιάξ· ὦ κροκώθ’ οἷ’ εἴργασαι·</l>
 					<l>κοὐκ ἔστ’ ἔτ’ ἐλπὶς οὐδεμία σωτηρίας.</l>
@@ -2524,7 +2524,7 @@ bring up to P3
 			</div1>
 			<div1 type="Lyric-Scene">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγε νυν ἡμεῖς παίσωμεν ἅπερ νόμος ἐνθάδε ταῖσι γυναιξίν,</l>
 						<l>ὅταν ὄργια σεμνὰ θεοῖν ἱεραῖς ὥραις ἀνέχωμεν, ἅπερ καὶ</l>
@@ -2545,7 +2545,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἅμα δὲ καὶ</l>
 						<l n="960">γένος Ὀλυμπίων θεῶν</l>
@@ -2554,7 +2554,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1a" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="962">εἰ δέ τις</l>
 						<l>προσδοκᾷ κακῶς ἐρεῖν</l>
@@ -2563,7 +2563,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1b" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="966">ἀλλὰ χρῆν</l>
 						<l>ὥσπερ ἔργον αὖ τι καινὸν</l>
@@ -2572,7 +2572,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρόβαινε ποσὶ τὸν εὐλύραν</l>
 						<l n="970">μέλπουσα καὶ τὴν τοξοφόρον</l>
@@ -2587,7 +2587,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἑρμῆν τε νόμιον ἄντομαι</l>
 						<l>καὶ Πᾶνα καὶ Νύμφας φίλας</l>
@@ -2602,7 +2602,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="985">ἀλλ’ εἶα πάλλ’ ἀνάστρεφ’ εὐρύθμῳ ποδί,</l>
 						<l>τόρευε πᾶσαν ᾠδήν·</l>
@@ -2614,7 +2614,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="990">εὔιον ὦ Διόνυσε</l>
 						<l>Βρόμιε καὶ Σεμέλας παῖ,</l>
@@ -2626,7 +2626,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="995">ἀμφὶ δὲ σοὶ κτυπεῖται</l>
 						<l>Κιθαιρώνιος ἠχώ,</l>
@@ -2645,7 +2645,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l>ἐνταῦτα νῦν οἰμῶξι πρὸς τὴν αἰτρίαν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ὦ τοξόθ’ ἱκετεύω σε.</l>
 				</sp>
@@ -2653,7 +2653,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l part="Y">μή μ’ ἰκετεῦσι σύ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>χάλασον τὸν ἧλον.</l>
 				</sp>
@@ -2661,7 +2661,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l part="Y">ἀλλὰ ταῦτα δρᾶσ’ ἐγώ.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>οἴμοι κακοδαίμων, μᾶλλον ἐπικρούεις σύ γε.</l>
 				</sp>
@@ -2669,7 +2669,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l n="1005">ἔτι μᾶλλο βοῦλις;</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ἀτταταῖ ἰατταταῖ·</l>
 					<l>κακῶς ἀπόλοιο.</l>
@@ -2679,7 +2679,7 @@ bring up to P3
 					<l part="Y">σῖγα κακοδαίμων γέρον.</l>
 					<l>πέρ’ ἐγὼ ’ξινίγκι πορμός, ἴνα πυλάξι σοι.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ταυτὶ τὰ βέλτιστ’ ἀπολέλαυκ’ Εὐριπίδου.</l>
 					<l>ἔα· θεοί, Ζεῦ σῶτερ, εἰσὶν ἐλπίδες.</l>
@@ -2690,7 +2690,7 @@ bring up to P3
 					<l n="1015">ἥξει με σώσων· οὐ γὰρ ἂν παρέπτετο.</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>φίλαι παρθένοι φίλαι, πῶς ἂν &lt;οὖν&gt;</l>
 						<l>ἐπέλθοιμι καὶ</l>
@@ -2699,7 +2699,7 @@ bring up to P3
 						<l n="1020">κατάνευσον, ἔασον ὡς</l>
 						<l>τὴν γυναῖκά μ’ ἐλθεῖν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἄνοικτος ὅς μ’ ἔδησε τὸν</l>
 						<l>πολυστονώτατον βροτῶν·</l>
@@ -2739,16 +2739,16 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>χαῖρ’ ὦ φίλη παῖ· τὸν δὲ πατέρα Κηφέα</l>
 						<l>ὅς σ’ ἐξέθηκεν ἀπολέσειαν οἱ θεοί.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>σὺ δ’ εἶ τίς ἥτις τοὐμὸν ᾤκτιρας πάθος;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>Ἠχὼ λόγων ἀντῳδὸς ἐπικοκκάστρια,</l>
 						<l n="1060">ἥπερ πέρυσιν ἐν τῷδε ταὐτῷ χωρίῳ</l>
@@ -2756,17 +2756,17 @@ bring up to P3
 						<l>ἀλλ’ ὦ τέκνον σὲ μὲν τὸ σαυτῆς χρὴ ποιεῖν,</l>
 						<l>κλάειν ἐλεινῶς.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">σὲ δ’ ἐπικλάειν ὕστερον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ἐμοὶ μελήσει ταῦτά γ’. ἀλλ’ ἄρχου λόγων.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="1065">ὦ νὺξ ἱερὰ</l>
 						<l>ὡς μακρὸν ἵππευμα διώκεις</l>
@@ -2774,90 +2774,90 @@ bring up to P3
 						<l>αἰθέρος ἱερᾶς</l>
 						<l>τοῦ σεμνοτάτου δῑ Ὀλύμπου;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>δῑ Ὀλύμπου.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="1070">τί ποτ’ Ἀνδρομέδα περίαλλα κακῶν</l>
 						<l>μέρος ἐξέλαχον—</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">μέρος ἐξέλαχον—</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>θανάτου τλήμων;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">θανάτου τλήμων;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ἀπολεῖς μ’ ὦ γραῦ στωμυλλομένη.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>στωμυλλομένη.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="1075">νὴ Δί’ ὀχληρά γ’ εἰσήρρηκας</l>
 						<l>λίαν.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">λίαν.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὦγάθ’ ἔασόν με μονῳδῆσαι,</l>
 						<l>καὶ χαριεῖ μοι. παῦσαι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">παῦσαι.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>βάλλ’ ἐς κόρακας.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">βάλλ’ ἐς κόρακας.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="1080">τί κακόν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τί κακόν;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">ληρεῖς.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ληρεῖς.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>οἴμωζ’.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">οἴμωζ’.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l part="Y">ὀτότυζ’.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ὀτότυζ’.</l>
 					</sp>
@@ -2865,7 +2865,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>οὖτος σί λαλῖς;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">οὖτος σί λαλῖς;</l>
 					</sp>
@@ -2873,7 +2873,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>πρυτάνεις καλέσω;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">πρυτάνεις καλέσω;</l>
 					</sp>
@@ -2881,7 +2881,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l n="1085">σί κακόν;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">σί κακόν;</l>
 					</sp>
@@ -2889,7 +2889,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>πῶτε τὸ πωνή;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">πῶτε τὸ πωνή;</l>
 					</sp>
@@ -2897,7 +2897,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>σὺ λαλῖς;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">σὺ λαλῖς;</l>
 					</sp>
@@ -2905,7 +2905,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l part="Y">κλαύσει.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">κλαύσει.</l>
 					</sp>
@@ -2913,15 +2913,15 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>κακκάσκι μοι;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">κακκάσκι μοι;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l n="1090">μὰ Δί’ ἀλλὰ γυνὴ πλησίον αὕτη.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>πλησίον αὕτη.</l>
 					</sp>
@@ -2930,7 +2930,7 @@ bring up to P3
 						<l>ποῦ στ’ η’ μιαρά; καὶ δὴ πεύγει.</l>
 						<l>ποῖ ποῖ πεύγεις;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">&lt; ποῖ ποῖ πεύγεις;&gt;</l>
 					</sp>
@@ -2938,7 +2938,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>οὐ καιρήσεις;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">&lt; οὐ καιρήσεις;&gt;</l>
 					</sp>
@@ -2946,7 +2946,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l n="1095">ἔτι γὰρ γρύζεις;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ἔτι γὰρ γρύζεις;</l>
 					</sp>
@@ -2954,7 +2954,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>λαβὲ τὴ μιαρά.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">λαβὲ τὴ μιαρά.</l>
 					</sp>
@@ -2965,7 +2965,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>ὦ θεοὶ τίν’ ἐς γῆν βαρβάρων ἀφίγμεθα</l>
 						<l>ταχεῖ πεδίλῳ; διὰ μέσου γὰρ αἰθέρος</l>
@@ -2978,7 +2978,7 @@ bring up to P3
 						<l part="Y">τί λέγι; τὴ Γόργος πέρι</l>
 						<l>τὸ γραμματέο σὺ τὴ κεπαλή;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">τὴν Γοργόνος</l>
 						<l>ἔγωγε φημί.</l>
@@ -2987,12 +2987,12 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l part="Y">Γόργο τοι κἀγὼ λέγι.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1105">ἔα· τίν’ ὄχθον τόνδ’ ὁρῶ καὶ παρθένον</l>
 						<l>θεαῖς ὁμοίαν ναῦν ὅπως ὡρμισμένην;</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>ὦ ξένε κατοίκτιρόν με τὴν παναθλίαν,</l>
 						<l>λῦσόν με δεσμῶν.</l>
@@ -3002,7 +3002,7 @@ bring up to P3
 						<l part="Y">οὐκὶ μὶ λαλῆσι σύ;</l>
 						<l>κατάρατο τολμᾷς ἀποτανουμένη λαλᾷς;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1110">ὦ παρθέν’ οἰκτίρω σὲ κρεμαμένην ὁρῶν.</l>
 					</sp>
@@ -3011,7 +3011,7 @@ bring up to P3
 						<l>οὐ παρτέν’ ἐστίν, ἀλλ’ ἀμαρτωλὴ γέρων</l>
 						<l>καὶ κλέπτο καὶ πανοῦργο.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l part="Y">ληρεῖς ὦ Σκύθα.</l>
 						<l>αὕτη γάρ ἐστιν Ἀνδρομέδα παῖς Κηφέως.</l>
@@ -3020,7 +3020,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>σκέψαι τὸ κύστο· μή τι μικτὸν παίνεται;</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1115">φέρε δεῦρό μοι τὴν χεῖρ’, ἵν’ ἅψωμαι κόρης·</l>
 						<l>φέρε Σκύθ’· ἀνθρώποισι γὰρ νοσήματα</l>
@@ -3033,7 +3033,7 @@ bring up to P3
 						<l>ἀτὰρ εἰ τὸ πρωκτὸ δεῦρο περιεστραμμένον,</l>
 						<l n="1120">οὐκ ἐπτόνησά σ’ αὐτὸ πυγίζεις ἄγων.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>τί δ’ οὐκ ἐᾷς λύσαντά μ’ αὐτὴν ὦ Σκύθα</l>
 						<l>πεσεῖν ἐς εὐνὴν καὶ γαμήλιον λέχος;</l>
@@ -3043,7 +3043,7 @@ bring up to P3
 						<l>εἰ σπόδρ’ ἐπιτυμεῖς τὴ γέροντο πύγισο,</l>
 						<l>τὴ σανίδο τρήσας ἐξόπιστο πρώκτισον.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l n="1125">μὰ Δί’ ἀλλὰ λύσω δεσμά.</l>
 					</sp>
@@ -3051,7 +3051,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l part="Y">μαστιγῶ σ’ ἄρα.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>καὶ μὴν ποιήσω τοῦτο.</l>
 					</sp>
@@ -3060,7 +3060,7 @@ bring up to P3
 						<l part="Y">τὸ κεπαλή σ’ ἄρα</l>
 						<l>τὸ ξιπομάκαιραν ἀποκεκόψι τουτοϊ.</l>
 					</sp>
-					<sp who="#eyripides">
+					<sp who="#euripides">
 						<speaker>Εὐριπίδης</speaker>
 						<l>αἰαῖ· τί δράσω; πρὸς τίνας στρεφθῶ λόγους;</l>
 						<l>ἀλλ’ οὐ &lt;γὰρ&gt; ἂν δέξαιτο βάρβαρος φύσις.</l>
@@ -3072,7 +3072,7 @@ bring up to P3
 						<speaker>Τοξότης</speaker>
 						<l>μιαρὸς ἀλώπηξ, οἶον ἐπιτήκιζί μοι.</l>
 					</sp>
-					<sp who="#mnesiloxos">
+					<sp who="#mnesilochos">
 						<speaker>Μνησίλοχος</speaker>
 						<l>μέμνησο Περσεῦ μ’ ὡς καταλείπεις ἀθλίαν.</l>
 					</sp>
@@ -3085,7 +3085,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Παλλάδα τὴν φιλόχορον ἐμοὶ</l>
 						<l>δεῦρο καλεῖν νόμος ἐς χορόν,</l>
@@ -3094,7 +3094,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1a" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1140">ἣ πόλιν ἡμετέραν ἔχει</l>
 						<l>καὶ κράτος φανερὸν μόνη</l>
@@ -3103,7 +3103,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φάνηθ’ ὦ τυράννους</l>
 						<l>στυγοῦσ’ ὥσπερ εἰκός.</l>
@@ -3111,7 +3111,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1b" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1145">δῆμός τοί σε καλεῖ γυναικῶν·</l>
 						<l>ἔχουσα δέ μοι μόλοις</l>
@@ -3130,7 +3130,7 @@ bring up to P3
 					<milestone ed="p" n="1155" unit="card"/>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1155">εἰ καὶ πρότερόν ποτ’ ἐπηκόω</l>
 						<l>ἤλθετον, &lt;ἔλθετε&gt; νῦν, ἀφίκεσθ’ ἱκετεύομεν</l>
@@ -3140,18 +3140,18 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1160">γυναῖκες εἰ βούλεσθε τὸν λοιπόν χρόνον</l>
 					<l>σπονδὰς ποιήσασθαι πρὸς ἐμέ, νυνὶ πάρα,</l>
 					<l>ἐφ’ ᾧτ’ ἀκοῦσαι μηδὲν ὑπ’ ἐμοῦ μηδαμὰ</l>
 					<l>κακὸν τὸ λοιπόν. ταῦτ’ ἐπικηρυκεύομαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>χρείᾳ δὲ ποίᾳ τόνδ’ ἐπεσφέρεις λόγον;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l n="1165">ὅδ’ ἐστὶν οὑν τῇ σανίδι κηδεστὴς ἐμός.</l>
 					<l>ἢν οὖν κομίσωμαι τοῦτον, οὐδὲν μή ποτε</l>
@@ -3159,12 +3159,12 @@ bring up to P3
 					<l>ἃ νῦν ὑποικουρεῖτε τοῖσιν ἀνδράσιν</l>
 					<l>ἀπὸ τῆς στρατιᾶς παροῦσιν ὑμῶν διαβαλῶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1170">τὰ μὲν παρ’ ἡμῶν ἴσθι σοι πεπεισμένα·</l>
 					<l>τὸν βάρβαρον δὲ τοῦτον αὐτὸς πεῖθε σύ.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἐμὸν ἔργον ἐστίν· καὶ σὸν ὦλάφιον ἅ σοι</l>
 					<l>καθ’ ὁδὸν ἔφραζον ταῦτα μεμνῆσθαι ποιεῖν.</l>
@@ -3175,7 +3175,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l>τί τὸ βόμβο τοῦτο; κῶμο τίς ἀνεγεῖρί μοι</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἡ παῖς ἔμελλε προμελετᾶν ὦ τοξότα.</l>
 					<l>ὀρχησομένη γὰρ ἔρχεθ’ ὡς ἄνδρας τινάς.</l>
@@ -3185,7 +3185,7 @@ bring up to P3
 					<l>ὀρκῆσι καὶ μελετῆσι, οὐ κωλύσ’ ἐγώ.</l>
 					<l n="1180">ὡς ἐλαπρός, ὥσπερ ψύλλο κατὰ τὸ κῴδιο.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>φέρε θοἰμάτιον ἄνωθεν ὦ τέκνον τοδί·</l>
 					<l>καθιζομένη δ’ ἐπὶ τοῖσι γόνασι τοῦ Σκύθου</l>
@@ -3197,7 +3197,7 @@ bring up to P3
 					<l>κάτησο κάτησο, ναῖκι ναῖκι τυγάτριον.</l>
 					<l n="1185">οἴμ’ ὠς στέριπο τὸ τιττἴ, ὤσπερ γογγύλη.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>αὔλει σὺ θᾶττον· ἔτι δέδοικας τὸν Σκύθην;</l>
 				</sp>
@@ -3207,7 +3207,7 @@ bring up to P3
 					<l n="1187a">ἀνακύπτι καὶ παρακύπτι ἀπεψωλημένος·</l>
 					<l n="1188">εἶεν· καλὴ τὸ σκῆμα περὶ τὸ πόστιον.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>καλῶς ἔχει. λαβὲ θοἰμάτιον· ὥρα ’στὶ νῷν</l>
 					<l n="1190">ἤδη βαδίζειν.</l>
@@ -3216,7 +3216,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l part="Y">οὐκὶ πιλῆσι πρῶτά με;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>πάνυ γε· φίλησον αὐτόν.</l>
 				</sp>
@@ -3226,7 +3226,7 @@ bring up to P3
 					<l>ὠς γλυκερὸ τὸ γλῶσσ’, ὤσπερ Ἀττικὸς μέλις.</l>
 					<l>τί οὐ κατεύδει παρ’ ἐμέ;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">χαῖρε τοξότα,</l>
 					<l>οὐ γὰρ γένοιτ’ ἂν τοῦτο.</l>
@@ -3236,7 +3236,7 @@ bring up to P3
 					<l part="Y">ναὶ &lt;ναὶ&gt; γρᾴδιο.</l>
 					<l>ἐμοὶ κάρισο σὺ τοῦτο.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">δώσεις οὖν δραχμήν;</l>
 				</sp>
@@ -3244,7 +3244,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l n="1195">ναὶ ναῖκι δῶσι.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">τἀργύριον τοίνυν φέρε.</l>
 				</sp>
@@ -3252,7 +3252,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l>ἀλλ’ οὐκ ἔκὠδέν· ἀλλὰ τὸ συβήνην λαβέ.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>ἔπειτα † κομίζεις αὐτοῖς.†</l>
 				</sp>
@@ -3262,7 +3262,7 @@ bring up to P3
 					<l>σὺ δὲ τοῦτο τήρει τὴ γέροντο, γρᾴδιο.</l>
 					<l n="1200">ὄνομα δέ σοι τί ἔστιν;</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l part="Y">Ἀρτεμισία.</l>
 				</sp>
@@ -3270,7 +3270,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l>μεμνῆσι τοίνυν τοὔνομ’· Ἀρταμουξία.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>Ἑρμῆ δόλιε ταυτὶ μὲν ἔτι καλῶς ποιεῖς.</l>
 					<l>σὺ μὲν οὖν ἀπότρεχε παιδάριον τουτὶ λαβών·</l>
@@ -3278,16 +3278,16 @@ bring up to P3
 					<l n="1205">ὅταν λυθῇς τάχιστα θεύξει καὶ τενεῖς</l>
 					<l>ὡς τὴν γυναῖκα καὶ τὰ παιδἴ οἴκαδε.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l>ἐμοὶ μελήσει ταῦτά γ’ ἢν ἅπαξ λυθῶ.</l>
 				</sp>
-				<sp who="#eyripides">
+				<sp who="#euripides">
 					<speaker>Εὐριπίδης</speaker>
 					<l>λέλυσο. σὸν ἔργον, φεῦγε πρὶν τὸν τοξότην</l>
 					<l>ἥκοντα καταλαβεῖν.</l>
 				</sp>
-				<sp who="#mnesiloxos">
+				<sp who="#mnesilochos">
 					<speaker>Μνησίλοχος</speaker>
 					<l part="Y">ἐγὼ δὴ τοῦτο δρῶ.</l>
 				</sp>
@@ -3303,7 +3303,7 @@ bring up to P3
 					<l>οἴμοι,</l>
 					<l>τί δρᾶσι; ποῖ τὸ γρᾴδῑ; Ἀρταμουξία.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τὴν γραῦν ἐρωτᾷς, ἣ ’φερεν τὰς πηκτίδας;</l>
 				</sp>
@@ -3311,7 +3311,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l>ναὶ ναῖκι. εἶδες αὐτό;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">ταύτῃ γ’ οἴχεται</l>
 					<l>αὐτή τ’ ἐκείνη καὶ γέρων τις εἵπετο.</l>
@@ -3320,7 +3320,7 @@ bring up to P3
 					<speaker>Τοξότης</speaker>
 					<l n="1220">κροκῶτ’ ἔκοντο τὴ γέροντο;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="Y">φήμ’ ἐγώ.</l>
 					<l>ἔτ’ ἂν καταλάβοις, εἰ διώκοις ταυτῃί.</l>
@@ -3330,7 +3330,7 @@ bring up to P3
 					<l>ὦ μιαρὸ γρᾶο· πότερα τρέξι τὴν ὀδό;</l>
 					<l>Ἀρταμουξία.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὀρθὴν ἄνω δίωκε. ποῖ θεῖς; οὐ πάλιν</l>
 					<l>τῃδὶ διώξει; σ’ τοὔμπαλιν τρέχεις σύ γε.</l>
@@ -3343,7 +3343,7 @@ bring up to P3
 			</div1>
 			<div1 type="Exodus">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τρέχε νυν κατὰ τοὺς κόρακας ἐπουρίσας, &lt;τρέχε.&gt;</l>
 						<l>ἀλλὰ πέπαισται μετρίως ἡμῖν·</l>

--- a/tei/aristophanes-wasps.xml
+++ b/tei/aristophanes-wasps.xml
@@ -55,7 +55,7 @@
 					<person xml:id="kategoros">
 						<persName>Κατήγορος</persName>
 					</person>
-					<person xml:id="filokleon">
+					<person xml:id="philokleon">
 						<persName>Φιλοκλέων</persName>
 					</person>
 					<person xml:id="kyon">
@@ -64,16 +64,16 @@
 					<person xml:id="bdelykleon">
 						<persName>Βδελυκλέων</persName>
 					</person>
-					<person xml:id="ksymotestis">
+					<person xml:id="xymotes_tis">
 						<persName>Ξυμότης τις</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="pais">
 						<persName>Παίς</persName>
 					</person>
-					<person xml:id="ksanthias">
+					<person xml:id="xanthias">
 						<persName>Ξανθίας</persName>
 					</person>
 					<person xml:id="artopolis">
@@ -167,7 +167,7 @@ bring up to P3
 					<speaker>Σωσίας</speaker>
 					<l>Οὗτος τί πάσχεις ὦ κακόδαιμον Ξανθία;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>φυλακὴν καταλύειν νυκτερινὴν διδάσκομαι.</l>
 				</sp>
@@ -176,7 +176,7 @@ bring up to P3
 					<l>κακὸν ἆρα ταῖς πλευραῖς τι προὐφείλεις μέγα.</l>
 					<l>ἆρ’ οἶσθά γ’ οἷον κνώδαλον φυλάττομεν;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="5">οἶδ’, ἀλλ’ ἐπιθυμῶ σμικρὸν ἀπομερμηρίσαι.</l>
 				</sp>
@@ -185,7 +185,7 @@ bring up to P3
 					<l>σὺ δ’ οὖν παρακινδύνεῡ, ἐπεὶ καὐτοῦ γ’ ἐμοῦ</l>
 					<l>κατὰ τοῖν κόραιν ὕπνου τι καταχεῖται γλυκύ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἀλλ’ ἦ παραφρονεῖς ἐτεὸν ἢ κορυβαντιᾷς;</l>
 				</sp>
@@ -193,7 +193,7 @@ bring up to P3
 					<speaker>Σωσίας</speaker>
 					<l>οὔκ, ἀλλ’ ὕπνος μ’ ἔχει τις ἐκ Σαβαζίου.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="10">τὸν αὐτὸν ἄρ’ ἐμοὶ βουκολεῖς Σαβάζιον.</l>
 					<l>κἀμοὶ γὰρ ἀρτίως ἐπεστρατεύσατο</l>
@@ -205,7 +205,7 @@ bring up to P3
 					<l>κἄγωγ’ ἀληθῶς οἷον οὐδεπώποτε.</l>
 					<l n="15">ἀτὰρ σὺ λέξον πρότερος.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">ἐδόκουν αἰετὸν</l>
 					<l>καταπτόμενον ἐς τὴν ἀγορὰν μέγαν πάνυ</l>
@@ -217,7 +217,7 @@ bring up to P3
 					<speaker>Σωσίας</speaker>
 					<l n="20">οὐδὲν ἄρα γρίφου διαφέρει Κλεώνυμος.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>πῶς δή;</l>
 				</sp>
@@ -227,7 +227,7 @@ bring up to P3
 					<l>‘τί ταὐτὸν ἐν γῇ τ’ ἀπέβαλεν κἀν οὐρανῷ</l>
 					<l>κἀν τῇ θαλάττῃ θηρίον τὴν ἀσπίδα;’</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οἴμοι τί δῆτά μοι κακὸν γενήσεται</l>
 					<l n="25">ἰδόντι τοιοῦτον ἐνύπνιον;</l>
@@ -237,7 +237,7 @@ bring up to P3
 					<l part="Y">μὴ φροντίσῃς.</l>
 					<l>οὐδὲν γὰρ ἔσται δεινὸν οὐ μὰ τοὺς θεούς.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>δεινόν γέ ποὔστ’ ἄνθρωπος ἀποβαλὼν ὅπλα.</l>
 					<l>ἀτὰρ σὺ τὸ σὸν αὖ λέξον.</l>
@@ -247,7 +247,7 @@ bring up to P3
 					<l part="Y">ἀλλ’ ἐστὶν μέγα.</l>
 					<l>περὶ τῆς πόλεως γάρ ἐστι τοῦ σκάφους ὅλου.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="30">λέγε νυν ἀνύσας τι τὴν τρόπιν τοῦ πράγματος.</l>
 				</sp>
@@ -260,7 +260,7 @@ bring up to P3
 					<l n="35">δημηγορεῖν φάλαινα πανδοκεύτρια,</l>
 					<l>ἔχουσα φωνὴν ἐμπεπρησμένης ὑός.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>αἰβοῖ.</l>
 				</sp>
@@ -268,7 +268,7 @@ bring up to P3
 					<speaker>Σωσίας</speaker>
 					<l part="Y">τί ἔστι;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">παῦε παῦε, μὴ λέγε·</l>
 					<l>ὄζει κάκιστον τοὐνύπνιον βύρσης σαπρᾶς.</l>
@@ -278,7 +278,7 @@ bring up to P3
 					<l>εἶθ’ ἡ μιαρὰ φάλαιν’ ἔχουσα τρυτάνην</l>
 					<l n="40">ἵστη βόειον δημόν.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">οἴμοι δείλαιος·</l>
 					<l>τὸν δῆμον ἡμῶν βούλεται διιστάναι.</l>
@@ -290,7 +290,7 @@ bring up to P3
 					<l>εἶτ’ Ἀλκιβιάδης εἶπε πρός με τραυλίσας,</l>
 					<l n="45">“ὁλᾷς; Θέωλος τὴν κεφαλὴν κόλακος ἔχει.”</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ὀρθῶς γε τοῦτ’ Ἀλκιβιάδης ἐτραύλισεν.</l>
 				</sp>
@@ -299,7 +299,7 @@ bring up to P3
 					<l>οὔκουν ἐκεῖν’ ἀλλόκοτον, ὁ Θέωρος κόραξ</l>
 					<l>γιγνόμενος;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">ἥκιστ’, ἀλλ’ ἄριστον.</l>
 				</sp>
@@ -307,7 +307,7 @@ bring up to P3
 					<speaker>Σωσίας</speaker>
 					<l part="Y">πῶς;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">ὅπως;</l>
 					<l>ἄνθρωπος ὢν εἶτ’ ἐγένετ’ ἐξαίφνης κόραξ·</l>
@@ -320,7 +320,7 @@ bring up to P3
 					<l>οὕτως ὑποκρινόμενον σοφῶς ὀνείρατα;</l>
 					<milestone ed="p" n="54" unit="card"/>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>φέρε νυν κατείπω τοῖς θεαταῖς τὸν λόγον,</l>
 					<l n="55">ὀλίγ’ ἄτθ’ ὑπειπὼν πρῶτον αὐτοῖσιν ταδί,</l>
@@ -349,7 +349,7 @@ bring up to P3
 					<speaker>Σωσίας</speaker>
 					<l>μὰ Δί’, ἀλλ’ ἀφ’ αὑτοῦ τὴν νόσον τεκμαίρεται.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οὔκ, ἀλλὰ “φιλο” μέν ἐστιν ἀρχὴ τοῦ κακοῦ.</l>
 					<l>ὁδὶ δέ φησι Σωσίας πρὸς Δερκύλον</l>
@@ -360,7 +360,7 @@ bring up to P3
 					<l part="Y">οὐδαμῶς γ’, ἐπεὶ</l>
 					<l n="80">αὕτη γε χρηστῶν ἐστιν ἀνδρῶν ἡ νόσος.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>Νικόστρατος δ’ αὖ φησιν ὁ Σκαμβωνίδης</l>
 					<l>εἶναι φιλοθύτην αὐτὸν ἢ φιλόξενον.</l>
@@ -371,7 +371,7 @@ bring up to P3
 					<l>ἐπεὶ καταπύγων ἐστὶν ὅ γε Φιλόξενος.</l>
 					<milestone ed="p" n="85" unit="card"/>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l n="85">ἄλλως φλυαρεῖτ’· οὐ γὰρ ἐξευρήσετε.</l>
 					<l>εἰ δὴ ’πιθυμεῖτ’ εἰδέναι, σιγᾶτε νῦν.</l>
@@ -430,7 +430,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ὦ Ξανθία καὶ Σωσία, καθεύδετε;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οἴμοι.</l>
 				</sp>
@@ -438,7 +438,7 @@ bring up to P3
 					<speaker>Σωσίας</speaker>
 					<l part="Y">τί ἔστι;</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l part="Y">Βδελυκλέων ἀνίσταται.</l>
 				</sp>
@@ -459,7 +459,7 @@ bring up to P3
 					<l>ἄναξ Πόσειδον τί ποτ’ ἄρ’ ἡ κάπνη ψοφεῖ;</l>
 					<l>οὗτος τίς εἶ σύ;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">καπνὸς ἔγωγ’ ἐξέρχομαι.</l>
 				</sp>
@@ -467,7 +467,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="145">καπνός; φέρ’ ἴδω ξύλου τίνος σύ.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">συκίνου.</l>
 				</sp>
@@ -491,7 +491,7 @@ bring up to P3
 					<l>καὶ τῆς κατακλῇδος ἐπιμελοῦ, καὶ τοῦ μοχλοῦ</l>
 					<l n="155">φύλατθ’ ὅπως μὴ τὴν βάλανον ἐκτρώξεται.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τί δράσετ’; οὐκ ἐκφρήσετ’ ὦ μιαρώτατοι</l>
 					<l>δικάσοντά μ’, ἀλλ’ ἐκφεύξεται Δρακοντίδης;</l>
@@ -500,7 +500,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>σὺ δὲ τοῦτο βαρέως ἂν φέροις;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ὁ γὰρ θεὸς</l>
 					<l>μαντευομένῳ μοὔχρησεν ἐν Δελφοῖς ποτέ,</l>
@@ -510,7 +510,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>Ἄπολλον ἀποτρόπαιε τοῦ μαντεύματος.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἴθ’ ἀντιβολῶ σ’ ἔκφρες με, μὴ διαρραγῶ.</l>
 				</sp>
@@ -518,7 +518,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>μὰ τὸν Ποσειδῶ Φιλοκλέων οὐδέποτέ γε.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>διατρώξομαι τοίνυν ὀδὰξ τὸ δίκτυον.</l>
 				</sp>
@@ -526,7 +526,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="165">ἀλλ’ οὐκ ἔχεις ὀδόντας.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">οἴμοι δείλαιος·</l>
 					<l>τῶς ἄν σ’ ἀποκτείναιμι; πῶς; δότε μοι ξίφος</l>
@@ -536,7 +536,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ἅνθρωπος οὗτος μέγα τι δρασείει κακόν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>μὰ τὸν Δί’ οὐ δῆτ’, ἀλλ’ ἀποδόσθαι βούλομαι</l>
 					<l n="170">τὸν ὄνον ἄγων αὐτοῖσι τοῖς κανθηλίοις·</l>
@@ -547,7 +547,7 @@ bring up to P3
 					<l part="Y">οὔκουν κἂν ἐγὼ</l>
 					<l>αὐτὸν ἀποδοίμην δῆτ’ ἄν;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">οὐχ ὥσπερ γ’ ἐγώ.</l>
 				</sp>
@@ -555,7 +555,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>μὰ Δί’ ἀλλ’ ἄμεινον.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἀλλὰ τὸν ὄνον ἔξαγε.</l>
 				</sp>
@@ -585,7 +585,7 @@ bring up to P3
 					<l>ποῖον; φέρ’ ἴδωμαι τουτονί. τουτὶ τί ἦν;</l>
 					<l>τίς εἶ ποτ’ ὦνθρωπ’ ἐτεόν;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">Οὖτις νὴ Δία.</l>
 				</sp>
@@ -593,7 +593,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="185">Οὖτις σύ; ποδαπός;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">Ἴθακος Ἀποδρασιππίδου.</l>
 				</sp>
@@ -604,7 +604,7 @@ bring up to P3
 					<l>ἵν’ ὑποδέδυκεν· ὥστ’ ἔμοιγ’ ἰνδάλλεται</l>
 					<l>ὁμοιότατος κλητῆρος εἶναι πωλίῳ.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="190">εἰ μή μ’ ἐάσεθ’ ἥσυχον, μαχούμεθα.</l>
 				</sp>
@@ -612,7 +612,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>περὶ τοῦ μαχεῖ νῷν δῆτα;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">περὶ ὄνου σκιᾶς.</l>
 				</sp>
@@ -620,7 +620,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>πονηρὸς εἶ πόρρω τέχνης καὶ παράβολος.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐγὼ πονηρός; οὐ μὰ Δί’ ἀλλ’ οὐκ οἶσθα σὺ</l>
 					<l>νῦν μ’ ὄντ’ ἄριστον· ἀλλ’ ἴσως, ὅταν φάγῃς</l>
@@ -630,7 +630,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ὤθει τὸν ὄνον καὶ σαυτὸν ἐς τὴν οἰκίαν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ὦ ξυνδικασταὶ καὶ Κλέων ἀμύνατε.</l>
 				</sp>
@@ -709,7 +709,7 @@ bring up to P3
 			</div1>
 			<div1 type="Parodos">
 				<div2 met="iambic tetrameter" type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="230">χώρει πρόβαιν’ ἐρρωμένως. ὦ Κωμία βραδύνεις.</l>
 						<l>μὰ τὸν Δί’ οὐ μέντοι πρὸ τοῦ γ’, ἀλλ’ ἦσθ’ ἱμὰς κύνειος·</l>
@@ -734,7 +734,7 @@ bring up to P3
 						<speaker>Παίς</speaker>
 						<l>τὸν πηλὸν ὦ πάτερ πάτερ τουτονὶ φύλαξαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κάρφος χαμᾶθέν νυν λαβὼν τὸν λύχνον πρόμυξον.</l>
 					</sp>
@@ -742,7 +742,7 @@ bring up to P3
 						<speaker>Παίς</speaker>
 						<l n="250">οὔκ, ἀλλὰ τῳδί μοι δοκῶ τὸν λύχνον προβύσειν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί δὴ μαθὼν τῷ δακτύλῳ τὴν θρυαλλίδ’ ὠθεῖς,</l>
 						<l>καὶ ταῦτα τοὐλαίου σπανίζοντος ὦνόητε;</l>
@@ -755,7 +755,7 @@ bring up to P3
 						<l>κἄπειτ’ ἴσως ἐν τῷ σκότῳ τουτουὶ στερηθεὶς</l>
 						<l>τὸν πηλὸν ὥσπερ ἀτταγᾶς τυρβάσεις βαδίζων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ μὴν ἐγὼ σοῦ χἀτέρους μείζονας κολάζω.</l>
 						<l>ἀλλ’ οὑτοσί μοι βόρβορος φαίνεται πατοῦντι·</l>
@@ -776,7 +776,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί ποτ’ οὐ πρὸ θυρῶν φαίνετ’ ἄρ’ ἡμῖν ὁ γέρων οὐδ’ ὑπακούει;</l>
 						<l>μῶν ἀπολώλεκε τὰς</l>
@@ -815,7 +815,7 @@ bring up to P3
 						<l>ἐθελήσεις τί μοι οὖν ὦ</l>
 						<l>πάτερ, ἤν σού τι δεηθῶ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάνυ γ’ ὦ παιδίον. ἀλλ’ εἰπέ,</l>
 						<l>τί βούλει με πρίασθαι</l>
@@ -827,7 +827,7 @@ bring up to P3
 						<l>μὰ Δί’ ἀλλ’ ἰσχάδας ὦ παππία·</l>
 						<l>ἥδιον γάρ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">οὐκ ἂν</l>
 						<l>μὰ Δί’, εἰ κρέμαισθέ γ’ ὑμεῖς.</l>
@@ -836,7 +836,7 @@ bring up to P3
 						<speaker>Παίς</speaker>
 						<l>μὰ Δί’ οὔ τἄρα προπέμψω σε τὸ λοιπόν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="300">ἀπὸ γὰρ τοῦδέ με τοῦ μισθαρίου</l>
 						<l>τρίτον αὐτὸν ἔχειν ἄλφιτα δεῖ καὶ ξύλα κὤψον·</l>
@@ -854,7 +854,7 @@ bring up to P3
 						<l>χρηστήν τινα νῷν ἢ</l>
 						<l>πόρον Ἕλλας ἱρὸν &lt;εὑρεῖν&gt;;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀπαπαῖ φεῦ, &lt;ἀπαπαῖ φεῦ,&gt;</l>
 						<l n="310">μὰ Δί’ οὐκ ἔγωγε νῷν οἶδ’</l>
@@ -864,7 +864,7 @@ bring up to P3
 						<speaker>Παίς</speaker>
 						<l>τί με δῆτ’ ὦ μελέα μῆτερ ἔτικτες;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἵν’ ἐμοὶ πράγματα βόσκειν παρέχῃς.</l>
 					</sp>
@@ -876,7 +876,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="monody">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>φίλοι, τήκομαι μὲν</l>
 						<l>πάλαι διὰ τῆς ὀπῆς</l>
@@ -904,7 +904,7 @@ bring up to P3
 			</div1>
 			<div1 type="Agon">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς γάρ ἐσθ’ ὁ ταῦτά σ’ εἵργων</l>
 						<l n="335">κἀποκλῄων τῇ θύρᾳ; λέξον·</l>
@@ -913,17 +913,17 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="proepirrheme">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οὑμὸς υἱός. ἀλλὰ μὴ βοᾶτε· καὶ γὰρ τυγχάνει</l>
 						<l>οὑτοσὶ πρόσθεν καθεύδων. ἀλλ’ ὕφεσθε τοῦ τόνου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοῦ δ’ ἔφεξιν ὦ μάταιε ταῦτα δρᾶν σε βούλεται;</l>
 						<l>&lt;καὶ&gt; τίνα πρόφασιν ἔχων;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="340">οὐκ ἐᾷ μ’ ὦνδρες δικάζειν οὐδὲ δρᾶν οὐδὲν κακόν,</l>
 						<l>ἀλλά μ’ εὐωχεῖν ἕτοιμός ἐστ’· ἐγὼ δ’ οὐ βούλομαι.</l>
@@ -931,7 +931,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τοῦτ’ ἐτόλμησ’ ὁ μιαρὸς χανεῖν</l>
 						<l n="342b">ὁ Δημολογοκλέων &lt;ὅδ’,&gt;</l>
@@ -944,7 +944,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="346">ἀλλ’ ἐκ τούτων ὥρα τινά σοι ζητεῖν καινὴν ἐπίνοιαν,</l>
 						<l>ἥτις σε λάθρᾳ τἀνδρὸς τουδὶ καταβῆναι δεῦρο ποιήσει.</l>
@@ -952,27 +952,27 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="epirrheme">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>τίς ἂν οὖν εἴη; ζητεῖθ’ ὑμεῖς, ὡς πᾶν &lt;ἂν&gt; ἔγωγε ποιοίην·</l>
 						<l>οὕτω κιττῶ διὰ τῶν σανίδων μετὰ χοιρίνης περιελθεῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="350">ἔστιν ὀπὴ δῆθ’ ἥντιν’ ἂν ἔνδοθεν οἷός τ’ εἴης διορύξαι,</l>
 						<l>εἶτ’ ἐκδῦναι ῥάκεσιν κρυφθεὶς ὥσπερ πολύμητις Ὀδυσσεύς;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>πάντα πέφαρκται κοὐκ ἔστιν ὀπῆς οὐδ’ εἰ σέρφῳ διαδῦναι.</l>
 						<l>ἀλλ’ ἄλλο τι δεῖ ζητεῖν ὑμᾶς· ὀπίαν δ’ οὐκ ἔστι γενέσθαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="354">μέμνησαι δῆθ’, ὅτ’ ἐπὶ στρατιᾶς κλέψας ποτὲ τοὺς ὀβελίσκους</l>
 						<l>ἵεις σαυτὸν κατὰ τοῦ τείχους ταχέως, ὅτε Νάξος ἑάλω.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οἶδ’· ἀλλὰ τί τοῦτ’; οὐδὲν γὰρ τοῦτ’ ἐστὶν ἐκείνῳ προσόμοιον.</l>
 						<l>ἥβων γὰρ κἀδυνάμην κλέπτειν, ἴσχυόν τ’ αὐτὸς ἐμαυτοῦ,</l>
@@ -980,7 +980,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="pnigos">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>κοὐδείς μ’ ἐφύλαττ’, ἀλλ’ ἐξῆν μοι</l>
 						<l>φεύγειν ἀδεῶς. νῦν δὲ ξὺν ὅπλοις</l>
@@ -993,7 +993,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="365">ἀλλὰ καὶ νῦν ἐκπόριζε</l>
 						<l>μηχανὴν ὅπως τάχισθ’· ἕως</l>
@@ -1002,17 +1002,17 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antiproepirrheme">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>διατραγεῖν τοίνυν κράτιστόν ἐστί μοι τὸ δίκτυον.</l>
 						<l>ἡ δέ μοι Δίκτυννα συγγνώμην ἔχοι τοῦ δικτύου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ταῦτα μὲν πρὸς ἀνδρός ἐστ’ ἄνοντος ἐς σωτηρίαν.</l>
 						<l n="370">ἀλλ’ ἔπαγε τὴν γνάθον.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>διατέτρωκται τοῦτό γ’. ἀλλὰ μὴ βοᾶτε μηδαμῶς,</l>
 						<l>ἀλλὰ τηρώμεσθ’ ὅπως μὴ Βδελυκλέων αἰσθήσεται.</l>
@@ -1020,7 +1020,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδὲν ὦ τᾶν δέδιθι, μηδέν·</l>
 						<l>ὡς ἐγὼ τοῦτόν γ’, ἐὰν γρύξῃ</l>
@@ -1033,7 +1033,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="antikatakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="379">ἀλλ’ ἐξάψας διὰ τῆς θυρίδος τὸ καλῴδιον εἶτα καθίμα</l>
 						<l>δήσας σαυτὸν καὶ τὴν ψυχὴν ἐμπλησάμενος Διοπείθους.</l>
@@ -1041,27 +1041,27 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="antepirrheme">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ἄγε νυν, ἢν αἰσθομένω τούτω ζητῆτόν μ’ ἐσκαλαμᾶσθαι</l>
 						<l>κἀνασπαστὸν ποιεῖν εἴσω, τί ποιήσετε; φράζετε νυνί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀμυνοῦμέν σοι τὸν πρινώδη θυμὸν ἅπαντες καλέσαντες</l>
 						<l>ὥστ’ οὐ δυνατόν σ’ εἵργειν ἔσται· τοιαῦτα ποιήσομεν ἡμεῖς.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="385">δράσω τοίνυν ὑμῖν πίσυνος, καὶ — μανθάνετ’; — ἤν τι πάθω ’γώ,</l>
 						<l>ἀνελόντες καὶ κατακλαύσαντες θεῖναί μ’ ὑπὸ τοῖσι δρυφάκτοις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδὲν πείσει· μηδὲν δείσῃς. ἀλλ’ ὦ βέλτιστε καθίει</l>
 						<l>σαυτὸν θαρρῶν κἀπευξάμενος τοῖσι πατρῴοισι θεοῖσιν.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="389">ὦ Λύκε δέσποτα, γείτων ἥρως· σὺ γὰρ οἷσπερ ἐγὼ κεχάρησαι,</l>
 						<l>τοῖς δακρύοισιν τῶν φευγόντων ἀεὶ καὶ τοῖς ὀλοφυρμοῖς·</l>
@@ -1074,7 +1074,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l n="395">οὗτος ἐγείρου.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">τί τὸ πρᾶγμ’;</l>
 					</sp>
@@ -1082,7 +1082,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l part="Y">ὥσπερ φωνή μέ τις ἐγκεκύκλωται.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>μῶν ὁ γέρων πῃ διαδύεται &lt;αὖ&gt;;</l>
 					</sp>
@@ -1091,7 +1091,7 @@ bring up to P3
 						<l part="Y">μὰ Δί’ οὐ δῆτ’, ἀλλὰ καθιμᾷ</l>
 						<l>αὑτὸν δήσας.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">ὦ μιαρώτατε τί ποιεῖς; οὐ μὴ καταβήσει;</l>
 					</sp>
@@ -1100,7 +1100,7 @@ bring up to P3
 						<l>ἀνάβαιν’ ἀνύσας κατὰ τὴν ἑτέραν καὶ ταῖσιν φυλλάσι παῖε,</l>
 						<l>ἤν πως πρύμνην ἀνακρούσηται πληγεὶς ταῖς εἰρεσιώναις.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οὐ ξυλλήψεσθ’ ὁπόσοισι δίκαι τῆτες μέλλουσιν ἔσεσθαι,</l>
 						<l>ὦ Σμικυθίων καὶ Τεισιάδη καὶ Χρήμων καὶ Φερέδειπνε;</l>
@@ -1111,7 +1111,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰπέ μοι τί μέλλομεν κινεῖν ἐκείνην τὴν χολήν,</l>
 						<l n="404">ἥνπερ, ἡνίκ’ ἄν τις ἡμῶν ὀργίσῃ τὴν σφηκιάν;</l>
@@ -1130,7 +1130,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l n="415">ὦγαθοὶ τὸ πρᾶγμ’ ἀκούσατ’, ἀλλὰ μὴ κεκράγετε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νὴ Δί’ ἐς τὸν οὐρανόν γ’.</l>
 					</sp>
@@ -1138,7 +1138,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l part="Y">ὡς τοῦδ’ ἐγὼ οὐ μεθήσομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ταῦτα δῆτ’ οὐ δεινὰ καὶ τυραννίς ἐστιν ἐμφανής;</l>
 						<l>ὦ πόλις καὶ Θεώρου θεοισεχθρία,</l>
@@ -1147,7 +1147,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="420">Ἡράκλεις καὶ κέντρ’ ἔχουσιν. οὐχ ὁρᾷς ὦ δέσποτα;</l>
 					</sp>
@@ -1155,25 +1155,25 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>οἷς γ’ ἀπώλεσαν Φίλιππον ἐν δίκῃ τὸν Γοργίου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ σέ γ’ αὐτοῖς ἐξολοῦμεν· ἀλλὰ πᾶς ἐπίστρεφε</l>
 						<l>δεῦρο κἀξείρας τὸ κέντρον εἶτ’ ἐπ’ αὐτὸν ἵεσο,</l>
 						<l>ξυσταλεὶς εὔτακτος ὀργῆς καὶ μένους ἐμπλήμενος,</l>
 						<l n="425">ὡς ἂν εὖ εἰδῇ τὸ λοιπὸν σμῆνος οἷον ὤργισεν.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>τοῦτο μέντοι δεινὸν ἤδη νὴ Δί’, εἰ μαχούμεθα·</l>
 						<l>ὡς ἔγωγ’ αὐτῶν ὁρῶν δέδοικα τὰς ἐγκεντρίδας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἀφίει τὸν ἄνδρ’· εἰ δὲ μή, φήμ’ ἐγὼ</l>
 						<l>τὰς χελώνας μακαριεῖν σε τοῦ δέρματος.</l>
 						<milestone ed="p" n="430" unit="card"/>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="430">εἶά νυν ὦ ξυνδικασταὶ σφῆκες ὀξυκάρδιοι,</l>
 						<l>οἱ μὲν ἐς τὸν πρωκτὸν αὐτῶν ἐσπέτεσθ’ ὠργισμένοι,</l>
@@ -1186,17 +1186,17 @@ bring up to P3
 						<l n="435">εἰ δὲ μή, ’ν πέδαις παχείαις οὐδὲν ἀριστήσετε.</l>
 						<l>ὡς ἐγὼ πολλῶν ἀκούσας οἶδα θρίων τὸν ψόφον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δὲ μὴ τοῦτον μεθήσεις, ἔν τί σοι παγήσεται.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ὦ Κέκροψ ἥρως ἄναξ τὰ πρὸς ποδῶν Δρακοντίδη,</l>
 						<l>περιορᾷς οὕτω μ’ ὑπ’ ἀνδρῶν βαρβάρων χειρούμενον,</l>
 						<l n="440">οὓς ἐγὼ ’δίδαξα κλάειν τέτταρ’ ἐς τὴν χοίνικα;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἶτα δῆτ’ οὐ πόλλ’ ἔνεστι δεινὰ τῷ γήρᾳ κακά;</l>
 						<l>δηλαδή· καὶ νῦν γε τούτω τὸν παλαιὸν δεσπότην</l>
@@ -1206,7 +1206,7 @@ bring up to P3
 						<l>ὥστε μὴ ῥιγῶν ἑκάστοτ’· ἀλλὰ τούτοις γ’ οὐκ ἔνι</l>
 						<l>οὐδ’ ἐν ὀφθαλμοῖσιν αἰδὼς τῶν παλαιῶν ἐμβάδων.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οὐκ ἀφήσεις οὐδὲ νυνί μ’ ὦ κάκιστον θηρίον,</l>
 						<l>οὐδ’ ἀναμνησθεὶς ὅθ’ εὑρὼν τοὺς βότρυς κλέπτοντά σε</l>
@@ -1214,7 +1214,7 @@ bring up to P3
 						<l>ὥστε σε ζηλωτὸν εἶναι; σὺ δ’ ἀχάριστος ἦσθ’ ἄρα.</l>
 						<l>ἀλλ’ ἄνες με καὶ σὺ καὶ σύ, πρὶν τὸν υἱὸν ἐκδραμεῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ τούτων μὲν τάχ’ ἡμῖν δώσετον καλὴν δίκην,</l>
 						<l>οὐκέτ’ ἐς μακρὰν ἵν’ εἰδῆθ’ οἷός ἐστ’ ἀνδρῶν τρόπος</l>
@@ -1224,7 +1224,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>παῖε παἶ ὦ Ξανθία τοὺς σφῆκας ἀπὸ τῆς οἰκίας.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>ἀλλὰ δρῶ τοῦτ’· ἀλλὰ καὶ σὺ τῦφε πολλῷ τῷ καπνῷ.</l>
 					</sp>
@@ -1232,7 +1232,7 @@ bring up to P3
 						<speaker>Σωσίας</speaker>
 						<l>οὐχὶ σοῦσθ’; οὐκ ἐς κόρακας; οὐκ ἄπιτε; παῖε τῷ ξύλῳ.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>καὶ σὺ προσθεὶς Αἰσχίνην ἔντυφε τὸν Σελλαρτίου.</l>
 						<l n="460">ἆρ’ ἐμέλλομέν ποθ’ ὑμᾶς ἀποσοβήσειν τῷ χρόνῳ.</l>
@@ -1245,7 +1245,7 @@ bring up to P3
 						<l>ἀλλὰ μὰ Δί’ οὐ ῥᾳδίως οὕτως ἂν αὐτοὺς διέφυγες,</l>
 						<l>εἴπερ ἔτυχον τῶν μελῶν τῶν Φιλοκλέους βεβρωκότες.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆρα δῆτ’ οὐκ αὐτὰ δῆλα</l>
 						<l>τοῖς πένησιν, ἡ τυραννὶς</l>
@@ -1261,7 +1261,7 @@ bring up to P3
 						<l>ἔσθ’ ὅπως ἄνευ μάχης καὶ τῆς κατοξείας βοῆς</l>
 						<l>ἐς λόγους ἔλθοιμεν ἀλλήλοισι καὶ διαλλαγάς;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σοὐς λόγους ὦ μισόδημε καὶ μοναρχίας ἐραστά,</l>
 						<l n="475">καὶ ξυνὼν Βρασίδᾳ καὶ φορῶν κράσπεδα</l>
@@ -1277,7 +1277,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="480">οὐδὲ μὴν οὐδ’ ἐν σελίνῳ σοὐστὶν οὐδ’ ἐν πηγάνῳ·</l>
 						<l>τοῦτο γὰρ παρεμβαλοῦμεν τῶν τριχοινίκων ἐπῶν.</l>
@@ -1289,7 +1289,7 @@ bring up to P3
 						<l>ἆρ’ ἂν ὦ πρὸς τῶν θεῶν ὑμεῖς ἀπαλλαχθεῖτέ μου;</l>
 						<l n="485">ἢ δέδοκταί μοι δέρεσθαι καὶ δέρειν δῑ ἡμέρας;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδέποτέ γ’, οὐχ ἕως ἄν τί μου λοιπὸν ᾖ,</l>
 						<l>ὅστις ἡμῶν ἐπὶ τυραννίδ’ ὧδ’ ἐστάλης.</l>
@@ -1310,7 +1310,7 @@ bring up to P3
 						<l>‘εἰπέ μοι, γήτειον αἰτεῖς· πότερον ἐπὶ τυραννίδι,</l>
 						<l>ἢ νομίζεις τὰς Ἀθήνας σοὶ φέρειν ἡδύσματα;’</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="500">κἀμέ γ’ ἡ πόρνη χθὲς εἰσελθόντα τῆς μεσημβρίας,</l>
 						<l>ὅτι κελητίσαι ’κέλευον, ὀξυθυμηθεῖσά μοι</l>
@@ -1324,7 +1324,7 @@ bring up to P3
 						<l>ζῆν βίον γενναῖον ὥσπερ Μόρυχος, αἰτίαν ἔχω</l>
 						<l>ταῦτα δρᾶν ξυνωμότης ὢν καὶ φρονῶν τυραννικά.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>νὴ Δί’ ἐν δίκῃ γ’· ἐγὼ γὰρ οὐδ’ ἂν ὀρνίθων γάλα</l>
 						<l>ἀντὶ τοῦ βίου λάβοιμ’ ἂν οὗ με νῦν ἀποστερεῖς·</l>
@@ -1337,7 +1337,7 @@ bring up to P3
 						<l>ἀλλ’ ἐὰν σιγῶν ἀνάσχῃ καὶ μάθῃς ἁγὼ λέγω,</l>
 						<l>ἀναδιδάξειν οἴομαί σ’ ὡς πάντα ταῦθ’ ἁμαρτάνεις.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="515">ἐξαμαρτάνω δικάζων;</l>
 					</sp>
@@ -1347,7 +1347,7 @@ bring up to P3
 						<l>οὐκ ἐπαϊεις ὑπ’ ἀνδρῶν, οὓς σὺ μόνον οὐ προσκυνεῖς.</l>
 						<l>ἀλλὰ δουλεύων λέληθας.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">παῦε δουλείαν λέγων,</l>
 						<l>ὅστις ἄρχω τῶν ἁπάντων.</l>
@@ -1358,7 +1358,7 @@ bring up to P3
 						<l>οἰόμενος ἄρχειν· ἐπεὶ δίδαξον ἡμᾶς ὦ πάτερ,</l>
 						<l n="520">ἥτις ἡ τιμή ’στί σοι καρπουμένῳ τὴν Ἑλλάδα.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>πάνυ γε, καὶ τούτοισί γ’ ἐπιτρέψαι ’θέλω.</l>
 					</sp>
@@ -1367,7 +1367,7 @@ bring up to P3
 						<l part="Y">καὶ μὴν ἐγώ.</l>
 						<l>ἄφετέ νυν ἅπαντες αὐτόν.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">καὶ ξίφος γέ μοι δότε.</l>
 						<l>ἢν γὰρ ἡττηθῶ λέγων σου, περιπεσοῦμαι τῷ ξίφει.</l>
@@ -1376,7 +1376,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>εἰπέ μοι, τί δ’ ἤν, τὸ δεῖνα, τῇ διαίτῃ μὴ ’μμένῃς;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="525">μηδέποτε πίοιμ’ ἀκράτου μισθὸν ἀγαθοῦ δαίμονος.</l>
 						<milestone ed="p" n="526" unit="card"/>
@@ -1385,7 +1385,7 @@ bring up to P3
 			</div1>
 			<div1 type="Agon">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν δὴ τὸν ἐκ θἠμετέρου</l>
 						<l>γυμνασίου δεῖ τι λέγειν</l>
@@ -1396,7 +1396,7 @@ bring up to P3
 						<l>ἐνεγκάτω μοι δεῦρο τὴν κίστην τις ὡς τάχιστα.</l>
 						<l n="530">ἀτὰρ φανεῖ ποῖός τις ὤν, ἢν ταῦτα παρακελεύῃ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μὴ κατὰ τὸν νεανίαν</l>
 						<l>τονδὶ λέγων. ὁρᾷς γὰρ ὥς</l>
@@ -1409,11 +1409,11 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>καὶ μὴν ὅσ’ ἂν λέξῃ γ’ ἁπλῶς μνημόσυνα γράψομαι ’γώ.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>τί γὰρ φάθ’ ὑμεῖς, ἢν ὁδί με τῷ λόγῳ κρατήσῃ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="540">οὐκέτι πρεσβυτῶν ὄχλος</l>
 						<l>χρήσιμος ἔστ’ οὐδ’ ἀκαρῆ·</l>
@@ -1424,7 +1424,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="katakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="546">ἀλλ’ ὦ περὶ τῆς πάσης μέλλων βασιλείας ἀντιλογήσειν</l>
 						<l>τῆς ἡμετέρας, νυνὶ θαρρῶν πᾶσαν γλῶτταν βασάνιζε.</l>
@@ -1432,7 +1432,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="epirrheme">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>καὶ μὴν εὐθύς γ’ ἀπὸ βαλβίδων περὶ τῆς ἀρχῆς ἀποδείξω</l>
 						<l>τῆς ἡμετέρας ὡς οὐδεμιᾶς ἥττων ἐστὶν βασιλείας.</l>
@@ -1450,7 +1450,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>τουτὶ περὶ τῶν ἀντιβολούντων ἔστω τὸ μνημόσυνόν μοι.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="560">εἶτ’ εἰσελθὼν ἀντιβοληθεὶς καὶ τὴν ὀργὴν ἀπομορχθεὶς</l>
 						<l>ἔνδον τούτων ὧν ἂν φάσκω πάντων οὐδὲν πεποίηκα,</l>
@@ -1475,7 +1475,7 @@ bring up to P3
 						<l>δεύτερον αὖ σου τουτὶ γράφομαι, τὴν τοῦ πλούτου καταχήνην·</l>
 						<l>καὶ τἀγαθά μοι μέμνησ’ ἅχεις φάσκων τῆς Ἑλλάδος ἄρχειν.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>παίδων τοίνυν δοκιμαζομένων αἰδοῖα πάρεστι θεᾶσθαι.</l>
 						<l>κἂν Οἴαγρος εἰσέλθῃ φεύγων, οὐκ ἀποφεύγει πρὶν ἂν ἡμῖν</l>
@@ -1493,7 +1493,7 @@ bring up to P3
 						<l>τουτὶ γάρ τοι σεμνόν, τούτων ὧν εἴρηκας μακαρίζω·</l>
 						<l>τῆς δ’ ἐπικλήρου τὴν διαθήκην ἀδικεῖς ἀνακογχυλιάζων.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="590">ἔτι δ’ ἡ βουλὴ χὠ δῆμος ὅταν κρῖναι μέγα πρᾶγμ’ ἀπορήσῃ</l>
 						<l>ἐψήφισται τοὺς ἀδικοῦντας τοῖσι δικασταῖς παραδοῦναι·</l>
@@ -1515,7 +1515,7 @@ bring up to P3
 						<l>πρωκτὸς λουτροῦ περιγιγνόμενος τῆς ἀρχῆς τῆς περισέμνου.</l>
 						<milestone ed="p" n="605" unit="card"/>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="605">ὃ δέ γ’ ἥδιστον τούτων ἐστὶν πάντων, οὗ ’γὼ ’πελελήσμην,</l>
 						<l>ὅταν οἴκαδ’ ἴω τὸν μισθὸν ἔχων, κἄπειθ’ ἥκονθ’ ἅμα πάντες</l>
@@ -1536,7 +1536,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="pnigos">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ὅστις ἀκούω ταὔθ’ ἅπερ ὁ Ζεύς;</l>
 						<l>ἢν γοῦν ἡμεῖς θορυβήσωμεν,</l>
@@ -1553,18 +1553,18 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐπώποθ’ οὕτω καθαρῶς</l>
 						<l>οὐδενὸς ἠκούσαμεν οὐδὲ</l>
 						<l>ξυνετῶς λέγοντος.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οὔκ, ἀλλ’ ἐρήμας ᾤεθ’ οὕτω ῥᾳδίως τρυγήσειν.</l>
 						<l n="635">καλῶς γὰρ ᾔδειν ὡς ἐγὼ ταύτῃ κράτιστός εἰμι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς δ’ ἐπὶ πάντ’ ἐλήλυθεν</l>
 						<l>κοὐδὲν παρῆλθεν, ὥστ’ ἔγωγ’</l>
@@ -1573,7 +1573,7 @@ bring up to P3
 						<l n="640">αὐτὸς ἔδοξα νήσοις,</l>
 						<l>ἡδόμενος λέγοντι.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ὡς οὗτος ἤδη σκορδινᾶται κἄστιν οὐκ ἐν αὑτοῦ.</l>
 					</sp>
@@ -1581,7 +1581,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>ἦ μὴν ἐγώ σε τήμερον σκύτη βλέπειν ποιήσω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεῖ δέ σε παντοίας πλέκειν</l>
 						<l n="645">εἰς ἀπόφυξιν παλάμας.</l>
@@ -1592,7 +1592,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="antikatakeleusmenos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="648">πρὸς ταῦτα μύλην ἀγαθὴν ὥρα ζητεῖν σοι καὶ νεόκοπτον,</l>
 						<l>ἢν μή τι λέγῃς, ἥτις δυνατὴ τὸν ἐμὸν θυμὸν κατερεῖξαι.</l>
@@ -1606,7 +1606,7 @@ bring up to P3
 						<l>ἰάσασθαι νόσον ἀρχαίαν ἐν τῇ πόλει ἐντετοκυῖαν.</l>
 						<l>ἀτὰρ ὦ πάτερ ἡμέτερε Κρονίδη —</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">παῦσαι καὶ μὴ πατέριζε.</l>
 						<l>εἰ μὴ γὰρ ὅπως δουλεύω ’γώ, τουτὶ ταχέως με διδάξεις,</l>
@@ -1624,7 +1624,7 @@ bring up to P3
 						<l>ἓξ χιλιάσιν, κοὔπω πλείους ἐν τῇ χώρᾳ κατένασθεν,</l>
 						<l>γίγνεται ἡμῖν ἑκατὸν δήπου καὶ πεντήκοντα τάλαντα.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οὐδ’ ἡ δεκάτη τῶν προσιόντων ἡμῖν ἄρ’ ἐγίγνεθ’ ὁ μισθός.</l>
 					</sp>
@@ -1632,7 +1632,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l n="665">μὰ Δί’ οὐ μέντοι.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">καὶ ποῖ τρέπεται δὴ ’πειτα τὰ χρήματα τἄλλα;</l>
 					</sp>
@@ -1653,7 +1653,7 @@ bring up to P3
 						<l>σοὶ δ’ ὧν ἄρχεις, πολλὰ μὲν ἐν γῇ πολλὰ δ’ ἐφ’ ὑγρᾷ πιτυλεύσας,</l>
 						<l>οὐδεὶς οὐδὲ σκορόδου κεφαλὴν τοῖς ἑψητοῖσι δίδωσιν.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="680">μὰ Δί’ ἀλλὰ παρ’ Εὐχαρίδου καὐτὸς τρεῖς γ’ ἄγλιθας μετέπεμψα.</l>
 						<l>ἀλλ’ αὐτήν μοι τὴν δουλείαν οὐκ ἀποφαίνων ἀποκναίεις.</l>
@@ -1676,7 +1676,7 @@ bring up to P3
 						<l n="695">σὺ δὲ χασκάζεις τὸν κωλακρέτην, τὸ δὲ πραττόμενόν σε λέληθεν.</l>
 						<milestone ed="p" n="696" unit="card"/>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ταυτί με ποιοῦσ’; οἴμοι τί λέγεις; ὥς μου τὸν θῖνα ταράττεις,</l>
 						<l>καὶ τὸν νοῦν μου προσάγεις μᾶλλον, κοὐκ οἶδ’ ὅ τι χρῆμά με ποιεῖς.</l>
@@ -1699,7 +1699,7 @@ bring up to P3
 						<l>ἄξια τῆς γῆς ἀπολαύοντες καὶ τοῦ ’ν Μαραθῶνι τροπαίου.</l>
 						<l>νῦν δ’ ὥσπερ ἐλαολόγοι χωρεῖθ’ ἅμα τῷ τὸν μισθὸν ἔχοντι.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οἴμοι τί πέπονθ’; ὡς νάρκη μου κατὰ τῆς χειρὸς καταχεῖται,</l>
 						<l>καὶ τὸ ξίφος οὐ δύναμαι κατέχειν, ἀλλ’ ἤδη μαλθακός εἰμι.</l>
@@ -1726,7 +1726,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="sphragis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="725">ἦ που σοφὸς ἦν ὅστις ἔφασκεν, πρὶν ἂν ἀμφοῖν μῦθον ἀκούσῃς,</l>
 						<l>οὐκ ἂν δικάσαις. σὺ γὰρ οὖν νῦν μοι νικᾶν πολλῷ δεδόκησαι·</l>
@@ -1738,7 +1738,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πιθοῦ πιθοῦ λόγοισι, μηδ’ ἄφρων γένῃ</l>
 						<l n="730">μηδ’ ἀτενὴς ἄγαν ἀτεράμων τ’ ἀνήρ.</l>
@@ -1764,7 +1764,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νενουθέτηκεν αὑτὸν ἐς τὰ πράγμαθ’, οἶς</l>
 						<l>τότ’ ἐπεμαίνετ’· ἔγνωκε γὰρ ἀρτίως,</l>
@@ -1777,7 +1777,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ἰώ μοί μοι.</l>
 					</sp>
@@ -1785,7 +1785,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l part="Y">οὗτος τί βοᾷς;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="750">μή μοι τούτων μηδὲν ὑπισχνοῦ.</l>
 						<l>κείνων ἔραμαι, κεῖθι γενοίμαν,</l>
@@ -1805,7 +1805,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="760">ἴθ’ ὦ πάτερ πρὸς τῶν θεῶν ἐμοὶ πιθοῦ.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τί σοι πίθωμαι; λέγ’ ὅ τι βούλει πλὴν ἑνός.</l>
 				</sp>
@@ -1813,7 +1813,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ποίου; φέρ’ ἴδω.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">τοῦ μὴ δικάζειν. τοῦτο δὲ</l>
 					<l>Ἅιδης διακρινεῖ πρότερον ἢ ’γὼ πείσομαι.</l>
@@ -1824,7 +1824,7 @@ bring up to P3
 					<l n="765">ἐκεῖσε μὲν μηκέτι βάδιζ’, ἀλλ’ ἐνθάδε</l>
 					<l>αὐτοῦ μένων δίκαζε τοῖσιν οἰκέταις.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>περὶ τοῦ; τί ληρεῖς;</l>
 				</sp>
@@ -1840,7 +1840,7 @@ bring up to P3
 					<l>ὕοντος εἴσει· κἄν ἔγρῃ μεσημβρινός,</l>
 					<l n="775">οὐδείς σ’ ἀποκλῄσει θεσμοθέτης τῇ κιγκλίδι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τουτί μ’ ἀρέσκει.</l>
 				</sp>
@@ -1850,7 +1850,7 @@ bring up to P3
 					<l>λέγῃ μακράν τις, οὐχὶ πεινῶν ἀναμενεῖς</l>
 					<l>δάκνων σεαυτὸν καὶ τὸν ἀπολογούμενον.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>πῶς οὖν διαγιγνώσκειν καλῶς δυνήσομαι</l>
 					<l n="780">ὥσπερ πρότερον τὰ πράγματ’ ἔτι μασώμενος;</l>
@@ -1861,7 +1861,7 @@ bring up to P3
 					<l>ὡς οἱ δικασταὶ ψευδομένων τῶν μαρτύρων</l>
 					<l>μόλις τὸ πρᾶγμ’ ἔγνωσαν ἀναμασώμενοι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἀνά τό με πείθεις. ἀλλ’ ἐκεῖν’ οὔπω λέγεις,</l>
 					<l n="785">τὸν μισθὸν ὁπόθεν λήψομαι.</l>
@@ -1870,7 +1870,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">παρ’ ἐμοῦ.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">καλῶς,</l>
 					<l>ὁτιὴ κατ’ ἐμαυτὸν κοὐ μεθ’ ἑτέρου λήψομαι.</l>
@@ -1886,7 +1886,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">ὁ δὲ τί πρὸς ταῦτ’ εἶφ’;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ὅ τι;</l>
 					<l>ἀλεκτρυόνος μ’ ἔφασκε κοιλίαν ἔχειν·</l>
@@ -1896,7 +1896,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ὁρᾷς ὅσον καὶ τοῦτο δῆτα κερδανεῖς.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>οὐ πάνυ τι μικρόν. ἀλλ’ ὅπερ μέλλεις ποίει.</l>
 				</sp>
@@ -1905,7 +1905,7 @@ bring up to P3
 					<l>ἀνάμενέ νυν· ἐγὼ δὲ ταῦθ’ ἥξω φέρων.</l>
 					<milestone ed="p" n="799" unit="card"/>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ὅρα τὸ χρῆμα, τὰ λόγῑ ὡς περαίνεται.</l>
 					<l n="800">ἠκηκόη γὰρ ὡς Ἀθηναῖοί ποτε</l>
@@ -1921,7 +1921,7 @@ bring up to P3
 					<l>ἀμὶς μέν, ἢν οὐρητιάσῃς, αὑτηὶ</l>
 					<l>παρά σοι κρεμήσετ’ ἐγγὺς ἐπὶ τοῦ παττάλου.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>σοφόν γε τουτὶ καὶ γέροντι πρόσφορον</l>
 					<l n="810">ἐξηῦρες ἀτεχνῶς φάρμακον στραγγουρίας.</l>
@@ -1931,7 +1931,7 @@ bring up to P3
 					<l>καὶ πῦρ γε τουτί· καὶ προσέστηκεν φακῆ</l>
 					<l>ῥοφεῖν, ἐὰν δέῃ τι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">τοῦτ’ αὖ δεξιόν·</l>
 					<l>κἂν γὰρ πυρέττω, τόν γε μισθὸν λήψομαι.</l>
@@ -1943,7 +1943,7 @@ bring up to P3
 					<l>ἵνα γ’, ἢν καθεύδῃς ἀπολογουμένου τινός,</l>
 					<l>ᾄδων ἄνωθεν ἐξεγείρῃ σ’ οὑτοσί.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἓν ἔτι ποθῶ, τὰ δ’ ἄλλ’ ἀρέσκει μοι.</l>
 				</sp>
@@ -1951,7 +1951,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">τὸ τί;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>θἠρῷον εἴ πως ἐκκομίσαις τὸ τοῦ Λύκου.</l>
 				</sp>
@@ -1959,7 +1959,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="820">πάρεστι τουτί, καὐτὸς ἅναξ οὑτοσί.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ὦ δέσποθ’ ἥρως ὡς χαλεπὸς ἄρ’ ἦσθ’ ἰδεῖν.</l>
 				</sp>
@@ -1967,7 +1967,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>οἷόσπερ ἡμῖν φαίνεται Κλεώνυμος.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>οὔκουν ἔχει γ’ οὐδ’ αὐτὸς ἥρως ὢν ὅπλα.</l>
 				</sp>
@@ -1976,7 +1976,7 @@ bring up to P3
 					<l>εἰ θᾶττον ἐκαθίζου σύ, θᾶττον ἂν δίκην</l>
 					<l n="825">ἐκάλουν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">κάλει νυν, ὡς κάθημαι ’γὼ πάλαι.</l>
 					<milestone ed="p" n="826" unit="card"/>
@@ -1987,7 +1987,7 @@ bring up to P3
 					<l>τί τίς κακὸν δέδρακε τῶν ἐν τᾠκίᾳ;</l>
 					<l>ἡ Θρᾷττα προσκαύσασα πρώην τὴν χύτραν —</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐπίσχες οὗτος· ὡς ὀλίγου μ’ ἀπώλεσας.</l>
 					<l n="830">ἄνευ δρυφάκτου τὴν δίκην μέλλεις καλεῖν,</l>
@@ -1997,7 +1997,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>μὰ τὸν Δί’ οὐ πάρεστιν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἀλλ’ ἐγὼ δραμὼν</l>
 					<l>αὐτὸς κομιοῦμαι τό γε παραυτίκ’ ἔνδοθεν.</l>
@@ -2042,7 +2042,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>τουτὶ τί ἔστι;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">χοιροκομεῖον Ἑστίας.</l>
 				</sp>
@@ -2050,7 +2050,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="845">εἶθ’ ἱεροσυλήσας φέρεις;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">οὔκ, ἀλλ’ ἵνα</l>
 					<l>ἀφ’ Ἑστίας ἀρχόμενος ἐπιτρίψω τινά.</l>
@@ -2060,7 +2060,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>φέρε νυν ἐνέγκω τὰς σανίδας καὶ τὰς γραφάς.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>οἴμοι διατρίβεις κἀπολεῖς τριψημερῶν·</l>
 					<l n="850">ἐγὼ δ’ ἀλοκίζειν ἐδεόμην τὸ χωρίον.</l>
@@ -2069,7 +2069,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ἰδού.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">κάλει νυν.</l>
 				</sp>
@@ -2078,7 +2078,7 @@ bring up to P3
 					<l part="Y">ταῦτα δή. τίς οὑτοσὶ</l>
 					<l>ὁ πρῶτός ἐστιν;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἐς κόρακας, ὡς ἄχθομαι</l>
 					<l>ὁτιὴ ’πελαθόμην τοὺς καδίσκους ἐκφέρειν.</l>
@@ -2087,7 +2087,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>οὗτος σὺ ποῖ θεῖς;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἐπὶ καδίσκους.</l>
 				</sp>
@@ -2096,7 +2096,7 @@ bring up to P3
 					<l part="Y">μη δαμῶς.</l>
 					<l n="855">ἐγὼ γὰρ εἶχον τούσδε τοὺς ἀρυστίχους.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>κάλλιστα τοίνυν· πάντα γὰρ πάρεστι νῷν</l>
 					<l>ὅσων δεόμεθα, πλήν γε δὴ τῆς κλεψύδρας.</l>
@@ -2105,7 +2105,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ἡδὶ δὲ δὴ τίς ἐστιν; οὐχὶ κλεψύδρα;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>εὖ γ’ ἐκπορίζεις αὐτὰ κἀπιχωρίως.</l>
 				</sp>
@@ -2119,7 +2119,7 @@ bring up to P3
 			</div1>
 			<div1 type="Lyric-Scene">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ἡμεῖς ἐπὶ ταῖς σπονδαῖς</l>
 						<l>καὶ ταῖς εὐχαῖς</l>
@@ -2134,7 +2134,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>εὐφημία μὲν πρῶτα νῦν ὑπαρχέτω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Φοῖβ’ Ἄπολλον Πύθῑ ἐπ’ ἀγαθῇ τύχῃ</l>
 						<l n="870">τὸ πρᾶγμ’ ὃ μηχανᾶται</l>
@@ -2164,7 +2164,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="885">ξυνευχόμεσθα &lt;ταὐτά&gt; σοι κἀπᾴδομεν</l>
 						<l>νέαισιν ἀρχαῖς ἕνεκα τῶν προλελεγμένων.</l>
@@ -2182,7 +2182,7 @@ bring up to P3
 					<l>εἴ τις θύρασιν ἡλιαστής, εἰσίτω·</l>
 					<l>ὡς ἡνίκ’ ἂν λέγωσιν οὐκ ἐσφρήσομεν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τίς ἆρ’ ὁ φεύγων;</l>
 				</sp>
@@ -2190,7 +2190,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">οὗτος.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ὅσον ἁλώσεται.</l>
 				</sp>
@@ -2201,7 +2201,7 @@ bring up to P3
 					<l>τὸν τυρὸν ἀδικεῖν ὅτι μόνος κατήσθιεν</l>
 					<l>τὸν Σικελικόν. τίμημα κλῳὸς σύκινος.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>θάνατος μὲν οὖν κύνειος, ἢν ἅπαξ ἁλῷ.</l>
 				</sp>
@@ -2209,7 +2209,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>καὶ μὴν ὁ φεύγων οὑτοσὶ Λάβης πάρα.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="900">ὦ μιαρὸς οὗτος· ὡς δὲ καὶ κλέπτον βλέπει,</l>
 					<l>οἷον σεσηρὼς ἐξαπατήσειν μ’ οἴεται.</l>
@@ -2224,7 +2224,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>πάρεστιν οὗτος.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἕτερος οὗτος αὖ Λάβης.</l>
 				</sp>
@@ -2233,7 +2233,7 @@ bring up to P3
 					<l>ἀγαθός γ’ ὑλακτεῖν καὶ διαλείχειν τὰς χύτρας.</l>
 					<l n="905">σίγα, κάθιζε· σὺ δ’ ἀναβὰς κατηγόρει.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>φέρε νυν ἅμα τήνδ’ ἐγχεάμενος κἀγὼ ῥοφῶ.</l>
 				</sp>
@@ -2245,7 +2245,7 @@ bring up to P3
 					<l n="910">ἀποδρὰς γὰρ ἐς τὴν γωνίαν τυρὸν πολὺν</l>
 					<l>κατεσικέλιζε κἀνέπλητ’ ἐν τῷ σκότῳ —</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>νὴ τὸν Δί’ ἀλλὰ δῆλός ἐστ’· ἔμοιγέ τοι</l>
 					<l>τυροῦ κάκιστον ἀρτίως ἐνήρυγεν</l>
@@ -2257,7 +2257,7 @@ bring up to P3
 					<l n="915">καίτοι τίς ὑμᾶς εὖ ποιεῖν δυνήσεται,</l>
 					<l>ἢν μή τι κἀμοί τις προβάλλῃ τῷ κυνί;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>οὐδὲν μετέδωκεν οὐδὲ τῷ κοινῷ γ’ ἐμοί.</l>
 					<l>θερμὸς γὰρ ἁνὴρ οὐδὲν ἧττον τῆς φακῆς.</l>
@@ -2267,7 +2267,7 @@ bring up to P3
 					<l>πρὸς τῶν θεῶν μὴ προκαταγίγνωσκ’ ὦ πάτερ,</l>
 					<l n="920">πρὶν ἄν γ’ ἀκούσῃς ἀμφοτέρων.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἀλλ’ ὦγαθὲ</l>
 					<l>τὸ πρᾶγμα φανερόν ἐστιν· αὐτὸ γὰρ βοᾷ.</l>
@@ -2279,7 +2279,7 @@ bring up to P3
 					<l>ὅστις περιπλεύσας τὴν θυείαν ἐν κύκλῳ</l>
 					<l n="925">ἐκ τῶν πόλεων τὸ σκῖρον ἐξεδήδοκεν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐμοὶ δέ γ’ οὐκ ἔστ’ οὐδὲ τὴν ὑδρίαν πλάσαι.</l>
 				</sp>
@@ -2290,7 +2290,7 @@ bring up to P3
 					<l>ἵνα μὴ κεκλάγγω διὰ κενῆς ἄλλως ἐγώ·</l>
 					<l n="930">ἐὰν δὲ μή, τὸ λοιπὸν οὐ κεκλάγξομαι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἰοὺ ἰού.</l>
 					<l>ὅσας κατηγόρησε τὰς πανουργίας.</l>
@@ -2306,7 +2306,7 @@ bring up to P3
 					<l>καὶ τἄλλα, τὰ σκεύη τὰ προσκεκαυμένα.</l>
 					<l n="940">ἀλλ’ ἔτι σύ γ’ οὐρεῖς καὶ καθίζεις οὐδέπω;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τοῦτον δέ γ’ οἶμ’ ἐγὼ χεσεῖσθαι τήμερον.</l>
 				</sp>
@@ -2316,7 +2316,7 @@ bring up to P3
 					<l>καὶ ταῦτα τοῖς φεύγουσιν, ἀλλ’ ὀδὰξ ἔχει;</l>
 					<l>ἀνάβαιν’, ἀπολογοῦ. τί σεσιώπηκας; λέγε.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="945">ἀλλ’ οὐκ ἔχειν οὗτός γ’ ἔοικεν ὅ τι λέγῃ.</l>
 				</sp>
@@ -2331,7 +2331,7 @@ bring up to P3
 					<l>ἀγαθὸς γάρ ἐστι καὶ διώκει τοὺς λύκους.</l>
 					<milestone ed="p" n="953" unit="card"/>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>κλέπτης μὲν οὖν οὗτός γε καὶ ξυνωμότης.</l>
 				</sp>
@@ -2340,7 +2340,7 @@ bring up to P3
 					<l>μὰ Δί’ ἀλλ’ ἄριστός ἐστι τῶν νυνὶ κυνῶν</l>
 					<l n="955">οἷός τε πολλοῖς προβατίοις ἐφεστάναι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τί οὖν ὄφελος, τὸν τυρὸν εἰ κατεσθίει;</l>
 				</sp>
@@ -2350,7 +2350,7 @@ bring up to P3
 					<l>καὶ τἄλλ’ ἄριστός ἐστιν· εἰ δ’ ὑφείλετο,</l>
 					<l>ξύγγνωθι. κιθαρίζειν γὰρ οὐκ ἐπίσταται.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="960">ἐγὼ δ’ ἐβουλόμην ἂν οὐδὲ γράμματα,</l>
 					<l>ἵνα μὴ κακουργῶν ἐνέγραφ’ ἡμῖν τὸν λόγον.</l>
@@ -2363,7 +2363,7 @@ bring up to P3
 					<l n="965">εἰ μὴ κατέκνησας τοῖς στρατιώταις ἅλαβες.</l>
 					<l>φησὶ κατακνῆσαι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">νὴ Δί’ ἀλλὰ ψεύδεται.</l>
 				</sp>
@@ -2376,7 +2376,7 @@ bring up to P3
 					<l>αὐτοῦ μένων γὰρ ἅττ’ ἂν εἴσω τις φέρῃ</l>
 					<l>τούτων μεταιτεῖ τὸ μέρος· εἰ δὲ μή, δάκνει.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>αἰβοῖ. τί κακόν ποτ’ ἔσθ’ ὅτῳ μαλάττομαι;</l>
 					<l>κακόν τι περιβαίνει με κἀναπείθομαι.</l>
@@ -2388,7 +2388,7 @@ bring up to P3
 					<l>ἀναβαίνετ’ ὦ πόνηρα καὶ κνυζούμενα</l>
 					<l>αἰτεῖτε κἀντιβολεῖτε καὶ δακρύετε.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>κατάβα κατάβα κατάβα κατάβα.</l>
 				</sp>
@@ -2398,7 +2398,7 @@ bring up to P3
 					<l n="980">καίτοι τὸ κατάβα τοῦτο πολλοὺς δὴ πάνυ</l>
 					<l>ἐξηπάτηκεν. ἀτὰρ ὅμως καταβήσομαι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐς κόρακας. ὡς οὐκ ἀγαθόν ἐστι τὸ ῥοφεῖν.</l>
 					<l>ἐγὼ γὰρ ἀπεδάκρυσα νῦν γνώμην ἐμὴν</l>
@@ -2408,7 +2408,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="985">οὔκουν ἀποφεύγει δῆτα;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">χαλεπὸν εἰδέναι.</l>
 				</sp>
@@ -2418,7 +2418,7 @@ bring up to P3
 					<l>τηνδὶ λαβὼν τὴν ψῆφον ἐπὶ τὸν ὕστερον</l>
 					<l>μύσας παρᾷξον κἀπόλυσον ὦ πάτερ.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>οὐ δῆτα· κιθαρίζειν γὰρ οὐκ ἐπίσταμαι.</l>
 				</sp>
@@ -2426,7 +2426,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="990">φέρε νύν σε τῃδὶ τὴν ταχίστην περιάγω.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ὅδ’ ἔσθ’ ὁ πρότερος;</l>
 				</sp>
@@ -2434,7 +2434,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">οὗτος·</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">αὕτη ’νταῦθ’ ἔνι.</l>
 				</sp>
@@ -2443,7 +2443,7 @@ bring up to P3
 					<l>ἐξηπάτηται κἀπολέλυκεν οὐχ ἑκών.</l>
 					<l>φέρ’ ἐξεράσω.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">πῶς ἄρ’ ἠγωνίσμεθα;</l>
 				</sp>
@@ -2453,7 +2453,7 @@ bring up to P3
 					<l n="995">πάτερ πάτερ τί πέπονθας; οἴμοι· ποῦ ’σθ’ ὕδωρ;</l>
 					<l>ἔπαιρε σαυτόν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">εἰπέ νυν ἐκεῖνό μοι,</l>
 					<l>ὄντως ἀπέφυγε;</l>
@@ -2462,7 +2462,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">νὴ Δί’·</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">οὐδέν εἰμ’ ἄρα.</l>
 				</sp>
@@ -2470,7 +2470,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>μὴ φροντίσῃς ὦ δαιμόνῑ· ἀλλ’ ἀνίστασο.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>πῶς οὖν ἐμαυτῷ τοῦτ’ ἐγὼ ξυνείσομαι,</l>
 					<l n="1000">φεύγοντ’ ἀπολύσας ἄνδρα; τί ποτε πείσομαι;</l>
@@ -2486,7 +2486,7 @@ bring up to P3
 					<l>κοὐκ ἐγχανεῖταί σ’ ἐξαπατῶν Ὑπέρβολος.</l>
 					<l>ἀλλ’ εἰσίωμεν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">
 						ταῦτά νυν, εἴπερ δοκεῖ.
@@ -2496,7 +2496,7 @@ bring up to P3
 			</div1>
 			<div1 type="Parabasis">
 				<div2 met="anapests" type="prelude">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἴτε χαίροντες ὅποι βούλεσθ’.</l>
 						<l n="1010">ὑμεῖς δὲ τέως ὦ μυριάδες</l>
@@ -2510,7 +2510,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="parabasis">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1015">νῦν αὖτε λεὼ| προσέχετε τὸν νοῦν, εἴπερ καθαρόν τι φιλεῖτε.</l>
 						<l>μέμψασθαι γὰρ τοῖσι θεαταῖς ὁ ποιητὴς νῦν ἐπιθυμεῖ.</l>
@@ -2552,7 +2552,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="anapests" type="pnigos">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ τὸ λοιπὸν τῶν ποιητῶν</l>
 						<l>ὦ δαιμόνιοι τοὺς ζητοῦντας</l>
@@ -2567,7 +2567,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1060">ὦ πάλαι ποτ’ ὄντες ἡμεῖς ἄλκιμοι μὲν ἐν χοροῖς,</l>
 						<l>ἄλκιμοι δ’ ἐν μάχαις,</l>
@@ -2585,7 +2585,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="epirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἴ τις ὑμῶν ὦ θεαταὶ τὴν ἐμὴν ἰδὼν φύσιν</l>
 						<l>εἶτα θαυμάζει μ’ ὁρῶν μέσον διεσφηκωμένον,</l>
@@ -2611,7 +2611,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆρα δεινὸς ἦ τόθ’ ὥστε πάντα μὴ δεδοικέναι,</l>
 						<l>καὶ κατεστρεψάμην</l>
@@ -2629,7 +2629,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλαχοῦ σκοποῦντες ἡμᾶς εἰς ἅπανθ’ εὑρήσετε</l>
 						<l>τοὺς τρόπους καὶ τὴν δίαιταν σφηξὶν ἐμφερεστάτους.</l>
@@ -2656,7 +2656,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>οὔτοι ποτὲ ζῶν τοῦτον ἀποδυθήσομαι,</l>
 					<l>ἐπεὶ μόνος μ’ ἔσωσε παρατεταγμένον,</l>
@@ -2666,7 +2666,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="1125">ἀγαθὸν ἔοικας οὐδὲν ἐπιθυμεῖν παθεῖν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>μὰ τὸν Δί’ οὐ γὰρ οὐδαμῶς μοι ξύμφορον.</l>
 					<l>καὶ γὰρ πρότερον ἐπανθρακίδων ἐμπλήμενος</l>
@@ -2677,7 +2677,7 @@ bring up to P3
 					<l>ἀλλ’ οὖν πεπειράσθω γ’, ἐπειδήπερ γ’ ἅπαξ</l>
 					<l n="1130">ἐμοὶ σεαυτὸν παραδέδωκας εὖ ποιεῖν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τί οὖν κελεύεις δρᾶν με;</l>
 				</sp>
@@ -2686,7 +2686,7 @@ bring up to P3
 					<l part="Y">τὸν τρίβων’ ἄφες,</l>
 					<l>τηνδὶ δὲ χλαῖναν ἀναβαλοῦ τριβωνικῶς.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἔπειτα παῖδας χρὴ φυτεύειν καὶ τρέφειν,</l>
 					<l>ὅθ’ οὑτοσί με νῦν ἀποπνῖξαι βούλεται;</l>
@@ -2695,7 +2695,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l n="1135">ἔχ’ ἀναβαλοῦ τηνδὶ λαβὼν καὶ μὴ λάλει.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>τουτὶ τὸ κακὸν τί ἐστι πρὸς πάντων θεῶν;</l>
 				</sp>
@@ -2703,7 +2703,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>οἱ μὲν καλοῦσι Περσίδ’ οἱ δὲ καυνάκην.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐγὼ δὲ σισύραν ᾠόμην Θυμαιτίδα.</l>
 				</sp>
@@ -2712,7 +2712,7 @@ bring up to P3
 					<l>κοὐ θαῦμά γ’· ἐς Σάρδεις γὰρ οὐκ ἐλήλυθας.</l>
 					<l n="1140">ἔγνως γὰρ ἄν· νῦν δ’ οὐχὶ γιγνώσκεις.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἐγώ;</l>
 					<l>μὰ τὸν Δί’ οὐ τοίνυν· ἀτὰρ δοκεῖ γέ μοι</l>
@@ -2722,7 +2722,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>οὔκ, ἀλλ’ ἐν Ἐκβατάνοισι ταῦθ’ ὑφαίνεται.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐν Ἐκβατάνοισι γίγνεται κρόκης χόλιξ;</l>
 				</sp>
@@ -2732,7 +2732,7 @@ bring up to P3
 					<l>ὑφαίνεται πολλαῖς δαπάναις. αὕτη γέ τοι</l>
 					<l>ἐρίων τάλαντον καταπέπωκε ῥᾳδίως.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>οὔκουν ἐριώλην δῆτ’ ἐχρῆν αὐτὴν καλεῖν</l>
 					<l>δικαιότερον ἢ καυνάκην;</l>
@@ -2742,7 +2742,7 @@ bring up to P3
 					<l part="Y">ἔχ’ ὦγαθέ,</l>
 					<l n="1150">καὶ στῆθ’ ἀναμπισχόμενος.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">οἴμοι δείλαιος·</l>
 					<l>ὡς θερμὸν ἡ μιαρά τί μου κατήρυγεν.</l>
@@ -2751,7 +2751,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>οὐκ ἀναβαλεῖ;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">μὰ Δί’ οὐκ ἔγωγ’. ἀλλ’ ὦγαθέ,</l>
 					<l>εἴπερ γ’ ἀνάγκη, κρίβανόν μ’ ἀμπίσχετε.</l>
@@ -2760,7 +2760,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>φέρ’ ἀλλ’ ἐγώ σε περιβαλῶ· σὺ δ’ οὖν ἴθι.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="1155">παράθου γε μέντοι καὶ κρεάγραν.</l>
 				</sp>
@@ -2768,7 +2768,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">τιὴ τί δή;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἵν’ ἐξέλῃς με πρὶν διερρυηκέναι.</l>
 				</sp>
@@ -2777,7 +2777,7 @@ bring up to P3
 					<l>ἄγε νυν ὑπολύου τὰς καταράτους ἐμβάδας,</l>
 					<l>τασδὶ δ’ ἀνύσας † ὑπόδυθι † τὰς Λακωνικάς.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐγὼ γὰρ ἂν τλαίην ὑποδήσασθαί ποτε</l>
 					<l n="1160">ἐχθρῶν παρ’ ἀνδρῶν δυσμενῆ καττύματα;</l>
@@ -2787,7 +2787,7 @@ bring up to P3
 					<l>ἔνθες ποτ’ ὦ τᾶν κἀπόβαιν’ ἐρρωμένως</l>
 					<l>ἐς τὴν Λακωνικὴν ἀνύσας.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἀκικεῖς γέ με</l>
 					<l>ἐς τὴν πολεμίαν ἀποβιβάζων τὸν πόδα.</l>
@@ -2796,7 +2796,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>φέρε καὶ τὸν ἕτερον.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">μηδαμῶς τοῦτόν γ’, ἐπεὶ</l>
 					<l n="1165">πάνυ μισολάκων αὐτοῦ ’στιν εἷς τῶν δακτύλων.</l>
@@ -2805,7 +2805,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>οὐκ ἔστι παρὰ ταῦτ’ ἄλλα.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">κακοδαίμων ἐγώ,</l>
 					<l>ὅστις ἐπὶ γήρως χίμετλον οὐδὲν λήψομαι.</l>
@@ -2816,7 +2816,7 @@ bring up to P3
 					<l>ὡδὶ προβὰς τρυφερόν τι διασαλακώνισον.</l>
 					<milestone ed="p" n="1170" unit="card"/>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="1170">ἰδού. θεῶ τὸ σχῆμα, καὶ σκέψαι μ’ ὅτῳ</l>
 					<l>μάλιστ’ ἔοικα τὴν βάδισιν τῶν πλουσίων.</l>
@@ -2825,7 +2825,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l>ὅτῳ; Δοθιῆνι σκόροδον ἠμφιεσμένῳ.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>καὶ μὴν προθυμοῦμαί γε σαυλοπρωκτιᾶν.</l>
 				</sp>
@@ -2834,7 +2834,7 @@ bring up to P3
 					<l>ἄγε νυν, ἐπιστήσει λόγους σεμνοὺς λέγειν</l>
 					<l n="1175">ἀνδρῶν παρόντων πολυμαθῶν καὶ δεξιῶν;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἔγωγε.</l>
 				</sp>
@@ -2842,7 +2842,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">τίνα δῆτ’ ἂν λέγοις;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">πολλοὺς πάνυ.</l>
 					<l>πρῶτον μὲν ὡς ἡ Λάμῑ ἁλοῦσ’ ἐπέρδετο,</l>
@@ -2853,7 +2853,7 @@ bring up to P3
 					<l>μή ’μοί γε μύθους, ἀλλὰ τῶν ἀνθρωπίνων,</l>
 					<l n="1180">οἵους λέγομεν μάλιστα τοὺς κατ’ οἰκίαν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐγᾦδα τοίνυν τῶν γε πάνυ κατ’ οἰκίαν</l>
 					<l>ἐκεῖνον ὡς ‘οὕτω ποτ’ ἦν μῦς καὶ γαλῆ.’</l>
@@ -2864,7 +2864,7 @@ bring up to P3
 					<l>τῷ κοπρολόγῳ καὶ ταῦτα λοιδορούμενος,</l>
 					<l n="1185">μῦς καὶ γαλᾶς μέλλεις λέγειν ἐν ἀνδράσιν;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ποίους τινὰς δὲ χρὴ λέγειν;</l>
 				</sp>
@@ -2873,7 +2873,7 @@ bring up to P3
 					<l part="Y">μεγαλοπρεπεῖς,</l>
 					<l>ὡς ξυνεθεώρεις Ἀνδροκλεῖ καὶ Κλεισθένει.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἐγὼ δὲ τεθεώρηκα ποώποτ’ οὐδαμοῖ</l>
 					<l>πλὴν ἐς Πάρον, καὶ ταῦτα δὔ ὀβολὼ φέρων.</l>
@@ -2886,7 +2886,7 @@ bring up to P3
 					<l>πλευρὰν βαθυτάτην καὶ χέρας καὶ λαγόνα καὶ</l>
 					<l>θώρακ’ ἄριστον.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">παῦε παῦ’, οὐδὲν λέγεις.</l>
 					<l n="1195">πῶς ἂν μαχέσαιτο παγκράτιον θώρακ’ ἔχων;</l>
@@ -2898,7 +2898,7 @@ bring up to P3
 					<l>πίνων σεαυτοῦ ποῖον ἂν λέξαι δοκεῖς</l>
 					<l>ἐπὶ νεότητος ἔργον ἀνδρικώτατον;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="1200">ἐκεῖν’ ἐκεῖν’ ἀνδρειότατόν γε τῶν ἐμῶν,</l>
 					<l>ὅτ’ Ἐργασίωνος τὰς χάρακας ὑφειλόμην.</l>
@@ -2909,7 +2909,7 @@ bring up to P3
 					<l>ἐδιώκαθές ποτ’ ἢ λαγών, ἢ λαμπάδα</l>
 					<l>ἔδραμες, ἀνευρὼν ὅ τι νεανικώτατον.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="1205">ἐγᾦδα τοίνυν τό γε νεανικώτατον·</l>
 					<l>ὅτε τὸν δρομέα Φάυλλον ὢν βούπαις ἔτι</l>
@@ -2920,7 +2920,7 @@ bring up to P3
 					<l>παὖ· ἀλλὰ δευρὶ κατακλινεὶς προσμάνθανε</l>
 					<l>ξυμποτικὸς εἶναι καὶ ξυνουσιαστικός.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l n="1210">πῶς οὖν κατακλινῶ; φράζ’ ἀνύσας.</l>
 				</sp>
@@ -2928,7 +2928,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">εὐσχημόνως.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ὡδὶ κελεύεις κατακλινῆναι;</l>
 				</sp>
@@ -2936,7 +2936,7 @@ bring up to P3
 					<speaker>Βδελυκλέων</speaker>
 					<l part="Y">μηδαμῶς.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>πῶς δαί;</l>
 				</sp>
@@ -2949,7 +2949,7 @@ bring up to P3
 					<l>ὕδωρ κατὰ χειρός· τὰς τραπέζας ἐσφέρειν·</l>
 					<l>δειπνοῦμεν· ἀπονενίμμεθ’· ἤδη σπένδομεν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>πρὸς τῶν θεῶν ἐνύπνιον ἑστιώμεθα;</l>
 				</sp>
@@ -2960,7 +2960,7 @@ bring up to P3
 					<l>ξένος τις ἕτερος πρὸς κεφαλῆς Ἀκέστορος.</l>
 					<l>τούτοις ξυνὼν τὰ σκόλῑ ὅπως δέξει καλῶς.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l>ἄληθες; ὡς οὐδεὶς Διακρίων δέξεται.</l>
 					<milestone ed="p" n="1224" unit="card"/>
@@ -2971,7 +2971,7 @@ bring up to P3
 					<l n="1225">ᾄδω δὲ πρῶτος Ἁρμοδίου· δέξαι δὲ σύ.</l>
 					<l met="lyric">‘οὐδεὶς πώποτ’ ἀνὴρ ἔγεντ’ Ἀθήναισ’—</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l met="lyric">οὐχ οὕτω γε πανοῦργος &lt;οὐδὲ&gt; κλέπτης.</l>
 				</sp>
@@ -2981,7 +2981,7 @@ bring up to P3
 					<l>φήσει γὰρ ἐξολεῖν σε καὶ διαφθερεῖν</l>
 					<l n="1230">καὶ τῆσδε τῆς γῆς ἐξελᾶν.</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ἐγὼ δέ γε,</l>
 					<l>ἐὰν ἀπειλῇ, νὴ Δί’ ἕτερ’ ἀντᾴσομαι·</l>
@@ -3001,7 +3001,7 @@ bring up to P3
 				<sp>
 					<l n="1240">τούτῳ τί λέξεις σκόλιον;</l>
 				</sp>
-				<sp who="#filokleon">
+				<sp who="#philokleon">
 					<speaker>Φιλοκλέων</speaker>
 					<l part="Y">ᾠδικῶς ἐγώ.</l>
 				</sp>
@@ -3022,7 +3022,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>πολλὰ δὴ διεκόμπασας σὺ κἀγώ.</l>
 					</sp>
@@ -3033,7 +3033,7 @@ bring up to P3
 						<l>παῖ παῖ, τὸ δεῖπνον Χρυσὲ συσκεύαζε νῷν,</l>
 						<l>ἵνα καὶ μεθυσθῶμεν διὰ χρόνου.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">μηδαμῶς.</l>
 						<l>κακὸν τὸ πίνειν· ἀπὸ γὰρ οἴνου γίγνεται</l>
@@ -3049,7 +3049,7 @@ bring up to P3
 						<l n="1260">ὧν ἔμαθες ἐν τῷ συμποσίῳ· κᾆτ’ ἐς γέλων</l>
 						<l>τὸ πρᾶγμ’ ἔτρεψας, ὥστ’ ἀφείς σ’ ἀποιχεται.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>μαθητέον τἄρ’ ἐστὶ πολλοὺς τῶν λόγων,</l>
 						<l>εἴπερ ἀποτείσω μηδέν, ἤν τι δρῶ κακόν.</l>
@@ -3063,7 +3063,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1265">πολλάκις δὴ ’δοξ’ ἐμαυτῷ δεξειὸς πεφυκέναι</l>
 						<l>καὶ σκαιὸς οὐδεπώποτε·</l>
@@ -3081,7 +3081,7 @@ bring up to P3
 				<div2 met="trochees" type="epirrheme">
 					 
 					<!-- AEM:  was marked as "lyric" -->
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1275">ὦ μακάρῑ Αὐτόμενες ὥς σε μακαρίζομεν,</l>
 						<l>παῖδας ἐφύτευσας ὅτι χειροτεχνικωτάτους·</l>
@@ -3096,7 +3096,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>
 							<gap desc="*"/>
@@ -3104,7 +3104,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 met="trochees" type="antepirrheme">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰσί τινες οἵ μ’ ἔλεγον ὡς καταδιηλλάγην,</l>
 						<l n="1285">ἡνίκα Κλέων μ’ ὑπετάραττεν ἐπικείμενος</l>
@@ -3119,7 +3119,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>ἰὼ χελῶναι μακάριαι τοῦ δέρματος,</l>
 					<l>καὶ τρὶς μακάριαι τοῦ ’πὶ ταῖς πλευραῖς τέγους.</l>
@@ -3127,12 +3127,12 @@ bring up to P3
 					<l n="1295">κεράμῳ τὸ νῶτον ὥστε τὰς πληγὰς στέγειν.</l>
 					<l>ἐγὼ δ’ ἀπόλωλα στιζόμενος βακτηρίᾳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἔστιν ὦ παῖ; παῖδα γάρ, κἂν ᾖ γέρων,</l>
 					<l>καλεῖν δίκαιον ὅστις ἂν πληγὰς λάβῃ.</l>
 				</sp>
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>οὐ γὰρ ὁ γέρων ἀτηρότατον ἄρ’ ἦν κακὸν</l>
 					<l n="1300">καὶ τῶν ξυνόντων πολὺ παροινικώτατος;</l>
@@ -3164,7 +3164,7 @@ bring up to P3
 					<milestone ed="p" n="1326" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ἄνεχε πάρεχε·</l>
 						<l>κλαύσεταί τις τῶν ὄπισθεν</l>
@@ -3173,14 +3173,14 @@ bring up to P3
 						<l n="1330">ὦ πόνηροι ταυτῃὶ τῇ</l>
 						<l>δᾳδὶ φρυκτοὺς σκευάσω.</l>
 					</sp>
-					<sp who="#ksymotestis">
+					<sp who="#xymotes_tis">
 						<speaker>Ξυμότης τις</speaker>
 						<l>ἦ μὴν σὺ δώσεις αὔριον τούτων δίκην</l>
 						<l>ἡμῖν ἅπασι, κεἰ σφόδρ’ εἶ νεανίας.</l>
 						<l>ἁθρόοι γὰρ ἥξομέν σε προσκαλούμενοι.</l>
 						<milestone ed="p" n="1335" unit="card"/>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="1335">ἰὴ ἰεῦ, καλούμενοι.</l>
 						<l>ἀρχαῖά γ’ ὑμῶν· ἆρά γ’ ἴσθ’</l>
@@ -3191,7 +3191,7 @@ bring up to P3
 						<l>ἡλιαστής; ἐκποδών.</l>
 						<milestone ed="p" n="1342" unit="card"/>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						  
 						<!-- AEM:  why another speech tag here? -->
@@ -3225,7 +3225,7 @@ bring up to P3
 						<l n="1365">ποθεῖν ἐρᾶν τ’ ἔοικας ὡραίας σοροῦ.</l>
 						<l>οὔτοι καταπροίξει μὰ τὸν Ἀπόλλω τοῦτο δρῶν.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ὡς ἡδέως φάγοις ἂν ἐξ ὄξους δίκην.</l>
 					</sp>
@@ -3234,7 +3234,7 @@ bring up to P3
 						<l>οὐ δεινὰ τωθάζειν σε τὴν αὐλητρίδα</l>
 						<l>τῶν ξυμποτῶν κλέψαντα;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">ποίαν αὐλητρίδα;</l>
 						<l n="1370">τί ταῦτα ληρεῖς ὥσπερ ἀπὸ τύμβου πεσών;</l>
@@ -3243,7 +3243,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>νὴ τὸν Δί’ αὕτη πού ’στί σοί γ’ ἡ Δαρδανίς.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οὔκ, ἀλλ’ ἐν ἀγορᾷ τοῖς θεοῖς δὰ|ς κάεται.</l>
 					</sp>
@@ -3251,7 +3251,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>δὰ|ς ἥδε;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">δὰ|ς δῆτ’. οὐχ ὁρᾷς ἐστιγμένην;</l>
 					</sp>
@@ -3259,7 +3259,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>τί δὲ τὸ μέλαν τοῦτ’ ἐστὶν αὐτῆς τοὐν μέσῳ;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="1375">ἡ πίττα δήπου καομένης ἐξέρχεται.</l>
 					</sp>
@@ -3267,7 +3267,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>ὁ δ’ ὄπισθεν οὐχὶ πρωκτός ἐστιν οὑτοσί;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ὄζος μὲν οὖν τῆς δᾳδὸς οὗτος ἐξέχει.</l>
 					</sp>
@@ -3275,7 +3275,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l>τί λέγεις σύ; ποῖος ὄζος; οὐκ εἶ δεῦρο σύ;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ἆ ἆ τί μέλλεις δρᾶν;</l>
 					</sp>
@@ -3285,7 +3285,7 @@ bring up to P3
 						<l n="1380">ἀφελόμενός σε καὶ νομίσας εἶναι σαπρὸν</l>
 						<l>κοὐδὲν δύνασθαι δρᾶν.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">ἄκουσόν νυν ἐμοῦ.</l>
 						<l>Ὀλυμπίασιν, ἡνίκ’ ἐθεώρουν ἐγώ,</l>
@@ -3311,7 +3311,7 @@ bring up to P3
 						<l>ὁρᾷς ἃ δέδρακας; πράγματ’ αὖ δεῖ καὶ δίκας</l>
 						<l>ἔχειν διὰ τὸν σὸν οἶνον.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">οὐδαμῶς γ’, ἐπεὶ</l>
 						<l>λόγοι διαλλάξουσιν αὐτὰ δεξιοί·</l>
@@ -3323,7 +3323,7 @@ bring up to P3
 						<l>τῆς Ἀγκυλίωνος θυγατέρος καὶ Σωστράτης,</l>
 						<l>οὕτω διαφθείρας ἐμοῦ τὰ φορτία.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ἄκουσον ὦ γύναι· λόγον σοι βούλομαι</l>
 						<l n="1400">λέξαι χαρίεντα.</l>
@@ -3332,7 +3332,7 @@ bring up to P3
 						<speaker>Αρτόπωλις</speaker>
 						<l part="Y">μὰ Δία μὴ ’μοί γ’ ὦ μέλε.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>Αἴσωπον ἀπὸ δείπνου βαδίζονθ’ ἑσπέρας</l>
 						<l>θρασεῖα καὶ μεθύση τις ὑλάκτει κύων.</l>
@@ -3346,7 +3346,7 @@ bring up to P3
 						<l>πρὸς τοὺς ἀγορανόμους βλάβης τῶν φορτίων,</l>
 						<l>κλητῆρ’ ἔχουσα Χαιρεφῶντα τουτονί.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>μὰ Δί’ ἀλλ’ ἄκουσον, ἤν τί σοι δόξω λέγειν.</l>
 						<l n="1410">Λᾶσός ποτ’ ἀντεδίδασκε καὶ Σιμωνίδης·</l>
@@ -3356,7 +3356,7 @@ bring up to P3
 						<speaker>Αρτόπωλις</speaker>
 						<l>ἄληθες οὗτος;</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">καὶ σὺ δή μοι Χαιρεφῶν</l>
 						<l>γυναικὶ † κλητεύειν ἐοικὼς † θαψίνῃ,</l>
@@ -3379,7 +3379,7 @@ bring up to P3
 						<l>ἐγὼ γὰρ ὑπὲρ αὐτοῦ δίκην δίδωμί σοι</l>
 						<l n="1420">ἣν ἂν σὺ τάξῃς, καὶ χάριν προσείσομαι.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ἐγὼ μὲν οὖν αὐτῷ διαλλαχθήσομαι</l>
 						<l>ἑκών· ὁμολογῶ γὰρ πατάξαι καὶ βαλεῖν.</l>
@@ -3391,7 +3391,7 @@ bring up to P3
 						<speaker>Κατήγορος</speaker>
 						<l>σὺ λέγε. δικῶν γὰρ οὐ δέομ’ οὐδὲ πραγμάτων.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ἀνὴρ Συβαρίτης ἐξέπεσεν ἐξ ἅρματος,</l>
 						<l>καί πως κατεάγη τῆς κεφαλῆς μέγα σφόδρα·</l>
@@ -3408,7 +3408,7 @@ bring up to P3
 						<speaker>Κατήγορος</speaker>
 						<l>ἀλλ’ οὖν σὺ μέμνησ’ αὐτὸς ἁπεκρίνατο.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="1435">ἄκουε, μὴ φεῦγ’. ἐν Συβάρει γυνή ποτε</l>
 						<l>κατέαξ’ ἐχῖνον.</l>
@@ -3417,7 +3417,7 @@ bring up to P3
 						<speaker>Κατήγορος</speaker>
 						<l part="Y">ταῦτ’ ἐγὼ μαρτύρομαι.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>οὑχῖνος οὖν ἔχων τιν’ ἐπεμαρτύρατο·</l>
 						<l>εἶθ’ ἡ Συβαρῖτις εἶπεν,  “εἰ ναὶ τὰν κόραν</l>
@@ -3433,7 +3433,7 @@ bring up to P3
 						<l>οὔτοι μὰ τὴν Δήμητρ’ ἔτ’ ἐνταυθοῖ μενεῖς,</l>
 						<l>ἀλλ’ ἀράμενος οἴσω σε —</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">τί ποιεῖς;</l>
 					</sp>
@@ -3443,7 +3443,7 @@ bring up to P3
 						<l>εἴσω φέρω σ’ ἐντεῦθεν· εἰ δὲ μή, τάχα</l>
 						<l n="1445">κλητῆρες ἐπιλείψουσι τοὺς καλουμένους.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>Αἴσωπον οἱ Δελφοί ποτ’ —</l>
 					</sp>
@@ -3451,7 +3451,7 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l part="Y">ὀλίγον μοι μέλει.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>φιάλην ἐπῃτιῶντο κλέψαι τοῦ θεοῦ·</l>
 						<l>ὁ δ’ ἔλεξεν αὐτοῖς, ὡς ὁ κάνθαρός ποτε —</l>
@@ -3465,7 +3465,7 @@ bring up to P3
 			</div1>
 			<div1 type="Choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1450">ζηλῶ γε τῆς εὐτυχίας</l>
 						<l>τὸν πρέσβυν οἷ μετέστη</l>
@@ -3499,7 +3499,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="Episode">
-				<sp who="#ksanthias">
+				<sp who="#xanthias">
 					<speaker>Ξανθίας</speaker>
 					<l>νὴ τὸν Διόνυσον ἄπορά γ’ ἡμῖν πράγματα</l>
 					<l n="1475">δαίμων τις ἐσκεκύκληκεν ἐς τὴν οἰκίαν.</l>
@@ -3511,51 +3511,51 @@ bring up to P3
 					<l>τοὺς νῦν διορχησάμενος ὀλίγον ὕστερον.</l>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>τίς ἐπ’ αὐλείοισι θύραις θάσσει;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>τουτὶ καὶ δὴ χωρεῖ τὸ κακόν.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>κλῇθρα χαλάσθω τάδε. καὶ δὴ γὰρ</l>
 						<l n="1485">σχήματος ἀρχὴ —</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>μᾶλλον δέ γ’ ἴσως μανίας ἀρχή.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>πλευρὰν λυγίσαντος ὑπὸ ῥώμης·</l>
 						<l>οἶον μυκτὴρ μυκᾶται καὶ</l>
 						<l>σφόνδυλος ἀχεῖ.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">πῖθ’ ἑλλέβορον.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l n="1490">πτήσσει Φρύνιχος ὥς τις ἀλέκτωρ —</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>τάχα βαλλήσεις.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>σκέλος οὐράνιόν γ’ ἐκλακτίζων.</l>
 						<l>πρωκτὸς χάσκει.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">κατὰ σαυτὸν ὅρα.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>νῦν γὰρ ἐν ἄρθροις τοῖς ἡμετέροις</l>
 						<l n="1495">στρέφεται χαλαρὰ κοτυληδών.</l>
@@ -3569,57 +3569,57 @@ bring up to P3
 						<speaker>Βδελυκλέων</speaker>
 						<l part="Y">μὰ Δί’ οὐ δῆτ’, ἀλλὰ μανικὰ πράγματα.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>θέρε νυν ἀνείπω κἀνταγωνιστὰς καλῶ.</l>
 						<l>εἴ τις τραγῳδός φησιν ὀρχεῖσθαι καλῶς,</l>
 						<l>ἐμοὶ διορχησόμενος ἐνθάδ’ εἰσίτω.</l>
 						<l n="1500">φησίν τις ἢ οὐδείς;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">εἶς γ’ ἐκεινοσὶ μόνος.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>τίς ὁ κακοδαίμων ἐστίν;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">υἱὸς Καρκίνου</l>
 						<l>ὁ μέσατος.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">ἀλλ’ οὗτός γε καταποθήσεται·</l>
 						<l>ἀπολῶ γὰρ αὐτὸν ἐμμελείᾳ κονδύλου.</l>
 						<l>ἐν τῷ ῥυθμῷ γὰρ οὐδέν ἐστ’.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l part="Y">ἀλλ’ ᾠζυρὲ</l>
 						<l n="1505">ἕτερος τραγῳδὸς Καρκινίτης ἔρχεται,</l>
 						<l>ἀδελφὸς αὐτοῦ.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l part="Y">νὴ Δί’ ὠψώνηκ’ ἄρα.</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l>μὰ τὸν Δί’ οὐδέν γ’ ἄλλο πλήν γε καρκίνους·</l>
 						<l>προσέρχεται γὰρ ἕτερος αὖ τῶν Καρκίνου.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>τουτὶ τί ἦν τὸ προσέρπον; ὀξὶς ἢ φάλαγξ;</l>
 					</sp>
-					<sp who="#ksanthias">
+					<sp who="#xanthias">
 						<speaker>Ξανθίας</speaker>
 						<l n="1510">ὁ πινοτήρης οὗτός ἐστι τοῦ γένους,</l>
 						<l>ὁ σμικρότατος, ὃς τὴν τραγῳδίαν ποιεῖ.</l>
 					</sp>
-					<sp who="#filokleon">
+					<sp who="#philokleon">
 						<speaker>Φιλοκλέων</speaker>
 						<l>ὦ Καρκίν’ ὦ μακάριε τῆς εὐπαιδίας,</l>
 						<l>ὅσον τὸ πλῆθος κατέπεσεν τῶν ὀρχίλων.</l>
@@ -3631,7 +3631,7 @@ bring up to P3
 			</div1>
 			<div1 type="Exodus">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φέρε νυν ἡμεῖς αὐτοῖς ὀλίγον ξυγχωρήσωμεν ἅπαντες,</l>
 						<l>ἵν’ ἐφ’ ἡσυχίας ἡμῶν πρόσθεν βεμβικίζωσιν ἑαυτούς.</l>
@@ -3639,7 +3639,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγ’ ὦ μεγαλώνυμα τέκνα</l>
 						<l>τοῦ θαλασσίου &lt;θεοῦ&gt;,</l>
@@ -3658,7 +3658,7 @@ bring up to P3
 					<milestone ed="p" n="1529" unit="card"/>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στρόβει, παράβαινε κύκλῳ καὶ γάστρισον σεαυτόν,</l>
 						<l n="1530">ῥῖπτε σκέλος οὐράνιον· βέμβικες ἐγγενέσθων.</l>

--- a/tei/euripides-bacchae.xml
+++ b/tei/euripides-bacchae.xml
@@ -51,13 +51,13 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="aggelosb" sex="MALE">
+					<person xml:id="angelos_b" sex="MALE">
 						<persName>Ἄγγελος Β</persName>
 					</person>
 					<person xml:id="dionysos" sex="MALE">
 						<persName>Διόνυσος</persName>
 					</person>
-					<person xml:id="aggelos" sex="MALE">
+					<person xml:id="angelos" sex="MALE">
 						<persName>Ἄγγελος</persName>
 					</person>
 					<person xml:id="teiresias" sex="MALE">
@@ -66,16 +66,16 @@
 					<person xml:id="therapon" sex="MALE">
 						<persName>Θεράπων</persName>
 					</person>
-					<person xml:id="agaye" sex="FEMALE">
+					<person xml:id="agaue" sex="FEMALE">
 						<persName>Ἀγαύη</persName>
 					</person>
 					<person xml:id="kadmos" sex="MALE">
 						<persName>Κάδμος</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="FEMALE">
+					<personGrp xml:id="choros" sex="FEMALE">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="pentheys" sex="MALE">
+					<person xml:id="pentheus" sex="MALE">
 						<persName>Πενθεύς</persName>
 					</person>
 				</listPerson>
@@ -245,7 +245,7 @@ convert to P3
 			<milestone ed="p" n="64" unit="card"/>
 			<div1 type="choral">
 				<div2 type="lyric">
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἀσίας ἀπὸ γᾶς</l>
 						<l n="65">ἱερὸν Τμῶλον ἀμείψασα θοάζω</l>
@@ -261,7 +261,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ</l>
 						<l n="73b">μάκαρ, ὅστις εὐδαίμων</l>
@@ -285,7 +285,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅν</l>
 						<l n="88b">ποτ’ ἔχουσ’ ἐν ὠδίνων</l>
@@ -309,7 +309,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="105">ὦ Σεμέλας τροφοὶ Θῆ‐</l>
 						<l>βαι, στεφανοῦσθε κισσῷ·</l>
@@ -330,7 +330,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="120">ὦ θαλάμευμα Κουρή‐</l>
 						<l>των ζάθεοί τε Κρήτας</l>
@@ -351,7 +351,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="135">ἡδὺς ἐν ὄρεσιν, ὅταν ἐκ θιάσων δρομαί‐</l>
 						<l>ων πέσῃ πεδόσε, νε‐</l>
@@ -476,7 +476,7 @@ convert to P3
 					<l>ὡς ἐπτόηται· τί ποτ’ ἐρεῖ νεώτερον;</l>
 					<milestone ed="p" n="215" unit="card"/>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="215">ἔκδημος ὢν μὲν τῆσδ’ ἐτύγχανον χθονός,</l>
 					<l>κλύω δὲ νεοχμὰ τήνδ’ ἀνὰ πτόλιν κακά,</l>
@@ -542,7 +542,7 @@ convert to P3
 					<l>ὅπου βότρυος ἐν δαιτὶ γίγνεται γάνος,</l>
 					<l>οὐχ ὑγιὲς οὐδὲν ἔτι λέγω τῶν ὀργίων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τῆς δυσσεβείας. ὦ ξέν’, οὐκ αἰδῇ θεοὺς</l>
 					<l>Κάδμον τε τὸν σπείραντα γηγενῆ στάχυν,</l>
@@ -633,7 +633,7 @@ convert to P3
 					<l>μαίνῃ γὰρ ὡς ἄλγιστα, κοὔτε φαρμάκοις</l>
 					<l>ἄκη λάβοις ἂν οὔτ’ ἄνευ τούτων νοσεῖς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ πρέσβυ, Φοῖβόν τ’ οὐ καταισχύνεις λόγοις,</l>
 					<l>τιμῶν τε Βρόμιον σωφρονεῖς, μέγαν θεόν.</l>
@@ -658,7 +658,7 @@ convert to P3
 					<l>κισσῷ· μεθ’ ἡμῶν τῷ θεῷ τιμὴν δίδου.</l>
 				</sp>
 				<milestone ed="p" n="343" unit="card"/>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>οὐ μὴ προσοίσεις χεῖρα, βακχεύσεις δ’ ἰών,</l>
 					<l>μηδ’ ἐξομόρξῃ μωρίαν τὴν σὴν ἐμοί;</l>
@@ -698,7 +698,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="370">Ὁσία πότνα θεῶν,</l>
 						<l>Ὁσία δ’ ἃ κατὰ γᾶν</l>
@@ -721,7 +721,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀχαλίνων στομάτων</l>
 						<l>ἀνόμου τ’ ἀφροσύνας</l>
@@ -744,7 +744,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἱκοίμαν ποτὶ Κύπρον,</l>
 						<l>νᾶσον τᾶς Ἀφροδίτας,</l>
@@ -765,7 +765,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ δαίμων ὁ Διὸς παῖς</l>
 						<l>χαίρει μὲν θαλίαισιν,</l>
@@ -810,7 +810,7 @@ convert to P3
 					<l>πολλῶν δ’ ὅδ’ ἁνὴρ θαυμάτων ἥκει πλέως</l>
 					<l n="450">ἐς τάσδε Θήβας. σοὶ δὲ τἄλλα χρὴ μέλειν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>μέθεσθε χειρῶν τοῦδ’· ἐν ἄρκυσιν γὰρ ὢν</l>
 					<l>οὐκ ἔστιν οὕτως ὠκὺς ὥστε μ’ ἐκφυγεῖν.</l>
@@ -831,7 +831,7 @@ convert to P3
 					<l>οὐ κόμπος οὐδείς· ῥᾴδιον δ’ εἰπεῖν τόδε.</l>
 					<l>τὸν ἀνθεμώδη Τμῶλον οἶσθά που κλύων.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>οἶδ’, ὃς τὸ Σάρδεων ἄστυ περιβάλλει κύκλῳ.</l>
 				</sp>
@@ -839,7 +839,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ἐντεῦθέν εἰμι, Λυδία δέ μοι πατρίς.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="465">πόθεν δὲ τελετὰς τάσδ’ ἄγεις ἐς Ἑλλάδα;</l>
 				</sp>
@@ -847,7 +847,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>Διόνυσος ἡμᾶς εἰσέβησ’, ὁ τοῦ Διός.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>Ζεὺς δ’ ἔστ’ ἐκεῖ τις, ὃς νέους τίκτει θεούς;</l>
 				</sp>
@@ -855,7 +855,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>οὔκ, ἀλλ’ ὁ Σεμέλην ἐνθάδε ζεύξας γάμοις.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>πότερα δὲ νύκτωρ σ’ ἢ κατ’ ὄμμ’ ἠνάγκασεν;</l>
 				</sp>
@@ -863,7 +863,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l n="470">ὁρῶν ὁρῶντα, καὶ δίδωσιν ὄργια.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>τὰ δ’ ὄργῑ ἐστὶ τίν’ ἰδέαν ἔχοντά σοι;</l>
 				</sp>
@@ -871,7 +871,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ἄρρητ’ ἀβακχεύτοισιν εἰδέναι βροτῶν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>ἔχει δ’ ὄνησιν τοῖσι θύουσιν τίνα;</l>
 				</sp>
@@ -879,7 +879,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>οὐ θέμις ἀκοῦσαί σ’, ἔστι δ’ ἄξῑ εἰδέναι.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="475">εὖ τοῦτ’ ἐκιβδήλευσας, ἵν’ ἀκοῦσαι θέλω.</l>
 					<milestone ed="p" n="476" unit="card"/>
@@ -888,7 +888,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ἀσέβειαν ἀσκοῦντ’ ὄργῑ ἐχθαίρει θεοῦ.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>τὸν θεὸν ὁρᾶν γὰρ φὴ|ς σαφῶς, ποῖός τις ἦν;</l>
 				</sp>
@@ -896,7 +896,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ὁποῖος ἤθελ’· οὐκ ἐγὼ ’τασσον τόδε.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>τοῦτ’ αὖ παρωχέτευσας εὖ κοὐδὲν λέγων.</l>
 				</sp>
@@ -904,7 +904,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l n="480">δόξει τις ἀμαθεῖ σοφὰ λέγων οὐκ εὖ φρονεῖν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>ἦλθες δὲ πρῶτα δεῦρ’ ἄγων τὸν δαίμονα;</l>
 				</sp>
@@ -912,7 +912,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>πᾶς ἀναχορεύει βαρβάρων τάδ’ ὄργια.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>φρονοῦσι γὰρ κάκιον Ἑλλήνων πολύ.</l>
 				</sp>
@@ -920,7 +920,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>τάδ’ εὖ γε μᾶλλον· οἱ νόμοι δὲ διάφοροι.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="485">τὰ δ’ ἱερὰ νύκτωρ ἢ μεθ’ ἡμέραν τελεῖς;</l>
 				</sp>
@@ -928,7 +928,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>νύκτωρ τὰ πολλά· σεμνότητ’ ἔχει σκότος.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>τοῦτ’ ἐς γυναῖκας δόλιόν ἐστι καὶ σαθρόν.</l>
 				</sp>
@@ -936,7 +936,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>κἀν ἡμέρᾳ τό γ’ αἰσχρὸν ἐξεύροι τις ἄν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>δίκην σε δοῦναι δεῖ σοφισμάτων κακῶν.</l>
 				</sp>
@@ -944,7 +944,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l n="490">σὲ δ’ ἀμαθίας γε κἀσεβοῦντ’ ἐς τὸν θεόν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>ὡς θρασὺς ὁ βάκχος κοὐκ ἀγύμναστος λόγων.</l>
 				</sp>
@@ -952,7 +952,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>εἴφ’ ὅ τι παθεῖν δεῖ· τί με τὸ δεινὸν ἐργάσῃ;</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>πρῶτον μὲν ἁβρὸν βόστρυχον τεμῶ σέθεν.</l>
 				</sp>
@@ -960,7 +960,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ἱερὸς ὁ πλόκαμος· τῷ θεῷ δ’ αὐτὸν τρέφω.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="495">ἔπειτα θύρσον τόνδε παράδος ἐκ χεροῖν.</l>
 				</sp>
@@ -968,7 +968,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>αὐτός μ’ ἀφαιροῦ· τόνδε Διονύσου φορῶ.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>εἱρκταῖσί τ’ ἔνδον σῶμα σὸν φυλάξομεν.</l>
 				</sp>
@@ -976,7 +976,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>λύσει μ’ ὁ δαίμων αὐτός, ὅταν ἐγὼ θέλω.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>ὅταν γε καλέσῃς αὐτὸν ἐν βάκχαις σταθείς.</l>
 				</sp>
@@ -984,7 +984,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l n="500">καὶ νῦν ἃ πάσχω πλησίον παρὼν ὁρᾷ.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>καὶ ποῦ ’στιν; οὐ γὰρ φανερὸς ὄμμασίν γ’ ἐμοῖς.</l>
 				</sp>
@@ -992,7 +992,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>παρ’ ἐμοί· σὺ δ’ ἀσεβὴς αὐτὸς ὢν οὐκ εἰσορᾷς.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>λάζυσθε· καταφρονεῖ με καὶ Θήβας ὅδε.</l>
 				</sp>
@@ -1000,7 +1000,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>αὐδῶ με μὴ δεῖν σωφρονῶν οὐ σώφροσιν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="505">ἐγὼ δὲ δεῖν γε, κυριώτερος σέθεν.</l>
 				</sp>
@@ -1008,7 +1008,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>οὐκ οἶσθ’ ὅ τι ζῇς, οὐδ’ ὃ δρᾷς, οὐδ’ ὅστις εἶ.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>Πενθεύς, Ἀγαύης παῖς, πατρὸς δ’ Ἐχίονος.</l>
 				</sp>
@@ -1016,7 +1016,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ἐνδυστυχῆσαι τοὔνομ’ ἐπιτήδειος εἶ.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>χώρει· καθείρξατ’ αὐτὸν ἱππικαῖς πέλας</l>
 					<l n="510">φάτναισιν, ὡς ἂν σκότιον εἰσορᾷ κνέφας.</l>
@@ -1036,7 +1036,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>
 							<gap desc="*"/>
@@ -1063,7 +1063,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἵαν οἵαν ὀργὰν</l>
 						<l>ἀναφαίνει χθόνιον</l>
@@ -1088,7 +1088,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πόθι Νύσας ἄρα τᾶς θη‐</l>
 						<l>ροτρόφου θυρσοφορεῖς</l>
@@ -1124,7 +1124,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς ὅδε, τίς &lt;ὅδε&gt; πόθεν ὁ κέλαδος</l>
 						<l>ἀνά μ’ ἐκάλεσεν Εὐίου;</l>
@@ -1138,7 +1138,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰὼ δέσποτα δέσποτα,</l>
 						<l>μόλε νυν ἡμέτερον ἐς</l>
@@ -1152,7 +1152,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆ ἆ,</l>
 						<l>τάχα τὰ Πενθέως μέλαθρα διατι‐</l>
@@ -1173,7 +1173,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆ ἆ,</l>
 						<l>πῦρ οὐ λεύσσεις, οὐδ’ αὐγάζῃ,</l>
@@ -1197,7 +1197,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ φάος μέγιστον ἡμῖν εὐίου βακχεύματος,</l>
 						<l>ὡς ἐσεῖδον ἀσμένη σε, μονάδ’ ἔχουσ’ ἐρημίαν.</l>
@@ -1211,7 +1211,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς γὰρ οὔ; τίς μοι φύλαξ ἦν, εἰ σὺ συμφορᾶς τύχοις;</l>
 						<l>ἀλλὰ πῶς ἠλευθερώθης ἀνδρὸς ἀνοσίου τυχών;</l>
@@ -1224,7 +1224,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="615">οὐδέ σου συνῆψε χεῖρε δεσμίοισιν ἐν βρόχοις;</l>
 					</sp>
@@ -1263,7 +1263,7 @@ convert to P3
 						<l>πρὸς σοφοῦ γὰρ ἀνδρὸς ἀσκεῖν σώφρον’ εὐοργησίαν.</l>
 						<milestone ed="p" n="642" unit="card"/>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>πέπονθα δεινά· διαπέφευγέ μ’ ὁ ξένος,</l>
 						<l>ὃς ἄρτι δεσμοῖς ἦν κατηναγκασμένος.</l>
@@ -1275,7 +1275,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>στῆσον πόδ’, ὀργῇ δ’ ὑπόθες ἥσυχον πόδα.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>πόθεν σὺ δεσμὰ διαφυγὼν ἔξω περᾷς;</l>
 					</sp>
@@ -1283,7 +1283,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>οὐκ εἶπον‐‐ἢ οὐκ ἤκουσας‐‐ὅτι λύσει μέ τις;</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="650">τίς; τοὺς λόγους γὰρ ἐσφέρεις καινοὺς ἀεί.</l>
 					</sp>
@@ -1291,7 +1291,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ὃς τὴν πολύβοτρυν ἄμπελον φύει βροτοῖς.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>
 							<gap desc="*"/>
@@ -1301,7 +1301,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ὠνείδισας δὴ τοῦτο Διονύσῳ καλόν.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>κλῄειν κελεύω πάντα πύργον ἐν κύκλῳ.</l>
 					</sp>
@@ -1309,7 +1309,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>τί δ’; οὐχ ὑπερβαίνουσι καὶ τείχη θεοί;</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="655">σοφὸς σοφὸς σύ, πλὴν ἃ δεῖ σ’ εἶναι σοφόν.</l>
 					</sp>
@@ -1320,17 +1320,17 @@ convert to P3
 						<l>ὃς ἐξ ὄρους πάρεστιν ἀγγελῶν τί σοι·</l>
 						<l>ἡμεῖς δέ σοι μενοῦμεν, οὐ φευξούμεθα.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l n="660">Πενθεῦ κρατύνων τῆσδε Θηβαίας χθονός,</l>
 						<l>ἥκω Κιθαιρῶν’ ἐκλιπών, ἵν’ οὔποτε</l>
 						<l>λευκῆς χιόνος ἀνεῖσαν εὐαγεῖς βολαί.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>ἥκεις δὲ ποίαν προστιθεὶς σπουδὴν λόγου;</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>βάκχας ποτνιάδας εἰσιδών, αἳ τῆσδε γῆς</l>
 						<l n="665">οἴστροισι λευκὸν κῶλον ἐξηκόντισαν,</l>
@@ -1341,7 +1341,7 @@ convert to P3
 						<l n="670">τὸ γὰρ τάχος σου τῶν φρενῶν δέδοικ’, ἄναξ,</l>
 						<l>καὶ τοὐξύθυμον καὶ τὸ βασιλικὸν λίαν.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>λέγ’, ὡς ἀθῷος ἐξ ἐμοῦ πάντως ἔσῃ.</l>
 						<l>τοῖς γὰρ δικαίοις οὐχὶ θυμοῦσθαι χρεών.</l>
@@ -1350,7 +1350,7 @@ convert to P3
 						<l>γυναιξὶ τόνδε τῇ δίκῃ προσθήσομεν.</l>
 						<milestone ed="p" n="677" unit="card"/>
 					</sp>
-					<sp n="Ἀγγελος" who="#aggelos">
+					<sp n="Ἀγγελος" who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ἀγελαῖα μὲν βοσκήματ’ ἄρτι πρὸς λέπας</l>
 						<l>μόσχων ὑπεξήκριζον, ἡνίχ’ ἥλιος</l>
@@ -1468,13 +1468,13 @@ convert to P3
 						<l>οὐδ’ ἄλλο τερπνὸν οὐδὲν ἀνθρώποις ἔτι.</l>
 					</sp>
 					<milestone ed="p" n="775" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="775">ταρβῶ μὲν εἰπεῖν τοὺς λόγους ἐλευθέρους</l>
 						<l>πρὸς τὸν τύραννον, ἀλλ’ ὅμως εἰρήσεται·</l>
 						<l>Διόνυσος ἥσσων οὐδενὸς θεῶν ἔφυ.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>ἤδη τόδ’ ἐγγὺς ὥστε πῦρ ὑφάπτεται</l>
 						<l>ὕβρισμα βακχῶν, ψόγος ἐς Ἕλληνας μέγας.</l>
@@ -1494,7 +1494,7 @@ convert to P3
 						<l n="790">ἀλλ’ ἡσυχάζειν· Βρόμιος οὐκ ἀνέξεται</l>
 						<l>κινοῦντα βάκχας &lt;σ’&gt; εὐίων ὀρῶν ἄπο.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>οὐ μὴ φρενώσεις μ’, ἀλλὰ δέσμιος φυγὼν</l>
 						<l>σῴσῃ τόδ’; ἢ σοὶ πάλιν ἀναστρέψω δίκην;</l>
@@ -1504,7 +1504,7 @@ convert to P3
 						<l>θύοιμ’ ἂν αὐτῷ μᾶλλον ἢ θυμούμενος</l>
 						<l n="795">πρὸς κέντρα λακτίζοιμι θνητὸς ὢν θεῷ.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>θύσω, φόνον γε θῆλυν, ὥσπερ ἄξιαι,</l>
 						<l>πολὺν ταράξας ἐν Κιθαιρῶνος πτυχαῖς.</l>
@@ -1514,7 +1514,7 @@ convert to P3
 						<l>φεύξεσθε πάντες· καὶ τόδ’ αἰσχρόν, ἀσπίδας</l>
 						<l>θύρσοισι βακχῶν ἐκτρέπειν χαλκηλάτους</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="800">ἀπόρῳ γε τῷδε συμπεπλέγμεθα ξένῳ,</l>
 						<l>ὃς οὔτε πάσχων οὔτε δρῶν σιγήσεται.</l>
@@ -1523,7 +1523,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ὦ τᾶν, ἔτ’ ἔστιν εὖ καταστῆσαι τάδε.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>τί δρῶντα; δουλεύοντα δουλείαις ἐμαῖς;</l>
 					</sp>
@@ -1531,7 +1531,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ἐγὼ γυναῖκας δεῦρ’ ὅπλων ἄξω δίχα.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="805">οἴμοι· τόδ’ ἤδη δόλιον ἔς με μηχανᾷ.</l>
 					</sp>
@@ -1539,7 +1539,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ποῖόν τι, σῷσαί σ’ εἰ θέλω τέχναις ἐμαῖς;</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>ξυνέθεσθε κοινῇ τάδ’, ἵνα βακχεύητ’ ἀεί.</l>
 					</sp>
@@ -1547,7 +1547,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>καὶ μὴν ξυνεθέμην‐‐τοῦτό γ’ ἔστι‐‐τῷ θεῷ.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>ἐκφέρετέ μοι δεῦρ’ ὅπλα, σὺ δὲ παῦσαι λέγων.</l>
 						<milestone ed="p" n="810" unit="card"/>
@@ -1557,7 +1557,7 @@ convert to P3
 						<l n="810">ἆ.</l>
 						<l>βούλῃ σφ’ ἐν ὄρεσι συγκαθημένας ἰδεῖν;</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>μάλιστα, μυρίον γε δοὺς χρυσοῦ σταθμόν.</l>
 					</sp>
@@ -1565,7 +1565,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>τί δ’ εἰς ἔρωτα τοῦδε πέπτωκας μέγαν;</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>λυπρῶς νιν εἰσίδοιμ’ ἂν ἐξῳνωμένας.</l>
 					</sp>
@@ -1573,7 +1573,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l n="815">ὅμως δ’ ἴδοις ἂν ἡδέως ἅ σοι πικρά;</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>σάφ’ ἴσθι, σιγῇ γ’ ὑπ’ ἐλάταις καθήμενος.</l>
 					</sp>
@@ -1581,7 +1581,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ἀλλ’ ἐξιχνεύσουσίν σε, κἂν ἔλθῃς λάθρᾳ.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>ἀλλ’ ἐμφανῶς· καλῶς γὰρ ἐξεῖπας τάδε.</l>
 					</sp>
@@ -1589,7 +1589,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ἄγωμεν οὖν σε κἀπιχειρήσεις ὁδῷ;</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="820">ἄγ’ ὡς τάχιστα, τοῦ χρόνου δέ σοι φθονῶ.</l>
 					</sp>
@@ -1597,7 +1597,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>στεῖλαί νυν ἀμφὶ χρωτὶ βυσσίνους πέπλους.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>τί δὴ τόδ’; ἐς γυναῖκας ἐξ ἀνδρὸς τελῶ;</l>
 					</sp>
@@ -1605,7 +1605,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>μή σε κτάνωσιν, ἢν ἀνὴρ ὀφθῇς ἐκεῖ.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>εὖ γ’ εἶπας αὖ τόδ’· ὥς τις εἶ πάλαι σοφός.</l>
 					</sp>
@@ -1613,7 +1613,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l n="825">Διόνυσος ἡμᾶς ἐξεμούσωσεν τάδε.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>πῶς οὖν γένοιτ’ ἂν ἃ σύ με νουθετεῖς καλῶς;</l>
 					</sp>
@@ -1621,7 +1621,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ἐγὼ στελῶ σε δωμάτων ἔσω μολών.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>τίνα στολήν; ἦ θῆλυν; ἀλλ’ αἰδώς μ’ ἔχει.</l>
 					</sp>
@@ -1629,7 +1629,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>οὐκέτι θεατὴς μαινάδων πρόθυμος εἶ.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="830">στολὴν δὲ τίνα φὴ|ς ἀμφὶ χρῶτ’ ἐμὸν βαλεῖν;</l>
 					</sp>
@@ -1637,7 +1637,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>κόμην μὲν ἐπὶ σῷ κρατὶ ταναὸν ἐκτενῶ.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>τὸ δεύτερον δὲ σχῆμα τοῦ κόσμου τί μοι;</l>
 					</sp>
@@ -1645,7 +1645,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>πέπλοι ποδήρεις· ἐπὶ κάρᾳ δ’ ἔσται μίτρα.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>ἦ καί τι πρὸς τοῖσδ’ ἄλλο προσθήσεις ἐμοί;</l>
 					</sp>
@@ -1653,7 +1653,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l n="835">θύρσον γε χειρὶ καὶ νεβροῦ στικτὸν δέρας.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>οὐκ ἂν δυναίμην θῆλυν ἐνδῦναι στολήν.</l>
 					</sp>
@@ -1661,7 +1661,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ἀλλ’ αἷμα θήσεις συμβαλὼν βάκχαις μάχην.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>ὀρθῶς· μολεῖν χρὴ πρῶτον εἰς κατασκοπήν.</l>
 					</sp>
@@ -1669,7 +1669,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>σοφώτερον γοῦν ἢ κακοῖς θηρᾶν κακά.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="840">καὶ πῶς δῑ ἄστεως εἶμι Καδμείους λαθών;</l>
 					</sp>
@@ -1677,7 +1677,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ὁδοὺς ἐρήμους ἴμεν· ἐγὼ δ’ ἡγήσομαι.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l>πᾶν κρεῖσσον ὥστε μὴ ’γγελᾶν βάκχας ἐμοί.</l>
 						<l>ἐλθόντ’ ἐς οἴκους . . . ἃν δοκῇ βουλεύσομαι.</l>
@@ -1686,7 +1686,7 @@ convert to P3
 						<speaker>Διόνυσος</speaker>
 						<l>ἔξεστι· πάντῃ τό γ’ ἐμὸν εὐτρεπὲς πάρα.</l>
 					</sp>
-					<sp who="#pentheys">
+					<sp who="#pentheus">
 						<speaker>Πενθεύς</speaker>
 						<l n="845">στείχοιμ’ ἄν· ἢ γὰρ ὅπλ’ ἔχων πορεύσομαι</l>
 						<l>ἢ τοῖσι σοῖσι πείσομαι βουλεύμασιν.</l>
@@ -1717,7 +1717,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆρ’ ἐν παννυχίοις χοροῖς</l>
 						<l>θήσω ποτὲ λευκὸν</l>
@@ -1744,7 +1744,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρμᾶται μόλις, ἀλλ’ ὅμως</l>
 						<l>πιστόν &lt;τι&gt; τὸ θεῖον</l>
@@ -1771,7 +1771,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐδαίμων μὲν ὃς ἐκ θαλάσσας</l>
 						<l>ἔφυγε χεῖμα, λιμένα δ’ ἔκιχεν·</l>
@@ -1798,7 +1798,7 @@ convert to P3
 					<l>μητρός τε τῆς σῆς καὶ λόχου κατάσκοπος·</l>
 					<l>πρέπεις δὲ Κάδμου θυγατέρων μορφὴν μιᾷ.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>καὶ μὴν ὁρᾶν μοι δύο μὲν ἡλίους δοκῶ,</l>
 					<l>δισσὰς δὲ Θήβας καὶ πόλισμ’ ἑπτάστομον·</l>
@@ -1811,7 +1811,7 @@ convert to P3
 					<l>ὁ θεὸς ὁμαρτεῖ, πρόσθεν ὢν οὐκ εὐμενής,</l>
 					<l>ἔνσπονδος ἡμῖν· νῦν δ’ ὁρᾷς ἃ χρή σ’ ὁρᾶν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="925">τί φαίνομαι δῆτ’; οὐχὶ τὴν Ἰνοῦς στάσιν</l>
 					<l>ἢ τὴν Ἀγαύης ἑστάναι, μητρός γ’ ἐμῆς;</l>
@@ -1822,7 +1822,7 @@ convert to P3
 					<l>ἀλλ’ ἐξ ἕδρας σοι πλόκαμος ἐξέστηχ’ ὅδε,</l>
 					<l>οὐχ ὡς ἐγώ νιν ὑπὸ μίτρᾳ καθήρμοσα.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="930">ἔνδον προσείων αὐτὸν ἀνασείων τ’ ἐγὼ</l>
 					<l>καὶ βακχιάζων ἐξ ἕδρας μεθώρμισα.</l>
@@ -1832,7 +1832,7 @@ convert to P3
 					<l>ἀλλ’ αὐτὸν ἡμεῖς, οἷς σε θεραπεύειν μέλει,</l>
 					<l>πάλιν καταστελοῦμεν· ἀλλ’ ὄρθου κάρα.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>ἰδού, σὺ κόσμει· σοὶ γὰρ ἀνακείμεσθα δή.</l>
 				</sp>
@@ -1841,7 +1841,7 @@ convert to P3
 					<l n="935">ζῶναί τέ σοι χαλῶσι κοὐχ ἑξῆς πέπλων</l>
 					<l>στολίδες ὑπὸ σφυροῖσι τείνουσιν σέθεν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>κἀμοὶ δοκοῦσι παρά γε δεξιὸν πόδα·</l>
 					<l>τἀνθένδε δ’ ὀρθῶς παρὰ τένοντ’ ἔχει πέπλος.</l>
@@ -1851,7 +1851,7 @@ convert to P3
 					<l>ἦ πού με τῶν σῶν πρῶτον ἡγήσῃ φίλων,</l>
 					<l n="940">ὅταν παρὰ λόγον σώφρονας βάκχας ἴδῃς.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>πότερα δὲ θύρσον δεξιᾷ λαβὼν χερὶ</l>
 					<l>ἢ τῇδε, βάκχῃ μᾶλλον εἰκασθήσομαι;</l>
@@ -1862,7 +1862,7 @@ convert to P3
 					<l>αἴρειν νιν· αἰνῶ δ’ ὅτι μεθέστηκας φρενῶν.</l>
 					<milestone ed="p" n="945" unit="card"/>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l n="945">ἆρ’ ἂν δυναίμην τὰς Κιθαιρῶνος πτυχὰς</l>
 					<l>αὐταῖσι βάκχαις τοῖς ἐμοῖς ὤμοις φέρειν;</l>
@@ -1872,7 +1872,7 @@ convert to P3
 					<l>δύναῑ ἄν, εἰ βούλοιο· τὰς δὲ πρὶν φρένας</l>
 					<l>οὐκ εἶχες ὑγιεῖς, νῦν δ’ ἔχεις οἵας σε δεῖ.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>μοχλοὺς φέρωμεν; ἢ χεροῖν ἀνασπάσω</l>
 					<l n="950">κορυφαῖς ὑποβαλὼν ὦμον ἢ βραχίονα;</l>
@@ -1882,7 +1882,7 @@ convert to P3
 					<l>μὴ σύ γε τὰ Νυμφῶν διολέσῃς ἱδρύματα</l>
 					<l>καὶ Πανὸς ἕδρας ἔνθ’ ἔχει συρίγματα.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>καλῶς ἔλεξας· οὐ σθένει νικητέον</l>
 					<l>γυναῖκας· ἐλάταισιν δ’ ἐμὸν κρύψω δέμας.</l>
@@ -1892,7 +1892,7 @@ convert to P3
 					<l n="955">κρύψῃ σὺ κρύψιν ἥν σε κρυφθῆναι χρεών,</l>
 					<l>ἐλθόντα δόλιον μαινάδων κατάσκοπον.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>καὶ μὴν δοκῶ σφᾶς ἐν λόχμαις ὄρνιθας ὣς</l>
 					<l>λέκτρων ἔχεσθαι φιλτάτοις ἐν ἕρκεσιν.</l>
@@ -1902,7 +1902,7 @@ convert to P3
 					<l>οὐκοῦν ἐπ’ αὐτὸ τοῦτ’ ἀποστέλλῃ φύλαξ·</l>
 					<l n="960">λήψῃ δ’ ἴσως σφᾶς, ἢν σὺ μὴ ληφθῇς πάρος.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l>κόμιζε διὰ μέσης με Θηβαίας χθονός·</l>
 					<l>μόνος γὰρ αὐτῶν εἰμ’ ἀνὴρ τολμῶν τόδε.</l>
@@ -1914,7 +1914,7 @@ convert to P3
 					<l n="965">ἕπου δέ· πομπὸς [δ’] εἶμ’ ἐγὼ σωτήριος,</l>
 					<l>κεῖθεν δ’ ἀπάξει σ’ ἄλλος.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l part="Y">ἡ τεκοῦσά γε.</l>
 				</sp>
@@ -1922,7 +1922,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ἐπίσημον ὄντα πᾶσιν.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l part="Y">ἐπὶ τόδ’ ἔρχομαι.</l>
 				</sp>
@@ -1930,7 +1930,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>φερόμενος ἥξεις . . .</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l part="Y">ἁβρότητ’ ἐμὴν λέγεις.</l>
 				</sp>
@@ -1938,7 +1938,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>ἐν χερσὶ μητρός.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l part="Y">καὶ τρυφᾶν μ’ ἀναγκάσεις.</l>
 				</sp>
@@ -1946,7 +1946,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l n="970">τρυφάς γε τοιάσδε.</l>
 				</sp>
-				<sp who="#pentheys">
+				<sp who="#pentheus">
 					<speaker>Πενθεύς</speaker>
 					<l part="Y">ἀξίων μὲν ἅπτομαι.</l>
 				</sp>
@@ -1966,7 +1966,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴτε θοαὶ Λύσσας κύνες ἴτ’ εἰς ὄρος,</l>
 						<l>θίασον ἔνθ’ ἔχουσι Κάδμου κόραι,</l>
@@ -1990,7 +1990,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὃς ἀδίκῳ γνώμᾳ παρανόμῳ τ’ ὀργᾷ</l>
 						<l>περὶ &lt;σὰ&gt; Βάκχῑ, ὄργια ματρός τε σᾶς</l>
@@ -2014,7 +2014,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1018">φάνηθι ταῦρος ἢ πολύκρανος ἰδεῖν</l>
 						<l>δράκων ἢ πυριφλέγων ὁρᾶσθαι λέων.</l>
@@ -2027,7 +2027,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelosb">
+				<sp who="#angelos_b">
 					<speaker>Ἄγγελος Β</speaker>
 					<l>ὦ δῶμ’ ὃ πρίν ποτ’ εὐτύχεις ἀν’ Ἑλλάδα,</l>
 					<l n="1025">Σιδωνίου γέροντος, ὃς τὸ γηγενὲς</l>
@@ -2035,32 +2035,32 @@ convert to P3
 					<l>ὥς σε στενάζω, δοῦλος ὢν μέν, ἀλλ’ ὅμως</l>
 					<l>[χρηστοῖσι δούλοις συμφορὰ τὰ δεσποτῶν].</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἔστιν; ἐκ βακχῶν τι μηνύεις νέον;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1030">Πενθεὺς ὄλωλεν, παῖς Ἐχίονος πατρός.</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦναξ Βρόμιε, θεὸς φαίνῃ μέγας.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>πῶς φῄς; τί τοῦτ’ ἔλεξας; ἦ ’πὶ τοῖς ἐμοῖς</l>
 						<l>χαίρεις κακῶς πράσσουσι δεσπόταις, γύναι;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐάζω ξένα μέλεσι βαρβάροις·</l>
 						<l n="1035">οὐκέτι γὰρ δεσμῶν ὑπὸ φόβῳ πτήσσω.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>Θήβας δ’ ἀνάνδρους ὧδ’ ἄγεις . . .</l>
 						<l>
@@ -2069,25 +2069,25 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ Διόνυσος ὁ Διόνυσος, οὐ Θῆβαι</l>
 						<l>κράτος ἔχουσ’ ἐμόν.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>συγγνωστὰ μέν σοι, πλὴν ἐπ’ ἐξειργασμένοις</l>
 						<l n="1040">κακοῖσι χαίρειν, ὦ γυναῖκες, οὐ καλόν.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔννεπέ μοι, φράσον, τίνι μόρῳ θνῄσκει</l>
 						<l>ἄδικος ἄδικά τ’ ἐκπορίζων ἀνήρ;</l>
 						<milestone ed="p" n="1043" unit="card"/>
 					</sp>
-					<sp n="Ἀγγελος" who="#aggelos">
+					<sp n="Ἀγγελος" who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ἐπεὶ θεράπνας τῆσδε Θηβαίας χθονὸς</l>
 						<l>λιπόντες ἐξέβημεν Ἀσωποῦ ῥοάς,</l>
@@ -2228,7 +2228,7 @@ convert to P3
 			<milestone ed="p" n="1153" unit="card"/>
 			<div1 type="choral">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀναχορεύσωμεν Βάκχιον,</l>
 						<l>ἀναβοάσωμεν ξυμφορὰν</l>
@@ -2244,7 +2244,7 @@ convert to P3
 						<l>περιβαλεῖν τέκνου.</l>
 						<milestone ed="p" n="1165" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1165">ἀλλ’, εἰσορῶ γὰρ ἐς δόμους ὁρμωμένην</l>
 						<l>Πενθέως Ἀγαύην μητέρ’ ἐν διαστρόφοις</l>
@@ -2253,74 +2253,74 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>Ἀσιάδες βάκχαι — </l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τί μ’ ὀροθύνεις, ὤ;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>φέρομεν ἐξ ὀρέων</l>
 						<l n="1170">ἕλικα νεότομον ἐπὶ μέλαθρα,</l>
 						<l>μακάριον θήραν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρῶ καί σε δέξομαι σύγκωμον.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>ἔμαρψα τόνδ’ ἄνευ βρόχων</l>
 						<l>&lt;λέοντος ἀγροτέρου&gt; νέον ἶνιν·</l>
 						<l n="1175">ὡς ὁρᾶν πάρα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πόθεν ἐρημίας;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>Κιθαιρὼν . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">Κιθαιρών;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>κατεφόνευσέ νιν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς ἁ βαλοῦσα;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l part="Y">πρῶτον ἐμὸν τὸ γέρας.</l>
 						<l n="1180">μάκαιρ’ Ἀγαύη κλῃζόμεθ’ ἐν θιάσοις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς ἄλλα;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l part="Y">τὰ Κάδμου . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί Κάδμου;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l part="Y">γένεθλα</l>
 						<l n="1182b">μετ’ ἐμὲ μετ’ ἐμὲ τοῦδ’</l>
 						<l>ἔθιγε θηρός· εὐτυχής γ’ ἅδ’ ἄγρα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>
 							<gap desc="*"/>
@@ -2329,68 +2329,68 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>μέτεχέ νυν θοίνας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τί; μετέχω, τλᾶμον;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l n="1185">νέος ὁ μόσχος ἄρ‐</l>
 						<l>τι γένυν ὑπὸ κόρυθ’ ἁπαλότριχα</l>
 						<l>κατάκομον θάλλει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρέπει γ’ ὥστε θὴρ ἄγραυλος φόβῃ.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>ὁ Βάκχιος κυναγέτας</l>
 						<l n="1190">σοφὸς σοφῶς ἀνέπηλ’ ἐπὶ θῆρα</l>
 						<l>τόνδε μαινάδας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ γὰρ ἄναξ ἀγρεύς.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>ἐπαινεῖς;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἐπαινῶ.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>τάχα δὲ Καδμεῖοι . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1195">καὶ παῖς γε Πενθεὺς . . .</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l part="Y">ματέρ’ ἐπαινέσεται,</l>
 						<l>λαβοῦσαν ἄγραν τάνδε λεοντοφυῆ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>περισσάν.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l part="Y">περισσῶς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀγάλλῃ;</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l part="Y">γέγηθα,</l>
 						<l n="1198b">μεγάλα μεγάλα καὶ</l>
@@ -2400,12 +2400,12 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1200">δεῖξόν νυν, ὦ τάλαινα, σὴν νικηφόρον</l>
 					<l>ἀστοῖσιν ἄγραν ἣν φέρουσ’ ἐλήλυθας.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ὦ καλλίπυργον ἄστυ Θηβαίας χθονὸς</l>
 					<l>ναίοντες, ἔλθεθ’ ὡς ἴδητε τήνδ’ ἄγραν,</l>
@@ -2448,7 +2448,7 @@ convert to P3
 					<l>στείχειν Ἀγαύην, οὐδ’ ἄκραντ’ ἠκούσαμεν·</l>
 					<l>λεύσσω γὰρ αὐτήν, ὄψιν οὐκ εὐδαίμονα.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>πάτερ, μέγιστον κομπάσαι πάρεστί σοι,</l>
 					<l>πάντων ἀρίστας θυγατέρας σπεῖραι μακρῷ</l>
@@ -2473,7 +2473,7 @@ convert to P3
 					<l>ὡς ὁ θεὸς ἡμᾶς ἐνδίκως μέν, ἀλλ’ ἄγαν,</l>
 					<l n="1250">Βρόμιος ἄναξ ἀπώλεσ’ οἰκεῖος γεγώς.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ὡς δύσκολον τὸ γῆρας ἀνθρώποις ἔφυ</l>
 					<l>ἔν τ’ ὄμμασι σκυθρωπόν. εἴθε παῖς ἐμὸς</l>
@@ -2491,7 +2491,7 @@ convert to P3
 					<l>ἐν τῷδ’ ἀεὶ μενεῖτ’ ἐν ᾧ καθέστατε,</l>
 					<l>οὐκ εὐτυχοῦσαι δόξετ’ οὐχὶ δυστυχεῖν.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>τί δ’ οὐ καλῶς τῶνδ’ ἢ τί λυπηρῶς ἔχει;</l>
 				</sp>
@@ -2499,7 +2499,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>πρῶτον μὲν ἐς τόνδ’ αἰθέρ’ ὄμμα σὸν μέθες.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l n="1265">ἰδού· τί μοι τόνδ’ ἐξυπεῖπας εἰσορᾶν;</l>
 				</sp>
@@ -2507,7 +2507,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>ἔθ’ αὑτὸς ἤ σοι μεταβολὰς ἔχειν δοκεῖ;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>λαμπρότερος ἢ πρὶν καὶ διειπετέστερος.</l>
 				</sp>
@@ -2515,7 +2515,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>τὸ δὲ πτοηθὲν τόδ’ ἔτι σῇ ψυχῇ πάρα;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>οὐκ οἶδα τοὔπος τοῦτο. γίγνομαι δέ πως</l>
 					<l n="1270">ἔννους, μετασταθεῖσα τῶν πάρος φρενῶν.</l>
@@ -2524,7 +2524,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>κλύοις ἂν οὖν τι κἀποκρίναῑ ἂν σαφῶς;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ὡς ἐκλέλησμαί γ’ ἃ πάρος εἴπομεν, πάτερ.</l>
 				</sp>
@@ -2532,7 +2532,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>ἐς ποῖον ἦλθες οἶκον ὑμεναίων μέτα;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>Σπαρτῷ μ’ ἔδωκας, ὡς λέγουσ’, Ἐχίονι.</l>
 				</sp>
@@ -2540,7 +2540,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l n="1275">τίς οὖν ἐν οἴκοις παῖς ἐγένετο σῷ πόσει;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>Πενθεύς, ἐμῇ τε καὶ πατρὸς κοινωνίᾳ.</l>
 				</sp>
@@ -2548,7 +2548,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>τίνος πρόσωπον δῆτ’ ἐν ἀγκάλαις ἔχεις;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>λέοντος, ὥς γ’ ἔφασκον αἱ θηρώμεναι.</l>
 				</sp>
@@ -2557,7 +2557,7 @@ convert to P3
 					<l>σκέψαι νυν ὀρθῶς· βραχὺς ὁ μόχθος εἰσιδεῖν.</l>
 					<milestone ed="p" n="1280" unit="card"/>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l n="1280">ἔα, τί λεύσσω; τί φέρομαι τόδ’ ἐν χεροῖν;</l>
 				</sp>
@@ -2565,7 +2565,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>ἄθρησον αὐτὸ καὶ σαφέστερον μάθε.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ὁρῶ μέγιστον ἄλγος ἡ τάλαιν’ ἐγώ.</l>
 				</sp>
@@ -2573,7 +2573,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>μῶν σοι λέοντι φαίνεται προσεικέναι;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>οὔκ, ἀλλὰ Πενθέως ἡ τάλαιν’ ἔχω κάρα.</l>
 				</sp>
@@ -2581,7 +2581,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l n="1285">ᾠμωγμένον γε πρόσθεν ἢ σὲ γνωρίσαι.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>τίς ἔκτανέν νιν; ‐‐πῶς ἐμὰς ἦλθεν χέρας;</l>
 				</sp>
@@ -2589,7 +2589,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>δύστην’ ἀλήθεῑ, ὡς ἐν οὐ καιρῷ πάρει.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>λέγ’, ὡς τὸ μέλλον καρδία πήδημ’ ἔχει.</l>
 				</sp>
@@ -2597,7 +2597,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>σύ νιν κατέκτας καὶ κασίγνηται σέθεν.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l n="1290">ποῦ δ’ ὤλετ’; ἦ κατ’ οἶκον; ἢ ποίοις τόποις;</l>
 				</sp>
@@ -2605,7 +2605,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>οὗπερ πρὶν Ἀκτέωνα διέλαχον κύνες.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>τί δ’ ἐς Κιθαιρῶν’ ἦλθε δυσδαίμων ὅδε;</l>
 				</sp>
@@ -2613,7 +2613,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>ἐκερτόμει θεὸν σάς τε βακχείας μολών.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ἡμεῖς δ’ ἐκεῖσε τίνι τρόπῳ κατήραμεν;</l>
 				</sp>
@@ -2621,7 +2621,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l n="1295">ἐμάνητε, πᾶσά τ’ ἐξεβακχεύθη πόλις.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>Διόνυσος ἡμᾶς ὤλεσ’, ἄρτι μανθάνω.</l>
 				</sp>
@@ -2629,7 +2629,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>ὕβριν &lt;γ’&gt; ὑβρισθείς· θεὸν γὰρ οὐχ ἡγεῖσθέ νιν.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>τὸ φίλτατον δὲ σῶμα ποῦ παιδός, πάτερ;</l>
 				</sp>
@@ -2637,7 +2637,7 @@ convert to P3
 					<speaker>Κάδμος</speaker>
 					<l>ἐγὼ μόλις τόδ’ ἐξερευνήσας φέρω.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l n="1300">ἦ πᾶν ἐν ἄρθροις συγκεκλῃμένον καλῶς;</l>
 				</sp>
@@ -2647,7 +2647,7 @@ convert to P3
 						<gap desc="*"/>
 					</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>Πενθεῖ δὲ τί μέρος ἀφροσύνης προσῆκ’ ἐμῆς;</l>
 				</sp>
@@ -2679,12 +2679,12 @@ convert to P3
 					<l n="1325">εἰ δ’ ἔστιν ὅστις δαιμόνων ὑπερφρονεῖ,</l>
 					<l>ἐς τοῦδ’ ἀθρήσας θάνατον ἡγείσθω θεούς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τὸ μὲν σὸν ἀλγῶ, Κάδμε· σὸς δ’ ἔχει δίκην</l>
 					<l>παῖς παιδὸς ἀξίαν μέν, ἀλγεινὴν δὲ σοί.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ὦ πάτερ, ὁρᾷς γὰρ τἄμ’ ὅσῳ μετεστράφη ...</l>
 					<l>
@@ -2736,7 +2736,7 @@ convert to P3
 					<speaker>Διόνυσος</speaker>
 					<l>πάλαι τάδε Ζεὺς οὑμὸς ἐπένευσεν πατήρ.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l n="1350">αἰαῖ, δέδοκται, πρέσβυ, τλήμονες φυγαί.</l>
 				</sp>
@@ -2758,7 +2758,7 @@ convert to P3
 					<l>κακῶν ὁ τλήμων, οὐδὲ τὸν καταιβάτην</l>
 					<l>Ἀχέροντα πλεύσας ἥσυχος γενήσομαι.</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ὦ πάτερ, ἐγὼ δὲ σοῦ στερεῖσα φεύξομαι.</l>
 				</sp>
@@ -2767,7 +2767,7 @@ convert to P3
 					<l>τί μ’ ἀμφιβάλλεις χερσίν, ὦ τάλαινα παῖ,</l>
 					<l n="1365">ὄρνις ὅπως κηφῆνα πολιόχρων κύκνος;</l>
 				</sp>
-				<sp who="#agaye">
+				<sp who="#agaue">
 					<speaker>Ἀγαύη</speaker>
 					<l>ποῖ γὰρ τράπωμαι πατρίδος ἐκβεβλημένη;</l>
 				</sp>
@@ -2777,7 +2777,7 @@ convert to P3
 					<milestone ed="p" n="1368" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>χαῖρ’, ὦ μέλαθρον, χαῖρ’, ὦ πατρία</l>
 						<l>πόλις· ἐκλείπω σ’ ἐπὶ δυστυχίᾳ</l>
@@ -2790,7 +2790,7 @@ convert to P3
 							<gap desc="*"/>
 						</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>στένομαί σε, πάτερ.</l>
 					</sp>
@@ -2799,7 +2799,7 @@ convert to P3
 						<l part="Y">κἀγὼ &lt;σέ&gt;, τέκνον,</l>
 						<l>καὶ σὰς ἐδάκρυσα κασιγνήτας.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>δεινῶς γὰρ τάνδ’ αἰκείαν</l>
 						<l n="1375">Διόνυσος ἄναξ τοὺς σοὺς εἰς</l>
@@ -2810,7 +2810,7 @@ convert to P3
 						<l>καὶ γὰρ ἔπασχον δεινὰ πρὸς ὑμῶν,</l>
 						<l>ἀγέραστον ἔχων ὄνομ’ ἐν Θήβαις.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>χαῖρε, πάτερ, μοι.</l>
 					</sp>
@@ -2819,7 +2819,7 @@ convert to P3
 						<l part="Y">χαῖρ’, ὦ μελέα</l>
 						<l n="1380">θύγατερ. χαλεπῶς &lt;δ’&gt; ἐς τόδ’ ἂν ἥκοις.</l>
 					</sp>
-					<sp who="#agaye">
+					<sp who="#agaue">
 						<speaker>Ἀγαύη</speaker>
 						<l>ἄγετ’, ὦ πομποί, με κασιγνήτας</l>
 						<l>ἵνα συμφυγάδας ληψόμεθ’ οἰκτράς.</l>
@@ -2829,7 +2829,7 @@ convert to P3
 						<l>μήθ’ ὅθι θύρσου μνῆμ’ ἀνάκειται·</l>
 						<l>Βάκχαις δ’ ἄλλαισι μέλοιεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλαὶ μορφαὶ τῶν δαιμονίων,</l>
 						<l>πολλὰ δ’ ἀέλπτως κραίνουσι θεοί·</l>

--- a/tei/euripides-electra.xml
+++ b/tei/euripides-electra.xml
@@ -57,7 +57,7 @@
 					<person xml:id="presbys" sex="MALE">
 						<persName>Πρέσβυς</persName>
 					</person>
-					<person xml:id="aggelos" sex="MALE">
+					<person xml:id="angelos" sex="MALE">
 						<persName>Ἄγγελος</persName>
 					</person>
 					<personGrp xml:id="dioskoyroi" sex="MALE">
@@ -66,10 +66,10 @@
 					<person xml:id="klytaimestra" sex="FEMALE">
 						<persName>Κλυταιμήστρα</persName>
 					</person>
-					<person xml:id="aytoyrgos" sex="MALE">
+					<person xml:id="autourgos" sex="MALE">
 						<persName>Αὐτουργός</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="FEMALE">
+					<personGrp xml:id="choros" sex="FEMALE">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="elektra" sex="FEMALE">
@@ -163,7 +163,7 @@ convert to P3
 		<body>
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp n="Αὐτουργός" who="#aytoyrgos">
+				<sp n="Αὐτουργός" who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>ὦ γῆς παλαιὸν ἄργος, Ἰνάχου ῥοαί,</l>
 					<l>ὅθεν ποτ’ ἄρας ναυσὶ χιλίαις Ἄρη</l>
@@ -239,7 +239,7 @@ convert to P3
 					<l>τεκοῦσα δ’ ἄλλους παῖδας Αἰγίσθῳ πάρα</l>
 					<l>πάρεργ’ Ὀρέστην κἀμὲ ποιεῖται δόμων — </l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>τί γὰρ τάδ’, ὦ δύστην’, ἐμὴν μοχθεῖς χάριν</l>
 					<l n="65">πόνους ἔχουσα, πρόσθεν εὖ τεθραμμένη,</l>
@@ -258,7 +258,7 @@ convert to P3
 					<l n="75">ἐξευτρεπίζειν. εἰσιόντι δ’ ἐργάτῃ</l>
 					<l>θύραθεν ἡδὺ τἄνδον εὑρίσκειν καλῶς.</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>εἴ τοι δοκεῖ σοι, στεῖχε· καὶ γὰρ οὐ πρόσω</l>
 					<l>πηγαὶ μελάθρων τῶνδ’. ἐγὼ δ’ ἅμ’ ἡμέρᾳ</l>
@@ -402,7 +402,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἀγαμέμνονος ὦ κόρα,</l>
 						<l>ἤλυθον, Ἠλέκτρα, ποτὶ</l>
@@ -435,7 +435,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="190">μεγάλα θεός· ἀλλ’ ἴθι,</l>
 						<l>καὶ παρ’ ἐμοῦ χρῆσαι πολύ‐</l>
@@ -469,7 +469,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πολλῶν κακῶν Ἕλλησιν αἰτίαν ἔχει</l>
 					<l>σῆς μητρὸς Ἑλένη σύγγονος δόμοις τε σοῖς.</l>
@@ -775,7 +775,7 @@ convert to P3
 					<l n="295">σοφοῖσι δ’ ἀνδρῶν· καὶ γὰρ οὐδ’ ἀζήμιον</l>
 					<l>γνώμην ἐνεῖναι τοῖς σοφοῖς λίαν σοφήν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>κἀγὼ τὸν αὐτὸν τῷδ’ ἔρον ψυχῆς ἔχω.</l>
 					<l>πρόσω γὰρ ἄστεως οὖσα τἀν πόλει κακὰ</l>
@@ -827,13 +827,13 @@ convert to P3
 					<l>ὁ δ’ ἄνδρ’ ἕν’ εἷς ὢν οὐ δυνήσεται κτανεῖν,</l>
 					<l>νέος πεφυκὼς κἀξ ἀμείνονος πατρός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ μὴν δέδορκα τόνδε, σὸν λέγω πόσιν,</l>
 					<l n="340">λήξαντα μόχθου πρὸς δόμους ὡρμημένον.</l>
 					<milestone ed="p" n="341" unit="card"/>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>ἔα· τίνας τούσδ’ ἐν πύλαις ὁρῶ ξένους;</l>
 					<l>τίνος δ’ ἕκατι τάσδ’ ἐπ’ ἀγραύλους πύλας</l>
@@ -847,7 +847,7 @@ convert to P3
 					<l>ἥκουσ’ Ὀρέστου πρός με κήρυκες λόγων.</l>
 					<l>ἀλλ’, ὦ ξένοι, σύγγνωτε τοῖς εἰρημένοις.</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>τί φασίν; ἁνὴρ ἔστι καὶ λεύσσει φάος;</l>
 				</sp>
@@ -855,7 +855,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="350">ἔστιν λόγῳ γοῦν, φασὶ δ’ οὐκ ἄπιστ’ ἐμοί.</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>ἦ καί τι πατρὸς σῶν τε μέμνηται κακῶν;</l>
 				</sp>
@@ -863,7 +863,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἐν ἐλπίσιν ταῦτ’· ἀσθενὴς φεύγων ἀνήρ.</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>ἦλθον δ’ Ὀρέστου τίν’ ἀγορεύοντες λόγον;</l>
 				</sp>
@@ -871,7 +871,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>σκοποὺς ἔπεμψε τούσδε τῶν ἐμῶν κακῶν.</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l n="355">οὐκοῦν τὰ μὲν λεύσσουσι, τὰ δὲ σύ που λέγεις.</l>
 				</sp>
@@ -879,7 +879,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἴσασιν, οὐδὲν τῶνδ’ ἔχουσιν ἐνδεές.</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>οὐκοῦν πάλαι χρῆν τοῖσδ’ ἀνεπτύχθαι πύλας;</l>
 					<l>χωρεῖτ’ ἐς οἴκους· ἀντὶ γὰρ χρηστῶν λόγων</l>
@@ -941,7 +941,7 @@ convert to P3
 					<l n="400">χρησμοί, βροτῶν δὲ μαντικὴν χαίρειν ἐῶ.</l>
 					<milestone ed="p" n="401" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>νῦν ἢ πάροιθεν μᾶλλον, Ἠλέκτρα, χαρᾷ</l>
 					<l>θερμαινόμεσθα καρδίαν· ἴσως γὰρ ἂν</l>
@@ -952,7 +952,7 @@ convert to P3
 					<l>ὦ τλῆμον, εἰδὼς δωμάτων χρείαν σέθεν</l>
 					<l n="405">τί τούσδ’ ἐδέξω μείζονας σαυτοῦ ξένους;</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l>τί δ’; εἴπερ εἰσὶν ὡς δοκοῦσιν εὐγενεῖς,</l>
 					<l>οὐκ ἔν τε μικροῖς ἔν τε μὴ στέρξουσ’ ὁμῶς;</l>
@@ -972,7 +972,7 @@ convert to P3
 					<l>λάβοιμεν ἄν τι· πικρὰ δ’ ἀγγείλαιμεν ἄν,</l>
 					<l>εἰ ζῶντ’ Ὀρέστην ἡ τάλαιν’ αἴσθοιτ’ ἔτι.</l>
 				</sp>
-				<sp who="#aytoyrgos">
+				<sp who="#autourgos">
 					<speaker>Αὐτουργός</speaker>
 					<l n="420">ἀλλ’, εἰ δοκεῖ σοι, τούσδ’ ἀπαγγελῶ λόγους</l>
 					<l>γέροντι· χώρει δ’ ἐς δόμους ὅσον τάχος</l>
@@ -991,7 +991,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κλειναὶ νᾶες, αἵ ποτ’ ἔβατε Τροίαν</l>
 						<l>τοῖς ἀμετρήτοις ἐρετμοῖς</l>
@@ -1007,7 +1007,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Νηρῇδες δ’ Εὐβοῖδας ἄκρας λιποῦσαι</l>
 						<l>μόχθους ἀσπιστὰς ἀκμόνων</l>
@@ -1023,7 +1023,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἰλιόθεν δ’ ἔκλυόν τινος ἐν λιμέσιν</l>
 						<l>Ναυπλίοισι βεβῶτος</l>
@@ -1042,7 +1042,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐν δὲ μέσῳ κατέλαμπε σάκει φαέθων</l>
 						<l n="465">κύκλος ἀελίοιο</l>
@@ -1061,7 +1061,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄορι δ’ ἐν φονίῳ τετραβάμονες ἵπποι ἔπαλ‐</l>
 						<l>λον, κελαινὰ δ’ ἀμφὶ νῶθ’ ἵετο κόνις.</l>
@@ -1303,7 +1303,7 @@ convert to P3
 					<milestone ed="p" n="585" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="585">ἔμολες ἔμολες, ὤ, χρόνιος ἁμέρα,</l>
 						<l>κατέλαμψας, ἔδειξας ἐμφανῆ</l>
@@ -1662,7 +1662,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀταλᾶς ὑπὸ ματρὸς &lt;ἄρν’&gt;</l>
 						<l>Ἀργείων</l>
@@ -1683,7 +1683,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θυμέλαι δ’ ἐπίτναντο χρυ‐</l>
 						<l>σήλατοι,</l>
@@ -1704,7 +1704,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τότε δὴ τότε φαεν‐</l>
 						<l>νὰς ἄστρων μετέβασ’ ὁδοὺς</l>
@@ -1720,7 +1720,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λέγεται, τὰν δὲ πί‐</l>
 						<l>στιν σμικρὰν παρ’ ἔμοιγ’ ἔχει,</l>
@@ -1737,7 +1737,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔα ἔα·</l>
 					<l>φίλαι, βοῆς ἠκούσατ’ — ἢ δοκὼ κενὴ</l>
@@ -1749,7 +1749,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>φίλαι, τί χρῆμα; πῶς ἀγῶνος ἥκομεν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ οἶδα πλὴν ἕν· φόνιον οἰμωγὴν κλύω.</l>
 				</sp>
@@ -1757,7 +1757,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἤκουσα κἀγώ, τηλόθεν μέν, ἀλλ’ ὅμως.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μακρὰν γὰρ ἕρπει γῆρυς, ἐμφανής γε μήν.</l>
 				</sp>
@@ -1765,7 +1765,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="755">Ἀργεῖος ὁ στεναγμός· ἦ φίλων ἐμῶν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ οἶδα· πᾶν γὰρ μείγνυται μέλος βοῆς.</l>
 				</sp>
@@ -1773,7 +1773,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>σφαγὴν ἀυτεῖς τήνδε μοι· τί μέλλομεν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔπισχε, τρανῶς ὡς μάθῃς τύχας σέθεν.</l>
 				</sp>
@@ -1781,11 +1781,11 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>οὐκ ἔστι· νικώμεσθα· ποῦ γὰρ ἄγγελοι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="760">ἥξουσιν· οὔτοι βασιλέα φαῦλον κτανεῖν.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὦ καλλίνικοι παρθένοι Μυκηνίδες,</l>
 					<l>νικῶντ’ Ὀρέστην πᾶσιν ἀγγέλλω φίλοις,</l>
@@ -1796,7 +1796,7 @@ convert to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="765">τίς δ’ εἶ σύ; πῶς μοι πιστὰ σημαίνεις τάδε;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐκ οἶσθ’ ἀδελφοῦ μ’ εἰσορῶσα πρόσπολον;</l>
 				</sp>
@@ -1806,7 +1806,7 @@ convert to P3
 					<l>εἶχον προσώπου· νῦν δὲ γιγνώσκω σε δή.</l>
 					<l>τί φῄς; τέθνηκε πατρὸς ἐμοῦ στυγνὸς φονεύς;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="770">τέθνηκε· δίς σοι ταὔθ’, ἃ γοῦν βούλῃ, λέγω.</l>
 				</sp>
@@ -1817,7 +1817,7 @@ convert to P3
 					<l>κτείνει Θυέστου παῖδα; βούλομαι μαθεῖν.</l>
 					<milestone ed="p" n="774" unit="card"/>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐπεὶ μελάθρων τῶνδ’ ἀπήραμεν πόδα,</l>
 					<l n="775">ἐσβάντες ᾖμεν δίκροτον εἰς ἁμαξιτὸν</l>
@@ -1919,7 +1919,7 @@ convert to P3
 			<milestone ed="p" n="859" unit="card"/>
 			<div1 type="choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θὲς ἐς χορόν, ὦ φίλα, ἴχνος,</l>
 						<l n="860">ὡς νεβρὸς οὐράνιον</l>
@@ -1943,7 +1943,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὺ μέν νυν ἀγάλματ’ ἄειρε</l>
 						<l>κρατί· τὸ δ’ ἁμέτερον</l>
@@ -2072,7 +2072,7 @@ convert to P3
 					<l>γραμμῆς ἵκηται καὶ τέλος κάμψῃ βίου.</l>
 				</sp>
 				<milestone ed="p" n="957" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔπραξε δεινά, δεινὰ δ’ ἀντέδωκε σοὶ</l>
 					<l>καὶ τῷδ’· ἔχει γὰρ ἡ Δίκη μέγα σθένος.</l>
@@ -2181,7 +2181,7 @@ convert to P3
 					<milestone ed="p" n="988" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>[ἰώ,]</l>
 						<l>βασίλεια γύναι χθονὸς Ἀργείας,</l>
@@ -2268,7 +2268,7 @@ convert to P3
 						<l>λέγ’, εἴ τι χρῄζεις, κἀντίθες παρρησίᾳ,</l>
 						<l n="1050">ὅπως τέθνηκε σὸς πατὴρ οὐκ ἐνδίκως.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δίκαῑ ἔλεξας· ἡ δίκη δ’ αἰσχρῶς ἔχει.</l>
 						<l>γυναῖκα γὰρ χρὴ πάντα συγχωρεῖν πόσει,</l>
@@ -2340,7 +2340,7 @@ convert to P3
 						<l>μεγάλων ἀμείνω σώφρον’ ἐν δόμοις λέχη.</l>
 						<milestone ed="p" n="1100" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1100">τύχη γυναικῶν ἐς γάμους. τὰ μὲν γὰρ εὖ,</l>
 						<l>τὰ δ’ οὐ καλῶς πίπτοντα δέρκομαι βροτῶν.]</l>
@@ -2458,7 +2458,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀμοιβαὶ κακῶν· μετάτροποι πνέου‐</l>
 						<l>σιν αὖραι δόμων. τότε μὲν &lt;ἐν&gt; λουτροῖς</l>
@@ -2473,7 +2473,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1155">παλίρρους δὲ τάνδ’ ὑπάγεται δίκα</l>
 						<l>διαδρόμου λέχους μέλεον ἃ πόσιν</l>
@@ -2491,7 +2491,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κλύεις ὑπώροφον βοάν;</l>
 					</sp>
@@ -2501,7 +2501,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ἰώ μοί μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<!-- last three lines of this speech were tagged "meter = lyric";  they are dochmiacs -->
 						<l>ᾤμωξα κἀγὼ πρὸς τέκνων χειρουμένης.</l>
@@ -2510,7 +2510,7 @@ convert to P3
 						<l>τάλαιν’, εὐνέταν.</l>
 						<milestone ed="p" n="1172" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ οἵδε μητρὸς νεοφόνοις ἐν αἵμασι</l>
 						<l>πεφυρμένοι βαίνουσιν ἐξ οἴκων πόδα,</l>
@@ -2539,7 +2539,7 @@ convert to P3
 						<l>διὰ πυρὸς ἔμολον ἁ τάλαινα ματρὶ τᾷδ’,</l>
 						<l>ἅ μ’ ἔτικτε κούραν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1185">ἰὼ τύχας, σᾶς τύχας,</l>
 						<l>μᾶτερ τεκοῦσ’ &lt;ἄλαστα&gt;,</l>
@@ -2567,7 +2567,7 @@ convert to P3
 						<l>τίνα γάμον εἶμι; τίς πόσις με δέξεται</l>
 						<l n="1200">νυμφικὰς ἐς εὐνάς;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάλιν, πάλιν φρόνημα σὸν</l>
 						<l>μετεστάθη πρὸς αὔραν·</l>
@@ -2585,7 +2585,7 @@ convert to P3
 						<l>ἰώ μοι, πρὸς πέδῳ</l>
 						<l>τιθεῖσα γόνιμα μέλεα; τὰν κόμαν δ’ ἐγὼ — </l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1210">σάφ’ οἶδα, δῑ ὀδύνας ἔβας,</l>
 						<l>ἰήιον κλύων γόον</l>
@@ -2601,7 +2601,7 @@ convert to P3
 						<l>παρῄδων τ’ ἐξ ἐμᾶν</l>
 						<l>ἐκρίμναθ’, ὥστε χέρας ἐμὰς λιπεῖν βέλος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάλαινα· πῶς ἔτλας φόνον</l>
 						<l>δῑ ὀμμάτων ἰδεῖν σέθεν</l>
@@ -2621,7 +2621,7 @@ convert to P3
 						<l>ἐγὼ δ’ ἐπεγκέλευσά σοι</l>
 						<l n="1225">ξίφους τ’ ἐφηψάμαν ἅμα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεινότατον παθέων ἔρεξας.</l>
 						<milestone ed="p" n="1227" unit="card"/>
@@ -2639,7 +2639,7 @@ convert to P3
 						<l n="1230">ἰδού, φίλᾳ τε κοὐ φίλᾳ</l>
 						<l>φάρεα τάδ’ ἀμφιβάλλομεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τέρμα κακῶν μεγάλων δόμοισιν.</l>
 						<milestone ed="p" n="1233" unit="card"/>
@@ -2648,7 +2648,7 @@ convert to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ οἵδε δόμων ὑπὲρ ἀκροτάτων</l>
 						<l>φαίνουσι τίνες — δαίμονες ἢ θεῶν</l>
@@ -2727,7 +2727,7 @@ convert to P3
 					<milestone ed="p" n="1292" unit="card"/>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ παῖδε Διός, θέμις ἐς φθογγὰς</l>
 						<l>τὰς ὑμετέρας ἡμῖν πελάθειν;</l>
@@ -2745,7 +2745,7 @@ convert to P3
 						<l>καὶ σοί· Φοίβῳ τήνδ’ ἀναθήσω</l>
 						<l>πρᾶξιν φονίαν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς ὄντε θεὼ τῆσδέ τ’ ἀδελφὼ</l>
 						<l>τῆς καπφθιμένης</l>
@@ -2863,7 +2863,7 @@ convert to P3
 						<l n="1355">μηδ’ ἐπιόρκων μέτα συμπλείτω·</l>
 						<l>θεὸς ὢν θνητοῖς ἀγορεύω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαίρετε· χαίρειν δ’ ὅστις δύναται</l>
 						<l>καὶ ξυντυχίᾳ μή τινι κάμνει</l>

--- a/tei/euripides-hecuba.xml
+++ b/tei/euripides-hecuba.xml
@@ -60,22 +60,22 @@
 					<person xml:id="polymestor" sex="MALE">
 						<persName>Πολυμήστωρ</persName>
 					</person>
-					<person xml:id="polydoroyeidolon" sex="MALE">
+					<person xml:id="polydorou_eidolon" sex="MALE">
 						<persName>Πολυδώρου εἴδωλον</persName>
 					</person>
-					<person xml:id="odysseys" sex="MALE">
+					<person xml:id="odysseus" sex="MALE">
 						<persName>Ὀδυσσεύς</persName>
 					</person>
 					<person xml:id="agamemnon" sex="MALE">
 						<persName>Ἀγαμέμνων</persName>
 					</person>
-					<person xml:id="ekabe" sex="FEMALE">
+					<person xml:id="hekabe" sex="FEMALE">
 						<persName>Ἑκάβη</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="FEMALE">
+					<personGrp xml:id="choros" sex="FEMALE">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="polyksene" sex="FEMALE">
+					<person xml:id="polyxene" sex="FEMALE">
 						<persName>Πολυξένη</persName>
 					</person>
 				</listPerson>
@@ -159,7 +159,7 @@ convert to P3
 		<body>
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp n="Πολυδώρου εἴδωλον" who="#polydoroyeidolon">
+				<sp n="Πολυδώρου εἴδωλον" who="#polydorou_eidolon">
 					<speaker>Πολυδώρου εἴδωλον</speaker>
 					<l>Ἥκω νεκρῶν κευθμῶνα καὶ σκότου πύλας</l>
 					<l>λιπών, ἵν’ Ἅιδης χωρὶς ᾤκισται θεῶν,</l>
@@ -229,7 +229,7 @@ convert to P3
 			<milestone ed="p" n="59" unit="card"/>
 			<div1 type="choral">
 				<div2 type="anapests">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἄγετ’, ὦ παῖδες, τὴν γραῦν πρὸ δόμων,</l>
 						<l n="60">ἄγετ’ ὀρθοῦσαι τὴν ὁμόδουλον,</l>
@@ -273,7 +273,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp n="Χορός" who="#xoros">
+					<sp n="Χορός" who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἑκάβη, σπουδῇ πρός σ’ ἐλιάσθην</l>
 						<l>τὰς δεσποσύνους σκηνὰς προλιποῦσ’,</l>
@@ -339,7 +339,7 @@ convert to P3
 					<milestone ed="p" n="154" unit="card"/>
 				</div2>
 				<div2 type="strophe">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οἲ ἐγὼ μελέα, τί ποτ’ ἀπύσω;</l>
 						<l n="155">ποίαν ἀχώ, ποῖον ὀδυρμόν,</l>
@@ -367,52 +367,52 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="mesode">
-					<sp who="#polyksene">
+					<sp who="#polyxene">
 						<speaker>Πολυξένη</speaker>
 						<l>ἰώ·</l>
 						<l>μᾶτερ μᾶτερ τί βοᾷς; τί νέον</l>
 						<l>καρύξασ’ οἴκων μ’ ὥστ’ ὄρνιν</l>
 						<l>θάμβει τῷδ’ ἐξέπταξας;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="180">οἴμοι τέκνον.</l>
 					</sp>
-					<sp who="#polyksene">
+					<sp who="#polyxene">
 						<speaker>Πολυξένη</speaker>
 						<l>τί με δυσφημεῖς; φροίμιά μοι κακά.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>αἰαῖ σᾶς ψυχᾶς.</l>
 					</sp>
-					<sp who="#polyksene">
+					<sp who="#polyxene">
 						<speaker>Πολυξένη</speaker>
 						<l>ἐξαύδα· μὴ κρύψῃς δαρόν.</l>
 						<l>δειμαίνω δειμαίνω, μᾶτερ,</l>
 						<l n="185">τί ποτ’ ἀναστένεις . . .</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>[ὦ] τέκνον τέκνον μελέας ματρὸς . . .</l>
 					</sp>
-					<sp who="#polyksene">
+					<sp who="#polyxene">
 						<speaker>Πολυξένη</speaker>
 						<l>τί &lt;δὲ&gt; τόδ’ ἀγγελεῖς;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>σφάξαι σ’ Ἀργείων κοινὰ</l>
 						<l>συντείνει πρὸς τύμβον γνώμα</l>
 						<l n="190">Πηλείᾳ γέννᾳ.</l>
 					</sp>
-					<sp who="#polyksene">
+					<sp who="#polyxene">
 						<speaker>Πολυξένη</speaker>
 						<l>οἴμοι μᾶτερ, πῶς φθέγγῃ</l>
 						<l>ἀμέγαρτα κακῶν; μάνυσόν μοι,</l>
 						<l>μάνυσον, μᾶτερ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>αὐδῶ, παῖ, δυσφήμους φήμας·</l>
 						<l n="195">ἀγγέλλουσ’ Ἀργείων δόξαι</l>
@@ -421,7 +421,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#polyksene">
+					<sp who="#polyxene">
 						<speaker>Πολυξένη</speaker>
 						<l>ὦ δεινὰ παθοῦσ’, ὦ παντλάμων,</l>
 						<l>ὦ δυστάνου μᾶτερ βιοτᾶς</l>
@@ -448,12 +448,12 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ μὴν Ὀδυσσεὺς ἔρχεται σπουδῇ ποδός,</l>
 					<l>Ἑκάβη, νέον τι πρὸς σὲ σημανῶν ἔπος.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>γύναι, δοκῶ μέν σ’ εἰδέναι γνώμην στρατοῦ</l>
 					<l>ψῆφόν τε τὴν κρανθεῖσαν· ἀλλ’ ὅμως φράσω.</l>
@@ -467,7 +467,7 @@ convert to P3
 					<l>γίγνωσκε δ’ ἀλκὴν καὶ παρουσίαν κακῶν</l>
 					<l>τῶν σῶν. σοφόν τοι κἀν κακοῖς ἃ δεῖ φρονεῖν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>αἰαῖ· παρέστηχ’, ὡς ἔοικ’, ἀγὼν μέγας,</l>
 					<l n="230">πλήρης στεναγμῶν οὐδὲ δακρύων κενός.</l>
@@ -479,54 +479,54 @@ convert to P3
 					<l>ἐξιστορῆσαι, σοὶ μὲν εἰρῆσθαι χρεών,</l>
 					<l>ἡμᾶς δ’ ἀκοῦσαι τοὺς ἐρωτῶντας τάδε.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἔξεστ’, ἐρώτα· τοῦ χρόνου γὰρ οὐ φθονῶ.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἶσθ’ ἡνίκ’ ἦλθες Ἰλίου κατάσκοπος,</l>
 					<l n="240">δυσχλαινίᾳ τ’ ἄμορφος, ὀμμάτων τ’ ἄπο</l>
 					<l>φόνου σταλαγμοὶ σὴν κατέσταζον γένυν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οἶδ’· οὐ γὰρ ἄκρας καρδίας ἔψαυσέ μου.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἔγνω δέ σ’ Ἑλένη καὶ μόνῃ κατεῖπ’ ἐμοί;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>μεμνήμεθ’ ἐς κίνδυνον ἐλθόντες μέγαν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="245">ἥψω δὲ γονάτων τῶν ἐμῶν ταπεινὸς ὤν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ὥστ’ ἐνθανεῖν γε σοῖς πέπλοισι χεῖρ’ ἐμήν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἔσωσα δῆτά σ’ ἐξέπεμψά τε χθονός;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ὥστ’ εἰσορᾶν γε φέγγος ἡλίου τόδε.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>τί δῆτ’ ἔλεξας δοῦλος ὢν ἐμὸς τότε;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="250">πολλῶν λόγων εὑρήμαθ’, ὥστε μὴ θανεῖν.</l>
 					<milestone ed="p" n="251" unit="card"/>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οὔκουν κακύνῃ τοῖσδε τοῖς βουλεύμασιν,</l>
 					<l>ὃς ἐξ ἐμοῦ μὲν ἔπαθες οἷα φὴ|ς παθεῖν,</l>
@@ -574,14 +574,14 @@ convert to P3
 					<l>πείσει· λόγος γὰρ ἔκ τ’ ἀδοξούντων ἰὼν</l>
 					<l n="295">κἀκ τῶν δοκούντων αὑτὸς οὐ ταὐτὸν σθένει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ ἔστιν οὕτω στερρὸς ἀνθρώπου φύσις,</l>
 					<l>ἥτις γόων σῶν καὶ μακρῶν ὀδυρμάτων</l>
 					<l>κλύουσα θρήνους οὐκ ἂν ἐκβάλοι δάκρυ.</l>
 					<milestone ed="p" n="299" unit="card"/>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>Ἑκάβη, διδάσκου, μηδὲ τῷ θυμουμένῳ</l>
 					<l n="300">τὸν εὖ λέγοντα δυσμενῆ ποιοῦ φρενός.</l>
@@ -617,12 +617,12 @@ convert to P3
 					<l n="330">θαυμάζεθ’, ὡς ἂν ἡ μὲν Ἑλλὰς εὐτυχῇ,</l>
 					<l>ὑμεῖς δ’ ἔχηθ’ ὅμοια τοῖς βουλεύμασιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>αἰαῖ· τὸ δοῦλον ὡς κακὸν πέφυκ’ ἀεὶ</l>
 					<l>τολμᾷ θ’ ἃ μὴ χρή, τῇ βίᾳ νικώμενον.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ὦ θύγατερ, οὑμοὶ μὲν λόγοι πρὸς αἰθέρα</l>
 					<l n="335">φροῦδοι μάτην ῥιφέντες ἀμφὶ σοῦ φόνου·</l>
@@ -634,7 +634,7 @@ convert to P3
 					<l>καὶ τῷδε — τὴν σὴν ὥστ’ ἐποικτῖραι τύχην.</l>
 					<milestone ed="p" n="342" unit="card"/>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>ὁρῶ σ’, Ὀδυσσεῦ, δεξιὰν ὑφ’ εἵματος</l>
 					<l>κρύπτοντα χεῖρα καὶ πρόσωπον ἔμπαλιν</l>
@@ -674,14 +674,14 @@ convert to P3
 					<l>θανὼν δ’ ἂν εἴη μᾶλλον εὐτυχέστερος</l>
 					<l>ἢ ζῶν· τὸ γὰρ ζῆν μὴ καλῶς μέγας πόνος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δεινὸς χαρακτὴρ κἀπίσημος ἐν βροτοῖς</l>
 					<l n="380">ἐσθλῶν γενέσθαι, κἀπὶ μεῖζον ἔρχεται</l>
 					<l>τῆς εὐγενείας ὄνομα τοῖσιν ἀξίοις.</l>
 					<milestone ed="p" n="382" unit="card"/>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>καλῶς μὲν εἶπας, θύγατερ, ἀλλὰ τῷ καλῷ</l>
 					<l>λύπη πρόσεστιν. εἰ δὲ δεῖ τῷ Πηλέως</l>
@@ -693,48 +693,48 @@ convert to P3
 					<!-- very odd crasis mark here -->
 					<l>ὃς παῖδα Θέτιδος ὤλεσεν τόξοις βαλών.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὐ σ’, ὦ γεραιά, κατθανεῖν Ἀχιλλέως</l>
 					<l n="390">φάντασμ’ Ἀχαιούς, ἀλλὰ τήνδ’, ᾐτήσατο.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ὑμεῖς δέ μ’ ἀλλὰ θυγατρὶ συμφονεύσατε,</l>
 					<l>καὶ δὶς τόσον πῶμ’ αἵματος γενήσεται</l>
 					<l>γαίᾳ νεκρῷ τε τῷ τάδ’ ἐξαιτουμένῳ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἅλις κόρης σῆς θάνατος, οὐ προσοιστέος</l>
 					<l n="395">ἄλλος πρὸς ἄλλῳ· μηδὲ τόνδ’ ὠφείλομεν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>πολλή γ’ ἀνάγκη θυγατρὶ συνθανεῖν ἐμέ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>πῶς; οὐ γὰρ οἶδα δεσπότας κεκτημένος.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ὁποῖα κισσὸς δρυός, ὅπως τῆσδ’ ἕξομαι.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὔκ, ἤν γε πείθῃ τοῖσι σοῦ σοφωτέροις.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="400">ὡς τῆσδ’ ἑκοῦσα παιδὸς οὐ μεθήσομαι.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἀλλ’ οὐδ’ ἐγὼ μὴν τήνδ’ ἄπειμ’ αὐτοῦ λιπών.</l>
 					<milestone ed="p" n="402" unit="card"/>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>μῆτερ, πιθοῦ μοι· καὶ σύ, παῖ Λαερτίου,</l>
 					<l>χάλα τοκεῦσιν εἰκότως θυμουμένοις,</l>
@@ -750,75 +750,75 @@ convert to P3
 					<l>τέλος δέχῃ δὴ τῶν ἐμῶν προσφθεγμάτων.</l>
 					<l>ὦ μῆτερ, ὦ τεκοῦσ’, ἄπειμι δὴ κάτω.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="415">ὦ θύγατερ, ἡμεῖς δ’ ἐν φάει δουλεύσομεν.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>ἄνυμφος ἀνυμέναιος ὧν μ’ ἐχρῆν τυχεῖν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἰκτρὰ σύ, τέκνον, ἀθλία δ’ ἐγὼ γυνή.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>ἐκεῖ δ’ ἐν Ἅιδου κείσομαι χωρὶς σέθεν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἴμοι· τί δράσω; ποῖ τελευτήσω βίον;</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l n="420">δούλη θανοῦμαι, πατρὸς οὖσ’ ἐλευθέρου.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἡμεῖς δὲ πεντήκοντά γ’ ἄμμοροι τέκνων.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>τί σοι πρὸς Ἕκτορ’ ἢ γέροντ’ εἴπω πόσιν;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἄγγελλε πασῶν ἀθλιωτάτην ἐμέ.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>ὦ στέρνα μαστοί θ’, οἵ μ’ ἐθρέψαθ’ ἡδέως.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="425">ὦ τῆς ἀώρου θύγατερ ἀθλίας τύχης.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>χαῖρ’, ὦ τεκοῦσα, χαῖρε Κασάνδρα τ’ ἐμοί,</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>χαίρουσιν ἄλλοι, μητρὶ δ’ οὐκ ἔστιν τόδε.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>ὅ τ’ ἐν φιλίπποις Θρῃξὶ Πολύδωρος κάσις.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>εἰ ζῇ γ’· ἀπιστῶ δ’· ὧδε πάντα δυστυχῶ.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l n="430">ζῇ καὶ θανούσης ὄμμα συγκλῄσει τὸ σόν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>τέθνηκ’ ἔγωγε πρὶν θανεῖν κακῶν ὕπο.</l>
 				</sp>
-				<sp who="#polyksene">
+				<sp who="#polyxene">
 					<speaker>Πολυξένη</speaker>
 					<l>κόμιζ’, Ὀδυσσεῦ, μ’ ἀμφιθεὶς κάρα πέπλοις</l>
 					<l>ὡς πρὶν σφαγῆναί γ’ ἐκτέτηκα καρδίαν</l>
@@ -827,7 +827,7 @@ convert to P3
 					<l>μέτεστι δ’ οὐδὲν πλὴν ὅσον χρόνον ξίφους</l>
 					<l>βαίνω μεταξὺ καὶ πυρᾶς Ἀχιλλέως.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἲ ’γώ, προλείπω· λύεται δέ μου μέλη.</l>
 					<l>ὦ θύγατερ, ἅψαι μητρός, ἔκτεινον χέρα,</l>
@@ -840,7 +840,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αὔρα, ποντιὰς αὔρα,</l>
 						<l n="445">ἅτε ποντοπόρους κομί‐</l>
@@ -856,7 +856,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="455">ἢ νάσων, ἁλιήρει</l>
 						<l>κώπᾳ πεμπομέναν τάλαι‐</l>
@@ -872,7 +872,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἢ Παλλάδος ἐν πόλει</l>
 						<l>τὰς καλλιδίφρους Ἀθα‐</l>
@@ -887,7 +887,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="475">ὤ μοι τεκέων ἐμῶν,</l>
 						<l>ὤ μοι πατέρων χθονός θ’,</l>
@@ -908,7 +908,7 @@ convert to P3
 					<l>ποῦ τὴν ἄνασσαν δή ποτ’ οὖσαν Ἰλίου</l>
 					<l n="485">Ἑκάβην ἂν ἐξεύροιμι, Τρῳάδες κόραι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>αὕτη πέλας σου νῶτ’ ἔχουσ’ ἐπὶ χθονί,</l>
 					<l>Ταλθύβιε, κεῖται ξυγκεκλῃμένη πέπλοις.</l>
@@ -929,7 +929,7 @@ convert to P3
 					<l>ἀνίστασ’, ὦ δύστηνε, καὶ μετάρσιον</l>
 					<l n="500">πλευρὰν ἔπαιρε καὶ τὸ πάλλευκον κάρα.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἔα· τίς οὗτος σῶμα τοὐμὸν οὐκ ἐᾷ</l>
 					<l>κεῖσθαι; τί κινεῖς μ’, ὅστις εἶ, λυπουμένην;</l>
@@ -939,7 +939,7 @@ convert to P3
 					<l>Ταλθύβιος ἥκω Δαναϊδῶν ὑπηρέτης,</l>
 					<l>Ἀγαμέμνονος πέμψαντος, ὦ γύναι, μέτα.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="505">ὦ φίλτατ’, ἆρα κἄμ’ ἐπισφάξαι τάφῳ</l>
 					<l>δοκοῦν Ἀχαιοῖς ἦλθες; ὡς φίλ’ ἂν λέγοις.</l>
@@ -951,7 +951,7 @@ convert to P3
 					<l>ἥκω μεταστείχων σε· πέμπουσιν δέ με</l>
 					<l n="510">δισσοί τ’ Ἀτρεῖδαι καὶ λεὼς Ἀχαιικός.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἴμοι, τί λέξεις; οὐκ ἄρ’ ὡς θανουμένους</l>
 					<l>μετῆλθες ἡμᾶς, ἀλλὰ σημανῶν κακά;</l>
@@ -1037,13 +1037,13 @@ convert to P3
 					<l>παιδὸς θανούσης, εὐτεκνωτάτην τέ σε</l>
 					<l>πασῶν γυναικῶν δυστυχεστάτην θ’ ὁρῶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δεινόν τι πῆμα Πριαμίδαις ἐπέζεσεν</l>
 					<l>πόλει τε τἠμῇ θεῶν ἀνάγκαισιν τόδε.</l>
 				</sp>
 				<milestone ed="p" n="585" unit="card"/>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="585">ὦ θύγατερ, οὐκ οἶδ’ εἰς ὅ τι βλέψω κακῶν,</l>
 					<l>πολλῶν παρόντων· ἢν γὰρ ἅψωμαί τινος,</l>
@@ -1100,7 +1100,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐμοὶ χρῆν συμφοράν,</l>
 						<l n="630">ἐμοὶ χρῆν πημονὰν γενέσθαι,</l>
@@ -1114,7 +1114,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πόνοι γὰρ καὶ πόνων</l>
 						<l n="640">ἀνάγκαι κρείσσονες κυκλοῦνται</l>
@@ -1128,7 +1128,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπὶ δορὶ καὶ φόνῳ καὶ ἐμῶν μελάθρων λώβᾳ·</l>
 						<l n="650">στένει δὲ καί τις ἀμφὶ τὸν εὔροον Εὐρώταν</l>
@@ -1148,7 +1148,7 @@ convert to P3
 					<l>ἡ πάντα νικῶσ’ ἄνδρα καὶ θῆλυν σπορὰν</l>
 					<l n="660">κακοῖσιν; οὐδεὶς στέφανον ἀνθαιρήσεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’, ὦ τάλαινα σῆς κακογλώσσου βοῆς;</l>
 					<l>ὡς οὔποθ’ εὕδει λυπρά σου κηρύγματα.</l>
@@ -1158,7 +1158,7 @@ convert to P3
 					<l>Ἑκάβῃ φέρω τόδ’ ἄλγος· ἐν κακοῖσι δὲ</l>
 					<l>οὐ ῥᾴδιον βροτοῖσιν εὐφημεῖν στόμα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="665">καὶ μὴν περῶσα τυγχάνει δόμων ὕπερ</l>
 					<l>ἥδ’, ἐς δὲ καιρὸν σοῖσι φαίνεται λόγοις.</l>
@@ -1169,7 +1169,7 @@ convert to P3
 					<l>δέσποιν’, ὄλωλας κοὐκέτ’ εἶ, βλέπουσα φῶς,</l>
 					<l>ἄπαις ἄνανδρος ἄπολις ἐξεφθαρμένη.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="670">οὐ καινὸν εἶπας, εἰδόσιν δ’ ὠνείδισας.</l>
 					<l>ἀτὰρ τί νεκρὸν τόνδε μοι Πολυξένης</l>
@@ -1181,7 +1181,7 @@ convert to P3
 					<l>ἥδ’ οὐδὲν οἶδεν, ἀλλά μοι Πολυξένην</l>
 					<l n="675">θρηνεῖ, νέων δὲ πημάτων οὐχ ἅπτεται.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἲ ’γὼ τάλαινα· μῶν τὸ βακχεῖον κάρα</l>
 					<l>τῆς θεσπιῳδοῦ δεῦρο Κασάνδρας φέρεις;</l>
@@ -1193,7 +1193,7 @@ convert to P3
 					<l n="680">εἴ σοι φανεῖται θαῦμα καὶ παρ’ ἐλπίδας.</l>
 					<milestone ed="p" n="681" unit="card"/>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<!-- last four lines of this speech were marked "lyric";  they are lyric iambics -->
 					<l>οἴμοι, βλέπω δὴ παῖδ’ ἐμὸν τεθνηκότα,</l>
@@ -1208,7 +1208,7 @@ convert to P3
 					<speaker>Θεράπαινα</speaker>
 					<l>ἔγνως γὰρ ἄτην παιδός, ὦ δύστηνε σύ;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<!-- last three lines of this speech were marked "lyric";  they are dochmiacs -->
 					<l>ἄπιστ’ ἄπιστα, καινὰ καινὰ δέρκομαι.</l>
@@ -1216,12 +1216,12 @@ convert to P3
 					<l>οὐδέ ποτ’ ἀστένακτος ἀδάκρυτος ἁ‐</l>
 					<l>μέρα [μ’] ἐπισχήσει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δείν’, ὦ τάλαινα, δεινὰ πάσχομεν κακά.</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ τέκνον τέκνον ταλαίνας ματρός,</l>
 						<l n="695">τίνι μόρῳ θνῄσκεις,</l>
@@ -1232,7 +1232,7 @@ convert to P3
 						<speaker>Θεράπαινα</speaker>
 						<l>οὐκ οἶδ’· ἐπ’ ἀκταῖς νιν κυρῶ θαλασσίαις . . .</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἔκβλητον, ἢ πέσημα φοινίου δορός,</l>
 						<l n="700">ἐν ψαμάθῳ λευρᾷ;</l>
@@ -1245,27 +1245,27 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὤμοι, αἰαῖ, ἔμαθον ἔνυπνον ὀμμάτων</l>
 						<l n="704">ἐμῶν ὄψιν· οὔ με παρέβα</l>
 						<l n="705">φάσμα μελανόπτερον, τὰν ἐσεῖδον ἀμφὶ σέ,</l>
 						<l>ὦ τέκνον, οὐκέτ’ ὄντα Διὸς ἐν φάει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="709">τίς γάρ νιν ἔκτειν’; οἶσθ’ ὀνειρόφρων φράσαι;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="710">ἐμὸς ἐμὸς ξένος, Θρῄκιος ἱππότας,</l>
 						<l>ἵν’ ὁ γέρων πατὴρ ἔθετό νιν κρύψας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="713">οἴμοι, τί λέξεις; χρυσὸν ὡς ἔχοι κτανών;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἄρρητ’ ἀνωνόμαστα, θαυμάτων πέρα,</l>
 						<l n="715">οὐχ ὅσῑ οὐδ’ ἀνεκτά. ποῦ δίκα ξένων;</l>
@@ -1276,7 +1276,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="iambics">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="722">ὦ τλῆμον, ὥς σε πολυπονωτάτην βροτῶν</l>
 						<l>δαίμων ἔθηκεν ὅστις ἐστί σοι βαρύς.</l>
@@ -1296,7 +1296,7 @@ convert to P3
 						<l>θανόντα Τρώων; οὐ γὰρ Ἀργεῖον πέπλοι</l>
 						<l n="735">δέμας περιπτύσσοντες ἀγγέλλουσί μοι.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>δύστην’, ἐμαυτὴν γὰρ λέγω λέγουσα σέ,</l>
 						<l>Ἑκάβη, τί δράσω; πότερα προσπέσω γόνυ</l>
@@ -1307,7 +1307,7 @@ convert to P3
 						<l>τί μοι προσώπῳ νῶτον ἐγκλίνασα σὸν</l>
 						<l n="740">δύρῃ, τὸ πραχθὲν δ’ οὐ λέγεις;  — τίς ἔσθ’ ὅδε;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἀλλ’, εἴ με δούλην πολεμίαν θ’ ἡγούμενος</l>
 						<l>γονάτων ἀπώσαιτ’, ἄλγος ἂν προσθείμεθ’ ἄν.</l>
@@ -1317,7 +1317,7 @@ convert to P3
 						<l>οὔτοι πέφυκα μάντις, ὥστε μὴ κλύων</l>
 						<l>ἐξιστορῆσαι σῶν ὁδὸν βουλευμάτων.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="745">ἆρ’ ἐκλογίζομαί γε πρὸς τὸ δυσμενὲς</l>
 						<l>μᾶλλον φρένας τοῦδ’, ὄντος οὐχὶ δυσμενοῦς;</l>
@@ -1327,7 +1327,7 @@ convert to P3
 						<l>εἴ τοί με βούλῃ τῶνδε μηδὲν εἰδέναι,</l>
 						<l>ἐς ταὐτὸν ἥκεις· καὶ γὰρ οὐδ’ ἐγὼ κλύειν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐκ ἂν δυναίμην τοῦδε τιμωρεῖν ἄτερ</l>
 						<l n="750">τέκνοισι τοῖς ἐμοῖσι. τί στρέφω τάδε;</l>
@@ -1340,7 +1340,7 @@ convert to P3
 						<l>τί χρῆμα μαστεύουσα; μῶν ἐλεύθερον</l>
 						<l n="755">αἰῶνα θέσθαι; ῥᾴδιον γάρ ἐστί σοι.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐ δῆτα· τοὺς κακοὺς δὲ τιμωρουμένη</l>
 						<l>αἰῶνα τὸν σύμπαντα δουλεύειν θέλω.</l>
@@ -1349,7 +1349,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>καὶ δὴ τίν’ ἡμᾶς εἰς ἐπάρκεσιν καλεῖς;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐδέν τι τούτων ὧν σὺ δοξάζεις, ἄναξ. — </l>
 						<l n="760">ὁρᾷς νεκρὸν τόνδ’, οὗ καταστάζω δάκρυ;</l>
@@ -1358,7 +1358,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ὁρῶ· τὸ μέντοι μέλλον οὐκ ἔχω μαθεῖν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τοῦτόν ποτ’ ἔτεκον κἄφερον ζώνης ὕπο.</l>
 					</sp>
@@ -1366,7 +1366,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ἔστιν δὲ τίς σῶν οὗτος, ὦ τλῆμον, τέκνων;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐ τῶν θανόντων Πριαμιδῶν ὑπ’ Ἰλίῳ.</l>
 					</sp>
@@ -1374,7 +1374,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="765">ἦ γάρ τιν’ ἄλλον ἔτεκες ἢ κείνους, γύναι;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἀνόνητά γ’, ὡς ἔοικε, τόνδ’ ὃν εἰσορᾷς.</l>
 						<milestone ed="p" n="767" unit="card"/>
@@ -1383,7 +1383,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ποῦ δ’ ὢν ἐτύγχαν’, ἡνίκ’ ὤλλυτο πτόλις;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>πατήρ νιν ἐξέπεμψεν ὀρρωδῶν θανεῖν.</l>
 					</sp>
@@ -1391,7 +1391,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ποῖ τῶν τότ’ ὄντων χωρίσας τέκνων μόνον;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="770">ἐς τήνδε χώραν, οὗπερ ηὑρέθη θανών.</l>
 					</sp>
@@ -1399,7 +1399,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>πρὸς ἄνδρ’ ὃς ἄρχει τῆσδε Πολυμήστωρ χθονός;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἐνταῦθ’ ἐπέμφθη πικροτάτου χρυσοῦ φύλαξ.</l>
 					</sp>
@@ -1407,7 +1407,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>θνῄσκει δὲ πρὸς τοῦ καὶ τίνος πότμου τυχών;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τίνος γ’ ὑπ’ ἄλλου; Θρῄξ νιν ὤλεσε ξένος.</l>
 					</sp>
@@ -1415,7 +1415,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="775">ὦ τλῆμον· ἦ που χρυσὸν ἠράσθη λαβεῖν;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τοιαῦτ’, ἐπειδὴ συμφορὰν ἔγνω Φρυγῶν.</l>
 					</sp>
@@ -1423,7 +1423,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ηὗρες δὲ ποῦ νιν; ἢ τίς ἤνεγκεν νεκρόν;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἥδ’, ἐντυχοῦσα ποντίας ἀκτῆς ἔπι.</l>
 					</sp>
@@ -1431,7 +1431,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>τοῦτον ματεύουσ’ ἢ πονοῦσ’ ἄλλον πόνον;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="780">λούτρ’ ᾤχετ’ οἴσουσ’ ἐξ ἁλὸς Πολυξένῃ.</l>
 					</sp>
@@ -1439,7 +1439,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>κτανών νιν, ὡς ἔοικεν, ἐκβάλλει ξένος.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>θαλασσόπλαγκτόν γ’, ὧδε διατεμὼν χρόα.</l>
 					</sp>
@@ -1447,7 +1447,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ὦ σχετλία σὺ τῶν ἀμετρήτων πόνων.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὄλωλα κοὐδὲν λοιπόν, Ἀγάμεμνον, κακῶν.</l>
 					</sp>
@@ -1455,7 +1455,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="785">φεῦ φεῦ· τίς οὕτω δυστυχὴς ἔφυ γυνή;</l>
 					</sp>
-					<sp n="Ἑκάβη" who="#ekabe">
+					<sp n="Ἑκάβη" who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐκ ἔστιν, εἰ μὴ τὴν Τύχην αὐτὴν λέγοις.</l>
 						<l>ἀλλ’ ὧνπερ οὕνεκ’ ἀμφὶ σὸν πίπτω γόνυ</l>
@@ -1528,7 +1528,7 @@ convert to P3
 						<l>ἐσθλοῦ γὰρ ἀνδρὸς τῇ δίκῃ θ’ ὑπηρετεῖν</l>
 						<l n="845">καὶ τοὺς κακοὺς δρᾶν πανταχοῦ κακῶς ἀεί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεινόν γε, θνητοῖς ὡς ἅπαντα συμπίτνει,</l>
 						<l>καὶ τὰς ἀνάγκας οἱ νόμοι διώρισαν,</l>
@@ -1553,7 +1553,7 @@ convert to P3
 						<l>βραδὺν δ’, Ἀχαιοῖς εἰ διαβληθήσομαι.</l>
 						<milestone ed="p" n="864" unit="card"/>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>φεῦ.</l>
 						<l>οὐκ ἔστι θνητῶν ὅστις ἔστ’ ἐλεύθερος·</l>
@@ -1576,7 +1576,7 @@ convert to P3
 						<l>ἢ φαρμάκοισιν ἢ ’πικουρίᾳ τινί;</l>
 						<l>τίς σοι ξυνέσται χείρ; πόθεν κτήσῃ φίλους;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="880">στέγαι κεκεύθασ’ αἵδε Τρῳάδων ὄχλον.</l>
 					</sp>
@@ -1584,7 +1584,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>τὰς αἰχμαλώτους εἶπας, Ἑλλήνων ἄγραν;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>σὺν ταῖσδε τὸν ἐμὸν φονέα τιμωρήσομαι.</l>
 					</sp>
@@ -1592,7 +1592,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>καὶ πῶς γυναιξὶν ἀρσένων ἔσται κράτος;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>δεινὸν τὸ πλῆθος σὺν δόλῳ τε δύσμαχον.</l>
 					</sp>
@@ -1600,7 +1600,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="885">δεινόν· τὸ μέντοι θῆλυ μέμφομαι γένος.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τί δ’; οὐ γυναῖκες εἷλον Αἰγύπτου τέκνα</l>
 						<l>καὶ Λῆμνον ἄρδην ἀρσένων ἐξῴκισαν;</l>
@@ -1630,7 +1630,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="905">σὺ μέν, ὦ πατρὶς Ἰλιάς,</l>
 						<l>τῶν ἀπορθήτων πόλις οὐκέτι λέξῃ·</l>
@@ -1645,7 +1645,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μεσονύκτιος ὠλλύμαν,</l>
 						<l n="915">ἦμος ἐκ δείπνων ὕπνος ἡδὺς ἐπ’ ὄσσοις</l>
@@ -1660,7 +1660,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐγὼ δὲ πλόκαμον ἀναδέτοις</l>
 						<l>μίτραισιν ἐρρυθμιζόμαν</l>
@@ -1677,7 +1677,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λέχη δὲ φίλια μονόπεπλος</l>
 						<l>λιποῦσα, Δωρὶς ὡς κόρα,</l>
@@ -1694,7 +1694,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὰν τοῖν Διοσκούροιν Ἑλέναν κάσιν</l>
 						<l>Ἰδαῖόν τε βούταν</l>
@@ -1730,7 +1730,7 @@ convert to P3
 					<l>ἐς ταὐτὸν ἥδε συμπίτνει δμωὶς σέθεν</l>
 					<l>λέγουσα μύθους, ὧν κλύων ἀφικόμην.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>αἰσχύνομαί σε προσβλέπειν ἐναντίον,</l>
 					<l>Πολυμῆστορ, ἐν τοιοῖσδε κειμένη κακοῖς.</l>
@@ -1746,7 +1746,7 @@ convert to P3
 					<l>καὶ θαῦμά γ’ οὐδέν. ἀλλὰ τίς χρεία σ’ ἐμοῦ;</l>
 					<l>τί χρῆμ’ ἐπέμψω τὸν ἐμὸν ἐκ δόμων πόδα·</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἴδιον ἐμαυτῆς δή τι πρὸς σὲ βούλομαι</l>
 					<l>καὶ παῖδας εἰπεῖν σούς· ὀπάονας δέ μοι</l>
@@ -1761,7 +1761,7 @@ convert to P3
 					<l n="985">φίλοις ἐπαρκεῖν; ὡς ἕτοιμός εἰμ’ ἐγώ.</l>
 					<milestone ed="p" n="986" unit="card"/>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>πρῶτον μὲν εἰπὲ παῖδ’ ὃν ἐξ ἐμῆς χερὸς</l>
 					<l>Πολύδωρον ἔκ τε πατρὸς ἐν δόμοις ἔχεις,</l>
@@ -1771,7 +1771,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>μάλιστα· τοὐκείνου μὲν εὐτυχεῖς μέρος.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="990">ὦ φίλταθ’, ὡς εὖ κἀξίως λέγεις σέθεν.</l>
 				</sp>
@@ -1779,7 +1779,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>τί δῆτα βούλῃ δεύτερον μαθεῖν ἐμοῦ;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>εἰ τῆς τεκούσης τῆσδε . . . μέμνηταί τί μου;</l>
 				</sp>
@@ -1787,7 +1787,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>καὶ δεῦρό γ’ ὡς σὲ κρύφιος ἐζήτει μολεῖν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>χρυσὸς δὲ σῶς ὃν ἦλθεν ἐκ Τροίας ἔχων;</l>
 				</sp>
@@ -1795,7 +1795,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l n="995">σῶς, ἐν δόμοις γε τοῖς ἐμοῖς φρουρούμενος.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>σῶσόν νυν αὐτὸν μηδ’ ἔρα τῶν πλησίον.</l>
 				</sp>
@@ -1803,7 +1803,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>ἥκιστ’· ὀναίμην τοῦ παρόντος, ὦ γύναι.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἶσθ’ οὖν ἃ λέξαι σοί τε καὶ παισὶν θέλω;</l>
 				</sp>
@@ -1811,7 +1811,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>οὐκ οἶδα· τῷ σῷ τοῦτο σημανεῖς λόγῳ.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="1000">ἔστ’, ὦ φιληθεὶς ὡς σὺ νῦν ἐμοὶ φιλῇ  — </l>
 				</sp>
@@ -1819,7 +1819,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>τί χρῆμ’ ὃ κἀμὲ καὶ τέκν’ εἰδέναι χρεών;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>χρυσοῦ παλαιαὶ Πριαμιδῶν κατώρυχες.</l>
 				</sp>
@@ -1827,7 +1827,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>ταῦτ’ ἔσθ’ ἃ βούλῃ παιδὶ σημῆναι σέθεν;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>μάλιστα, διὰ σοῦ γ’· εἶ γὰρ εὐσεβὴς ἀνήρ.</l>
 				</sp>
@@ -1835,7 +1835,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l n="1005">τί δῆτα τέκνων τῶνδε δεῖ παρουσίας;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἄμεινον, ἢν σὺ κατθάνῃς, τούσδ’ εἰδέναι.</l>
 				</sp>
@@ -1843,7 +1843,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>καλῶς ἔλεξας· τῇδε καὶ σοφώτερον.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οἶσθ’ οὖν Ἀθάνας Ἰλίας ἵνα στέγαι;</l>
 				</sp>
@@ -1851,7 +1851,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>ἐνταῦθ’ ὁ χρυσός ἐστι; σημεῖον δὲ τί;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="1010">μέλαινα πέτρα γῆς ὑπερτέλλουσ’ ἄνω.</l>
 				</sp>
@@ -1859,7 +1859,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>ἔτ’ οὖν τι βούλῃ τῶν ἐκεῖ φράζειν ἐμοί;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>σῶσαί σε χρήμαθ’ οἷς συνεξῆλθον θέλω.</l>
 				</sp>
@@ -1867,7 +1867,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>ποῦ δῆτα; πέπλων ἐντὸς ἢ κρύψασ’ ἔχεις;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>σκύλων ἐν ὄχλῳ ταῖσδε σῴζεται στέγαις.</l>
 				</sp>
@@ -1875,7 +1875,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l n="1015">ποῦ δ’; αἵδ’ Ἀχαιῶν ναύλοχοι περιπτυχαί.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἰδίᾳ γυναικῶν αἰχμαλωτίδων στέγαι.</l>
 				</sp>
@@ -1883,7 +1883,7 @@ convert to P3
 					<speaker>Πολυμήστωρ</speaker>
 					<l>τἄνδον δὲ πιστὰ κἀρσένων ἐρημία;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οὐδεὶς Ἀχαιῶν ἔνδον, ἀλλ’ ἡμεῖς μόναι.</l>
 					<l>ἀλλ’ ἕρπ’ ἐς οἴκους· καὶ γὰρ Ἀργεῖοι νεῶν</l>
@@ -1891,13 +1891,13 @@ convert to P3
 					<l>ὡς πάντα πράξας ὧν σε δεῖ στείχῃς πάλιν</l>
 					<l>ξὺν παισὶν οὗπερ τὸν ἐμὸν ᾤκισας γόνον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1024">οὔπω δέδωκας, ἀλλ’ ἴσως δώσεις δίκην·</l>
 					<milestone ed="p" n="1025" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1025">ἀλίμενόν τις ὡς εἰς ἄντλον πεσὼν</l>
 						<l>†λέχριος ἐκπεσῇ φίλας καρδίας,</l>
@@ -1917,7 +1917,7 @@ convert to P3
 						</stage>
 						<l n="1035">ὤμοι, τυφλοῦμαι φέγγος ὀμμάτων τάλας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἠκούσατ’ ἀνδρὸς Θρῃκὸς οἰμωγήν, φίλαι;</l>
 					</sp>
@@ -1925,7 +1925,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>ὤμοι μάλ’ αὖθις, τέκνα, δυστήνου σφαγῆς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φίλαι, πέπρακται καίν’ ἔσω δόμων κακά.</l>
 					</sp>
@@ -1934,24 +1934,24 @@ convert to P3
 						<l>ἀλλ’ οὔτι μὴ φύγητε λαιψηρῷ ποδί·</l>
 						<l n="1040">βάλλων γὰρ οἴκων τῶνδ’ ἀναρρήξω μυχούς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰδού, βαρείας χειρὸς ὁρμᾶται βέλος.</l>
 						<l>βούλεσθ’ ἐπεσπέσωμεν; ὡς ἀκμὴ καλεῖ</l>
 						<l>Ἑκάβῃ παρεῖναι Τρῳάσιν τε συμμάχους.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἄρασσε, φείδου μηδέν, ἐκβάλλων πύλας·</l>
 						<l n="1045">οὐ γάρ ποτ’ ὄμμα λαμπρὸν ἐνθήσεις κόραις,</l>
 						<l>οὐ παῖδας ὄψῃ ζῶντας οὓς ἔκτειν’ ἐγώ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ γὰρ καθεῖλες Θρῇκα, καὶ κρατεῖς, ξένον,</l>
 						<l>δέσποινα, καὶ δέδρακας οἷάπερ λέγεις;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὄψῃ νιν αὐτίκ’ ὄντα δωμάτων πάρος</l>
 						<l n="1050">τυφλὸν τυφλῷ στείχοντα παραφόρῳ ποδί,</l>
@@ -1999,7 +1999,7 @@ convert to P3
 						<l>τέκνων ἐμῶν φύλαξ ὀλέθριον κοίταν;</l>
 					</sp>
 					<milestone ed="p" n="1085" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1085">ὦ τλῆμον, ὥς σοι δύσφορ’ εἴργασται κακά·</l>
 						<l>δράσαντι δ’ αἰσχρὰ δεινὰ τἀπιτίμια.</l>
@@ -2026,7 +2026,7 @@ convert to P3
 						<l>μελάγχρωτα πορθμὸν ᾄξω τάλας;</l>
 						<milestone ed="p" n="1107" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>συγγνώσθ’, ὅταν τις κρείσσον’ ἢ φέρειν κακὰ</l>
 						<l>πάθῃ, ταλαίνης ἐξαπαλλάξαι ζόης.</l>
@@ -2141,7 +2141,7 @@ convert to P3
 						<l>γένος γὰρ οὔτε πόντος οὔτε γῆ τρέφει</l>
 						<l>τοιόνδ’· ὁ δ’ αἰεὶ ξυντυχὼν ἐπίσταται.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδὲν θρασύνου μηδὲ τοῖς σαυτοῦ κακοῖς</l>
 						<l>τὸ θῆλυ συνθεὶς ὧδε πᾶν μέμψῃ γένος.</l>
@@ -2149,7 +2149,7 @@ convert to P3
 						<l>αἳ δ’ εἰς ἀριθμὸν τῶν κακῶν πεφύκαμεν.]</l>
 					</sp>
 					<milestone ed="p" n="1187" unit="card"/>
-					<sp n="Ἑκάβη" who="#ekabe">
+					<sp n="Ἑκάβη" who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>Ἀγάμεμνον, ἀνθρώποισιν οὐκ ἐχρῆν ποτε</l>
 						<l>τῶν πραγμάτων τὴν γλῶσσαν ἰσχύειν πλέον·</l>
@@ -2210,7 +2210,7 @@ convert to P3
 						<l>αὐτὸν δὲ χαίρειν τοῖς κακοῖς σὲ φήσομεν</l>
 						<l>τοιοῦτον ὄντα . . . δεσπότας δ’ οὐ λοιδορῶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φεῦ φεῦ· βροτοῖσιν ὡς τὰ χρηστὰ πράγματα</l>
 						<l>χρηστῶν ἀφορμὰς ἐνδίδωσ’ ἀεὶ λόγων.</l>
@@ -2244,7 +2244,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l n="1255">οἴμοι τέκνων τῶνδ’ ὀμμάτων τ’ ἐμῶν, τάλας.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἀλγεῖς· τί δ’; ἦ ’μὲ παιδὸς οὐκ ἀλγεῖν δοκεῖς;</l>
 					</sp>
@@ -2252,7 +2252,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>χαίρεις ὑβρίζουσ’ εἰς ἔμ’, ὦ πανοῦργε σύ;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐ γάρ με χαίρειν χρή σε τιμωρουμένην;</l>
 					</sp>
@@ -2260,7 +2260,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>ἀλλ’ οὐ τάχ’, ἡνίκ’ ἄν σε ποντία νοτὶς — </l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1260">μῶν ναυστολήσῃ γῆς ὅρους Ἑλληνίδος;</l>
 					</sp>
@@ -2268,7 +2268,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>κρύψῃ μὲν οὖν πεσοῦσαν ἐκ καρχησίων.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>πρὸς τοῦ βιαίων τυγχάνουσαν ἁλμάτων;</l>
 					</sp>
@@ -2276,7 +2276,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>αὐτὴ πρὸς ἱστὸν ναὸς ἀμβήσῃ ποδί.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὑποπτέροις νώτοισιν ἢ ποίῳ τρόπῳ;</l>
 					</sp>
@@ -2284,7 +2284,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l n="1265">κύων γενήσῃ πύρσ’ ἔχουσα δέργματα.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>πῶς δ’ οἶσθα μορφῆς τῆς ἐμῆς μετάστασιν;</l>
 					</sp>
@@ -2292,7 +2292,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>ὁ Θρῃξὶ μάντις εἶπε Διόνυσος τάδε.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>σοὶ δ’ οὐκ ἔχρησεν οὐδὲν ὧν ἔχεις κακῶν;</l>
 					</sp>
@@ -2300,7 +2300,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>οὐ γάρ ποτ’ ἂν σύ μ’ εἷλες ὧδε σὺν δόλῳ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1270">θανοῦσα δ’ ἢ ζῶσ’ ἐνθάδ’ ἐκπλήσω βίον;</l>
 					</sp>
@@ -2308,7 +2308,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>θανοῦσα· τύμβῳ δ’ ὄνομα σῷ κεκλήσεται — </l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>μορφῆς ἐπῳδόν, ἢ τί, τῆς ἐμῆς ἐρεῖς;</l>
 					</sp>
@@ -2316,7 +2316,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>κυνὸς ταλαίνης σῆμα, ναυτίλοις τέκμαρ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐδὲν μέλει μοι σοῦ γέ μοι δόντος δίκην.</l>
 					</sp>
@@ -2324,7 +2324,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l n="1275">καὶ σήν γ’ ἀνάγκη παῖδα Κασάνδραν θανεῖν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἀπέπτυσ’· αὐτῷ ταῦτα σοὶ δίδωμ’ ἔχειν.</l>
 					</sp>
@@ -2332,7 +2332,7 @@ convert to P3
 						<speaker>Πολυμήστωρ</speaker>
 						<l>κτενεῖ νιν ἡ τοῦδ’ ἄλοχος, οἰκουρὸς πικρά.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>μήπω μανείη Τυνδαρὶς τοσόνδε παῖς.</l>
 					</sp>
@@ -2379,7 +2379,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴτε πρὸς λιμένας σκηνάς τε, φίλαι,</l>
 						<l>τῶν δεσποσύνων πειρασόμεναι</l>

--- a/tei/euripides-helen.xml
+++ b/tei/euripides-helen.xml
@@ -51,7 +51,7 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="grays">
+					<person xml:id="graus">
 						<persName>Γραῦς</persName>
 					</person>
 					<person xml:id="theoklymenos">
@@ -60,10 +60,10 @@
 					<person xml:id="dioskoroi">
 						<persName>Διόσκοροι</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<person xml:id="teykros">
+					<person xml:id="teukros">
 						<persName>Τεῦκρος</persName>
 					</person>
 					<person xml:id="theonoe">
@@ -72,13 +72,13 @@
 					<person xml:id="therapon">
 						<persName>Θεράπων</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="meneleos">
 						<persName>Μενελέως</persName>
 					</person>
-					<person xml:id="elene">
+					<person xml:id="helene">
 						<persName>Ἑλένη</persName>
 					</person>
 				</listPerson>
@@ -169,7 +169,7 @@ convert to P3
 		<body>
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp n="Ἑλένη" who="#elene">
+				<sp n="Ἑλένη" who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>Νείλου μὲν αἵδε καλλιπάρθενοι ῥοαί,</l>
 					<l>ὃς ἀντὶ δίας ψακάδος Αἰγύπτου πέδον</l>
@@ -247,7 +247,7 @@ convert to P3
 					<l>μή μοι τὸ σῶμά γ’ ἐνθάδ’ αἰσχύνην ὄφλῃ.</l>
 				</sp>
 				<milestone ed="p" n="68" unit="card"/>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>τίς τῶνδ’ ἐρυμνῶν δωμάτων ἔχει κράτος;</l>
 					<l>Πλούτου γὰρ οἶκος ἄξιος προσεικάσαι,</l>
@@ -260,250 +260,250 @@ convert to P3
 					<l>γαίᾳ πόδ’ εἶχον, τῷδ’ ἂν εὐστόχῳ πτερῷ </l>
 					<l>ἀπόλαυσιν εἰκοῦς ἔθανες ἂν Διὸς κόρης.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>τί δ’, ὦ ταλαίπωρ’ — ὅστις ὤν μ’ ἀπεστράφης</l>
 					<l>καὶ ταῖς ἐκείνης συμφοραῖς ἐμὲ στυγεῖς;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="80">ἥμαρτον· ὀργῇ δ’ εἶξα μᾶλλον ἤ με χρῆν·</l>
 					<l>μισεῖ γὰρ Ἑλλὰς πᾶσα τὴν Διὸς κόρην.</l>
 					<l>σύγγνωθι δ’ ἡμῖν τοῖς λελεγμένοις, γύναι.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>τίς δ’ εἶ; πόθεν γῆς τῆσδ’ ἐπεστράφης πέδον;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>εἷς τῶν Ἀχαιῶν, ὦ γύναι, τῶν ἀθλίων.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="85">οὐ τἄρα σ’ Ἑλένην εἰ στυγεῖς θαυμαστέον.</l>
 					<l>ἀτὰρ τίς εἶ πόθεν; τίνος δ’ αὐδᾶν σε χρή;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὄνομα μὲν ἡμῖν Τεῦκρος, ὁ δὲ φύσας πατὴρ</l>
 					<l>Τελαμών, Σαλαμὶς δὲ πατρὶς ἡ θρέψασά με.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>τί δῆτα Νείλου τούσδ’ ἐπιστρέφῃ γύας;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="90">φυγὰς πατρῴας ἐξελήλαμαι χθονός.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>τλήμων ἂν εἴης· τίς δέ σ’ ἐκβάλλει πάτρας;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>Τελαμὼν ὁ φύσας. τίν’ ἂν ἔχοις μᾶλλον φίλον;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἐκ τοῦ; τὸ γάρ τοι πρᾶγμα συμφορὰν ἔχει.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>Αἴας μ’ ἀδελφὸς ὤλεσ’ ἐν Τροίᾳ θανών.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="95">πῶς; οὔ τί που σῷ φασγάνῳ βίον στερείς;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>οἰκεῖον αὐτὸν ὤλεσ’ ἅλμ’ ἐπὶ ξίφος.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>μανέντ’; ἐπεὶ τίς σωφρονῶν τλαίη τάδ’ ἄν;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>τὸν Πηλέως τιν’ οἶσθ’ Ἀχιλλέα γόνον;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ναί·</l>
 					<l>μνηστήρ ποθ’ Ἑλένης ἦλθεν, ὡς ἀκούομεν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="100">θανὼν ὅδ’ ὅπλων ἔριν ἔθηκε συμμάχοις.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>καὶ δὴ τί τοῦτ’ Αἴαντι γίγνεται κακόν;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ἄλλου λαβόντος ὅπλ’ ἀπηλλάχθη βίου.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>σὺ τοῖς ἐκείνου δῆτα πήμασιν νοσεῖς; </l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὁθούνεκ’ αὐτῷ γ’ οὐ ξυνωλόμην ὁμοῦ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="105">ἦλθες γάρ, ὦ ξέν’, Ἰλίου κλεινὴν πόλιν;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>καὶ ξύν γε πέρσας αὐτὸς ἀνταπωλόμην.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἤδη γὰρ ἧπται καὶ κατείργασται πυρί;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὥστ’ οὐδ’ ἴχνος γε τειχέων εἶναι σαφές.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ὦ τλῆμον Ἑλένη, διὰ σ’ ἀπόλλυνται Φρύγες.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="110">καὶ πρός γ’ Ἀχαιοί· μεγάλα δ’ εἴργασται κακά.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>πόσον χρόνον γὰρ διαπεπόρθηται πόλις;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ἑπτὰ σχεδόν τι καρπίμους ἐτῶν κύκλους.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>χρόνον δ’ ἐμείνατ’ ἄλλον ἐν Τροίᾳ πόσον;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>πολλὰς σελήνας, δέκα διελθούσας ἔτη.</l>
 					<milestone ed="p" n="115" unit="card"/>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="115">ἦ καὶ γυναῖκα Σπαρτιᾶτιν εἵλετε;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>Μενέλαος αὐτὴν ἦγ’ ἐπισπάσας κόμης.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>εἶδες σὺ τὴν δύστηνον; ἢ κλύων λέγεις;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὥσπερ γε σέ, οὐδὲν ἧσσον, ὀφθαλμοῖς ὁρῶ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>σκοπεῖτε μὴ δόκησιν εἴχετ’ ἐκ θεῶν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="120">ἄλλου λόγου μέμνησο, μὴ κείνης ἔτι.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οὕτω δοκεῖτε τὴν δόκησιν ἀσφαλῆ;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>αὐτὸς γὰρ ὄσσοις εἰδόμην· καὶ νοῦς ὁρᾷ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἤδη δ’ ἐν οἴκοις σὺν δάμαρτι Μενέλεως;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>οὔκουν ἐν Ἄργει &lt;γ’&gt; οὐδ’ ἐπ’ Εὐρώτα ῥοαῖς.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="125">αἰαῖ· κακὸν τόδ’ εἶπας οἷς κακὸν λέγεις.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὡς κεῖνος ἀφανὴς σὺν δάμαρτι κλῄζεται.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οὐ πᾶσι πορθμὸς αὑτὸς Ἀργείοισιν ἦν;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ἦν, ἀλλὰ χειμὼν ἄλλοσ’ ἄλλον ὥρισεν.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ποίοισιν ἐν νώτοισι ποντίας ἁλός;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="130">μέσον περῶσι πέλαγος Αἰγαίου πόρου. </l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>κἀκ τοῦδε Μενέλαν οὔτις εἶδ’ ἀφιγμένον;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>οὐδείς· θανὼν δὲ κλῄζεται καθ’ Ἑλλάδα.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἀπωλόμεσθα· Θεστιὰς δ’ ἔστιν κόρη;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>Λήδαν ἔλεξας; οἴχεται θανοῦσα δή.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="135">οὔ πού νιν Ἑλένης αἰσχρὸν ὤλεσεν κλέος;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>φασίν, βρόχῳ γ’ ἅψασαν εὐγενῆ δέρην.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οἱ Τυνδάρειοι δ’ εἰσὶν ἢ οὐκ εἰσὶν κόροι;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>τεθνᾶσι καὶ οὐ τεθνᾶσι· δύο δ’ ἐστὸν λόγω.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>πότερος ὁ κρείσσων; ὦ τάλαιν’ ἐγὼ κακῶν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="140">ἄστροις σφ’ ὁμοιωθέντε φάσ’ εἶναι θεώ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>καλῶς ἔλεξας τοῦτο· θάτερον δὲ τί;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>σφαγαῖς ἀδελφῆς οὕνεκ’ ἐκπνεῦσαι βίον.</l>
 					<l>ἅλις δὲ μύθων· οὐ διπλᾶ χρῄζω στένειν.</l>
@@ -515,7 +515,7 @@ convert to P3
 					<l>οἰκεῖν Ἀπόλλων, ὄνομα νησιωτικὸν</l>
 					<l n="150">Σαλαμῖνα θέμενον τῆς ἐκεῖ χάριν πάτρας.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>πλοῦς, ὦ ξέν’, αὐτὸς σημανεῖ· σὺ δ’ ἐκλιπὼν</l>
 					<l>γῆν τήνδε φεῦγε πρίν σε παῖδα Πρωτέως</l>
@@ -525,7 +525,7 @@ convert to P3
 					<l>ὅτου δ’ ἕκατι, μήτε σὺ ζήτει μαθεῖν</l>
 					<l>ἐγώ τε σιγῶ· τί γὰρ ἂν ὠφελοῖμί σε;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>καλῶς ἔλεξας, ὦ γύναι· θεοὶ δέ σοι</l>
 					<l>ἐσθλῶν ἀμοιβὰς ἀντιδωρησαίατο. </l>
@@ -538,7 +538,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="hexameter">
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὤ, μεγάλων ἀχέων καταβαλλομένα μέγαν οἶκτον</l>
 						<l n="165">ποῖον ἁμιλλαθῶ γόον; ἢ τίνα μοῦσαν ἐπέλθω</l>
@@ -547,7 +547,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>πτεροφόροι νεάνιδες,</l>
 						<l>παρθένοι Χθονὸς κόραι</l>
@@ -568,7 +568,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κυανοειδὲς ἀμφ’ ὕδωρ</l>
 						<l n="180">ἔτυχον ἕλικά τ’ ἀνὰ χλόαν</l>
@@ -589,7 +589,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἰὼ ἰώ·</l>
 						<l>θήραμα βαρβάρου πλάτας,</l>
@@ -615,7 +615,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ αἰαῖ·</l>
 						<l>ὦ δαίμονος πολυστόνου</l>
@@ -641,7 +641,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>φεῦ φεῦ, τίς ἢ Φρυγῶν</l>
 						<l n="230">ἢ τίς Ἑλλανίας ἀπὸ χθονὸς </l>
@@ -676,12 +676,12 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔχεις μὲν ἀλγείν’, οἶδα· σύμφορον δέ τοι </l>
 					<l>ὡς ῥᾷστα τἀναγκαῖα τοῦ βίου φέρειν.</l>
 				</sp>
-				<sp n="Ἑλένη" who="#elene">
+				<sp n="Ἑλένη" who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="255">φίλαι γυναῖκες, τίνι πότμῳ συνεζύγην;</l>
 					<l>ἆρ’ ἡ τεκοῦσά μ’ ἔτεκεν ἀνθρώποις τέρας;</l>
@@ -745,48 +745,48 @@ convert to P3
 					<l>αἱ μὲν γὰρ ἄλλαι διὰ τὸ κάλλος εὐτυχεῖς</l>
 					<l n="305">γυναῖκες, ἡμᾶς δ’ αὐτὸ τοῦτ’ ἀπώλεσεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Ἑλένη, τὸν ἐλθόνθ’, ὅστις ἐστὶν ὁ ξένος,</l>
 					<l>μὴ πάντ’ ἀληθῆ δοξάσῃς εἰρηκέναι.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>καὶ μὴν σαφῶς γ’ ἔλεξ’ ὀλωλέναι πόσιν. </l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πόλλ’ ἂν γένοιτο καὶ διὰ ψευδῶν ἔπη.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="310">καὶ τἄμπαλίν γε τῶνδ’ ἀληθείᾳ σαφῆ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐς ξυμφορὰν γὰρ ἀντὶ τἀγαθοῦ φέρῃ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>φόβος γὰρ ἐς τὸ δεῖμα περιβαλών μ’ ἄγει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς δ’ εὐμενείας τοισίδ’ ἐν δόμοις ἔχεις;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>πάντες φίλοι μοι πλὴν ὁ θηρεύων γάμους.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="315">οἶσθ’ οὖν ὃ δρᾶσον; μνήματος λιποῦσ’ ἕδραν — </l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἐς ποῖον ἕρπεις μῦθον ἢ παραίνεσιν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐλθοῦσ’ ἐς οἴκους, ἣ τὰ πάντ’ ἐπίσταται,</l>
 					<l>τῆς ποντίας Νηρῇδος ἐκγόνου κόρης,</l>
@@ -804,29 +804,29 @@ convert to P3
 				</sp>
 				<milestone ed="p" n="330" unit="card"/>
 				<div2 type="lyric">
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="330">φίλαι, λόγους ἐδεξάμαν·</l>
 						<l>βᾶτε βᾶτε δ’ ἐς δόμους,</l>
 						<l>ἀγῶνας ἐντὸς οἴκων</l>
 						<l>ὡς πύθησθε τοὺς ἐμούς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θέλουσαν οὐ μόλις καλεῖς.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="335">ἰὼ μέλεος ἁμέρα.</l>
 						<l>τίν’ ἄρα τάλαινα τίνα δακρυό‐ </l>
 						<l>εντα λόγον ἀκούσομαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μὴ πρόμαντις ἀλγέων</l>
 						<l>προλάμβαν’, ὦ φίλα, γόους.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="340">τί μοι πόσις μέλεος ἔτλα;</l>
 						<l>πότερα δέρκεται φάος</l>
@@ -834,12 +834,12 @@ convert to P3
 						<l n="344">ἢ ’ν νέκυσι κατὰ χθονὸς</l>
 						<l n="345">τὰν χρόνιον ἔχει τύχαν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐς τὸ φέρτερον τίθει</l>
 						<l>τὸ μέλλον, ὅ τι γενήσεται.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>σὲ γὰρ ἐκάλεσα, σὲ δὲ κατόμοσα,</l>
 						<l>τὸν ὑδρόεντι δόνακι χλωρὸν</l>
@@ -856,13 +856,13 @@ convert to P3
 						<l>ας ἐνίζοντι Πριαμί</l>
 						<l>δᾳ ποτ’ ἀμφὶ βουστάθμους.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="360">ἄλλοσ’ ἀποτροπὰ κακῶν</l>
 						<l>γένοιτο, τὸ δὲ σὸν εὐτυχές.</l>
 						<milestone ed="p" n="362" unit="card"/>
 					</sp>
-					<sp n="Ἑλένη" who="#elene">
+					<sp n="Ἑλένη" who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἰὼ Τροία τάλαινα,</l>
 						<l n="362b">δῑ ἔργ’ ἄνεργ’ ὄλλυσαι</l>
@@ -956,7 +956,7 @@ convert to P3
 						<l>ὅστις διαγγείλειε τἄμ’ ἔσω κακά;</l>
 					</sp>
 					<milestone ed="p" n="437" unit="card"/>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>τίς πρὸς πύλαισιν; οὐκ ἀπαλλάξῃ δόμων</l>
 						<l>καὶ μὴ πρὸς αὐλείοισιν ἑστηκὼς πύλαις</l>
@@ -968,7 +968,7 @@ convert to P3
 						<l>ὦ γραῖα, ταὐτὰ ταῦτ’ ἔπη κἄλλως λέγειν</l>
 						<l>ἔξεστι, πείσομαι γάρ· ἀλλ’ ἄνες λόγον.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>ἄπελθ’· ἐμοὶ γὰρ τοῦτο πρόσκειται, ξένε,</l>
 						<l>μηδένα πελάζειν τοισίδ’ Ἑλλήνων δόμοις.</l>
@@ -977,7 +977,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="445">ἆ· μὴ προσείλει χεῖρα μηδ’ ὤθει βίᾳ.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>πείθῃ γὰρ οὐδὲν ὧν λέγω, σὺ δ’ αἴτιος.</l>
 					</sp>
@@ -985,7 +985,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἄγγειλον εἴσω δεσπόταισι τοῖσι σοῖς. . . .</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>πικρῶς ἄρ’ οἶμαί γ’ ἀγγελεῖν τοὺς σοὺς λόγους.</l>
 					</sp>
@@ -993,7 +993,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ναυαγὸς ἥκω ξένος, ἀσύλητον γένος.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l n="450">οἶκον πρὸς ἄλλον νύν τιν’ ἀντὶ τοῦδ’ ἴθι.</l>
 					</sp>
@@ -1001,7 +1001,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οὔκ, ἀλλ’ ἔσω πάρειμι· καὶ σύ μοι πιθοῦ.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>ὀχληρὸς ἴσθ’ ὤν· καὶ τάχ’ ὠσθήσῃ βίᾳ.</l>
 					</sp>
@@ -1009,7 +1009,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>αἰαῖ· τὰ κλεινὰ ποῦ ’στί μοι στρατεύματα;</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>οὐκοῦν ἐκεῖ που σεμνὸς ἦσθ’, οὐκ ἐνθάδε.</l>
 					</sp>
@@ -1017,7 +1017,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="455">ὦ δαῖμον, ὡς ἀνάξῑ ἠτιμώμεθα.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>τί βλέφαρα τέγγεις δάκρυσι; πρὸς τίν’ οἰκτρὸς εἶ;</l>
 					</sp>
@@ -1025,7 +1025,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>πρὸς τὰς πάροιθεν συμφορὰς εὐδαίμονας.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>οὔκουν ἀπελθὼν δάκρυα σοῖς δώσεις φίλοις;</l>
 					</sp>
@@ -1033,7 +1033,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τίς δ’ ἥδε χώρα; τοῦ δὲ βασίλειοι δόμοι;</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l n="460">Πρωτεὺς τάδ’ οἰκεῖ δώματ’, Αἴγυπτος δὲ γῆ.</l>
 					</sp>
@@ -1041,7 +1041,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>Αἴγυπτος; ὦ δύστηνος, οἷ πέπλευκ’ ἄρα.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>τί δὴ τὸ Νείλου μεμπτόν ἐστί σοι γάνος;</l>
 					</sp>
@@ -1049,7 +1049,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οὐ τοῦτ’ ἐμέμφθην· τὰς ἐμὰς στένω τύχας.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>πολλοὶ κακῶς πράσσουσιν, οὐ σὺ δὴ μόνος.</l>
 					</sp>
@@ -1057,7 +1057,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="465">ἔστ’ οὖν ἐν οἴκοις ὅντιν’ ὀνομάζεις ἄναξ; </l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>τόδ’ ἐστὶν αὐτοῦ μνῆμα, παῖς δ’ ἄρχει χθονός.</l>
 					</sp>
@@ -1065,7 +1065,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ποῦ δῆτ’ ἂν εἴη; πότερον ἐκτὸς ἢ ’ν δόμοις;</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>οὐκ ἔνδον· Ἕλλησιν δὲ πολεμιώτατος.</l>
 					</sp>
@@ -1073,7 +1073,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τίν’ αἰτίαν σχὼν ἧς ἐπηυρόμην ἐγώ;</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l n="470">Ἑλένη κατ’ οἴκους ἐστὶ τούσδ’ ἡ τοῦ Διός.</l>
 					</sp>
@@ -1081,7 +1081,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>πῶς φῄς; τίν’ εἶπας μῦθον; αὖθίς μοι φράσον.</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>ἡ Τυνδαρὶς παῖς, ἣ κατὰ Σπάρτην ποτ’ ἦν.</l>
 					</sp>
@@ -1089,7 +1089,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>πόθεν μολοῦσα; τίνα τὸ πρᾶγμ’ ἔχει λόγον;</l>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>Λακεδαίμονος γῆς δεῦρο νοστήσασ’ ἄπο.</l>
 					</sp>
@@ -1098,7 +1098,7 @@ convert to P3
 						<l n="475">πότε; οὔ τί που λελῄσμεθ’ ἐξ ἄντρων λέχος;</l>
 						<milestone ed="p" n="476" unit="card"/>
 					</sp>
-					<sp who="#grays">
+					<sp who="#graus">
 						<speaker>Γραῦς</speaker>
 						<l>πρὶν τοὺς Ἀχαιούς, ὦ ξέν’, ἐς Τροίαν μολεῖν.</l>
 						<l>ἀλλ’ ἕρπ’ ἀπ’ οἴκων· ἔστι γάρ τις ἐν δόμοις</l>
@@ -1146,7 +1146,7 @@ convert to P3
 					<milestone ed="p" n="515" unit="card"/>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="515">ἤκουσα τᾶς θεσπιῳδοῦ κόρας,</l>
 						<l>ἃ χρῄζουσ’ ἐφάνη τυράννοις</l>
@@ -1165,7 +1165,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="dialogue">
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἥδ’ αὖ τάφου τοῦδ’ εἰς ἕδρας ἐγὼ πάλιν</l>
 						<l>στείχω, μαθοῦσα Θεονόης φίλους λόγους,</l>
@@ -1193,7 +1193,7 @@ convert to P3
 						<l>μεῖνον· τί φεύγεις; ὡς δέμας δείξασα σὸν</l>
 						<l>ἔκπληξιν ἡμῖν ἀφασίαν τε προστίθης.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="550">ἀδικούμεθ’, ὦ γυναῖκες· εἰργόμεσθα γὰρ</l>
 						<l>τάφου πρὸς ἀνδρὸς τοῦδε, καί μ’ ἑλὼν θέλει</l>
@@ -1203,7 +1203,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οὐ κλῶπές ἐσμεν, οὐχ ὑπηρέται κακῶν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>καὶ μὴν στολήν γ’ ἄμορφον ἀμφὶ σῶμ’ ἔχεις.</l>
 					</sp>
@@ -1211,7 +1211,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="555">στῆσον, φόβου μεθεῖσα, λαιψηρὸν πόδα.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἵστημ’, ἐπεί γε τοῦδ’ ἐφάπτομαι τόπου.</l>
 					</sp>
@@ -1219,7 +1219,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τίς εἶ; τίν’ ὄψιν σήν, γύναι, προσδέρκομαι;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>σὺ δ’ εἶ τίς; αὑτὸς γὰρ σὲ κἄμ’ ἔχει λόγος.</l>
 					</sp>
@@ -1227,7 +1227,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οὐπώποτ’ εἶδον προσφερέστερον δέμας.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="560">ὦ θεοί· θεὸς γὰρ καὶ τὸ γιγνώσκειν φίλους.</l>
 					</sp>
@@ -1235,7 +1235,7 @@ convert to P3
 						<speaker>&lt;Μενελέως</speaker>
 						<l>Ἑλληνὶς εἶ τις ἢ ἐπιχωρία γυνή;&gt;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>Ἑλληνίς· ἀλλὰ καὶ τὸ σὸν θέλω μαθεῖν.</l>
 					</sp>
@@ -1243,7 +1243,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>Ἑλένῃ σ’ ὁμοίαν δὴ μάλιστ’ εἶδον, γύναι.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἐγὼ δὲ Μενέλεῴ γε σέ· οὐδ’ ἔχω τί φῶ.</l>
 					</sp>
@@ -1252,7 +1252,7 @@ convert to P3
 						<l n="565">ἔγνως γὰρ ὀρθῶς ἄνδρα δυστυχέστατον.</l>
 						<milestone ed="p" n="566" unit="card"/>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὦ χρόνιος ἐλθὼν σῆς δάμαρτος ἐς χέρας.</l>
 					</sp>
@@ -1260,7 +1260,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ποίας δάμαρτος; μὴ θίγῃς ἐμῶν πέπλων.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἥν σοι δίδωσι Τυνδάρεως, ἐμὸς πατήρ.</l>
 					</sp>
@@ -1268,7 +1268,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ὦ φωσφόρ’ Ἑκάτη, πέμπε φάσματ’ εὐμενῆ.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="570">οὐ νυκτίφαντον πρόπολον Ἐνοδίας μ’ ὁρᾷς.</l>
 					</sp>
@@ -1276,7 +1276,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οὐ μὴν γυναικῶν γ’ εἷς δυοῖν ἔφυν πόσις.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ποίων δὲ λέκτρων δεσπότης ἄλλων ἔφυς;</l>
 					</sp>
@@ -1284,7 +1284,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἣν ἄντρα κεύθει κἀκ Φρυγῶν κομίζομαι.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὐκ ἔστιν ἄλλη σή τις ἀντ’ ἐμοῦ γυνή. </l>
 					</sp>
@@ -1292,7 +1292,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="575">οὔ που φρονῶ μὲν εὖ, τὸ δ’ ὄμμα μου νοσεῖ;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὐ γάρ με λεύσσων σὴν δάμαρθ’ ὁρᾶν δοκεῖς;</l>
 					</sp>
@@ -1300,7 +1300,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τὸ σῶμ’ ὅμοιον, τὸ δὲ σαφές μ’ ἀποστερεῖ.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>σκέψαι· τί σοὐνδεῖ; τίς δὲ σοῦ σοφώτερος;</l>
 					</sp>
@@ -1308,7 +1308,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἔοικας· οὔτοι τοῦτό γ’ ἐξαρνήσομαι.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="580">τίς οὖν διδάξει σ’ ἄλλος ἢ τὰ σ’ ὄμματα;</l>
 					</sp>
@@ -1316,7 +1316,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἐκεῖ νοσοῦμεν, ὅτι δάμαρτ’ ἄλλην ἔχω.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὐκ ἦλθον ἐς γῆν Τρῳάδ’, ἀλλ’ εἴδωλον ἦν.</l>
 					</sp>
@@ -1324,7 +1324,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>καὶ τίς βλέποντα σώματ’ ἐξεργάζεται;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>αἰθήρ, ὅθεν σὺ θεοπόνητ’ ἔχεις λέχη.</l>
 					</sp>
@@ -1332,7 +1332,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="585">τίνος πλάσαντος θεῶν; ἄελπτα γὰρ λέγεις.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>Ἥρας, διάλλαγμ’, ὡς Πάρις με μὴ λάβοι.</l>
 					</sp>
@@ -1340,7 +1340,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>πῶς οὖν ἂν ἐνθάδ’ ἦσθά &lt;τ’&gt; ἐν Τροίᾳ θ’ ἅμα;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>τοὔνομα γένοιτ’ ἂν πολλαχοῦ, τὸ σῶμα δ’ οὔ.</l>
 					</sp>
@@ -1348,7 +1348,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>μέθες με, λύπης ἅλις ἔχων ἐλήλυθα.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="590">λείψεις γὰρ ἡμᾶς, τὰ δὲ κέν’ ἐξάξεις λέχη;</l>
 					</sp>
@@ -1356,7 +1356,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>καὶ χαῖρέ γ’, Ἑλένῃ προσφερὴς ὁθούνεκ’ εἶ.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἀπωλόμην· λαβοῦσά σ’ οὐχ ἕξω πόσιν.</l>
 					</sp>
@@ -1364,14 +1364,14 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τοὐκεῖ με μέγεθος τῶν πόνων πείθει, σὺ δ’ οὔ.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οἲ ἐγώ· τίς ἡμῶν ἐγένετ’ ἀθλιωτέρα;</l>
 						<l n="595">οἱ φίλτατοι λείπουσί μ’ οὐδ’ ἀφίξομαι</l>
 						<l>Ἕλληνας οὐδὲ πατρίδα τὴν ἐμήν ποτε.</l>
 						<milestone ed="p" n="597" unit="card"/>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>Μενέλαε, μαστεύων σε κιγχάνω μόλις</l>
 						<l>πᾶσαν πλανηθεὶς τήνδε βάρβαρον χθόνα,</l>
@@ -1381,7 +1381,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="600">τί δ’ ἔστιν; οὔ που βαρβάρων συλᾶσθ’ ὕπο;</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>θαῦμ’ ἔστ’, ἔλασσον τοὔνομ’ ἢ τὸ πρᾶγμ’ ἔχον.</l>
 					</sp>
@@ -1389,7 +1389,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>λέγ’· ὡς φέρεις τι τῇδε τῇ σπουδῇ νέον.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>λέγω πόνους σε μυρίους τλῆναι μάτην.</l>
 					</sp>
@@ -1397,7 +1397,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>παλαιὰ θρηνεῖς πήματ’· ἀγγέλλεις δὲ τί;</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l n="605">βέβηκεν ἄλοχος σὴ πρὸς αἰθέρος πτυχὰς</l>
 						<l>ἀρθεῖσ’ ἄφαντος· οὐρανῷ δὲ κρύπτεται</l>
@@ -1427,7 +1427,7 @@ convert to P3
 						<l>ἥ σ’ εἰς ἐμὰς ἔδωκεν ὠλένας λαβεῖν.</l>
 						<milestone ed="p" n="625" unit="card"/>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="625">ὦ φίλτατ’ ἀνδρῶν Μενέλεως, ὁ μὲν χρόνος</l>
 						<l>παλαιός, ἡ δὲ τέρψις ἀρτίως πάρα.</l>
@@ -1443,7 +1443,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>γέγηθα, κρατὶ δ’ ὀρθίους ἐθείρας</l>
 						<l>ἀνεπτέρωκα καὶ δάκρυ σταλάσσω,</l>
@@ -1463,14 +1463,14 @@ convert to P3
 						<l>τὸ κακὸν δ’ ἀγαθὸν σέ τε κἀμὲ συνάγαγε, πόσιν</l>
 						<l n="645">χρόνιον, ἀλλ’ ὅμως ὀναίμαν τύχας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						 
 
 						<speaker>Χορός</speaker>
 						<l>ὄναιο δῆτα. ταὐτὰ δὴ ξυνεύχομαι·</l>
 						<l>δυοῖν γὰρ ὄντοιν οὐχ ὃ μὲν τλήμων, ὃ δ’ οὔ.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>φίλαι φίλαι, τὰ πάρος οὐκέτι</l>
 						<l>στένομεν οὐδ’ ἀλγῶ.</l>
@@ -1484,7 +1484,7 @@ convert to P3
 						<l>ἐμὰ δὲ χαρμονὰ δάκρυα· πλέον ἔχει</l>
 						<l n="655">χάριτος ἢ λύπας.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>τί φῶ; τίς ἂν τάδ’ ἤλπισεν βροτῶν ποτε;</l>
 						<l>ἀδόκητον ἔχω σε πρὸς στέρνοις.</l>
@@ -1495,7 +1495,7 @@ convert to P3
 						<l>μολεῖν Ἰλίου τε μελέους πύργους.</l>
 						<l n="660">πρὸς θεῶν, δόμων πῶς τῶν ἐμῶν ἀπεστάλης;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἒ ἔ· πικρὰς ἐς ἀρχὰς βαίνεις,</l>
 						<l>ἒ ἔ· πικρὰν δ’ ἐρευνᾷς φάτιν.</l>
@@ -1504,7 +1504,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>λέγ’· ὡς ἀκουστὰ πάντα δῶρα δαιμόνων.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἀπέπτυσα μὲν λόγον, οἷον οἷον ἐσοίσομαι.</l>
 					</sp>
@@ -1513,7 +1513,7 @@ convert to P3
 						<l n="665">ὅμως δὲ λέξον· ἡδύ τοι μόχθων κλύειν.</l>
 						<milestone ed="p" n="666" unit="card"/>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὐκ ἐπὶ βαρβάρου λέκτρα νεανία</l>
 						<l>πετομένας κώπας,</l>
@@ -1523,7 +1523,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τίς &lt;γάρ&gt; σε δαίμων ἢ πότμος συλᾷ πάτρας;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="670">ὁ Διὸς ὁ Διός, ὦ πόσι, παῖς μ’ . . .</l>
 						<l>ἐπέλασεν Νείλῳ.</l>
@@ -1532,7 +1532,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>θαυμαστά· τοῦ πέμψαντος; ὦ δεινοὶ λόγοι.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>κατεδάκρυσα καὶ βλέφαρον ὑγραίνω</l>
 						<l>δάκρυσιν· ἁ Διός μ’ ἄλοχος ὤλεσεν.</l>
@@ -1541,7 +1541,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="675">Ἥρα; τί νῷν χρῄζουσα προσθεῖναι κακόν;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὤμοι ἐμῶν δεινῶν, λουτρῶν καὶ κρηνῶν,</l>
 						<l>ἵνα θεαὶ μορφὰν </l>
@@ -1551,7 +1551,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τὰ δ’ ἐς κρίσιν σοι τῶνδ’ ἔθηχ’ Ἥρα κακῶν — ;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="680">Πάριν ὡς ἀφέλοιτο — </l>
 					</sp>
@@ -1559,7 +1559,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l part="Y">πῶς; αὔδα.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>Κύπρις ᾧ μ’ ἐπένευσεν — </l>
 					</sp>
@@ -1567,7 +1567,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l part="Y">ὦ τλᾶμον.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>τλάμων, τλάμων· ὧδ’ ἐπέλασ’ Αἰγύπτῳ.</l>
 					</sp>
@@ -1575,7 +1575,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>εἶτ’ ἀντέδωκ’ εἴδωλον, ὡς σέθεν κλύω.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>τὰ δὲ &lt;σὰ&gt; κατὰ μέλαθρα πάθεα πάθεα, μᾶ‐</l>
 						<l n="685">τερ, οἲ ’γώ.</l>
@@ -1584,7 +1584,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l part="Y">τί φῄς;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὐκ ἔστι μάτηρ· ἀγχόνιον δὲ βρόχον</l>
 						<l>δῑ ἐμὰν κατεδήσατο δυσγάμου αἰσχύναν.</l>
@@ -1593,7 +1593,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ὤμοι· θυγατρὸς δ’ Ἑρμιόνης ἔστιν βίος;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἄγαμος ἄτεκνος, ὦ πόσι, καταστένει</l>
 						<l n="690">γάμον ἄγαμον &lt;ἐμόν&gt;.</l>
@@ -1604,7 +1604,7 @@ convert to P3
 						<l>τάδε καὶ σὲ διώλεσε μυριάδας τε</l>
 						<l>χαλκεόπλων Δαναῶν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἐμὲ δὲ πατρίδος ἄπο κακόποτμον ἀραίαν</l>
 						<l n="695">ἔβαλε θεὸς ἀπό &lt;τε&gt; πόλεος ἀπό τε σέθεν,</l>
@@ -1614,12 +1614,12 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="dialogue">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ καὶ τὰ λοιπὰ τῆς τύχης εὐδαίμονος</l>
 						<l>τύχοιτε, πρὸς τὰ πρόσθεν ἀρκέσειεν ἄν.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l n="700">Μενέλαε, κἀμοὶ πρόσδοτον τῆς ἡδονῆς, </l>
 						<l>ἣν μανθάνω μὲν καὐτός, οὐ σαφῶς δ’ ἔχω.</l>
@@ -1628,7 +1628,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἀλλ’, ὦ γεραιέ, καὶ σὺ κοινώνει λόγων.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>οὐχ ἥδε μόχθων τῶν ἐν Ἰλίῳ βραβεύς;</l>
 					</sp>
@@ -1637,7 +1637,7 @@ convert to P3
 						<l>οὐχ ἥδε, πρὸς θεῶν δ’ ἦμεν ἠπατημένοι,</l>
 						<l n="705">νεφέλης ἄγαλμ’ ἔχοντες ἐν χεροῖν λυγρόν.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>τί φῄς;</l>
 						<l>νεφέλης ἄρ’ ἄλλως εἴχομεν πόνους πέρι;</l>
@@ -1646,7 +1646,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>Ἥρας τάδ’ ἔργα καὶ θεῶν τρισσῶν ἔρις.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ἡ δ’ οὖσ’ ἀληθῶς ἐστιν ἥδε σὴ δάμαρ;</l>
 					</sp>
@@ -1654,7 +1654,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="710">αὕτη· λόγοις [δ’] ἐμοῖσι πίστευσον τάδε.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ὦ θύγατερ, ὁ θεὸς ὡς ἔφυ τι ποικίλον</l>
 						<l>καὶ δυστέκμαρτον. εὖ δέ πως πάντα στρέφει</l>
@@ -1694,7 +1694,7 @@ convert to P3
 						<l>φρουρεῖν ὅπως ἂν εἰς ἓν ἐλθόντες τύχης</l>
 						<l>ἐκ βαρβάρων σωθῶμεν, ἢν δυνώμεθα.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ἔσται τάδ’, ὦναξ. ἀλλά τοι τὰ μάντεων</l>
 						<l n="745">ἐσεῖδον ὡς φαῦλ’ ἐστὶ καὶ ψευδῶν πλέα.</l>
@@ -1712,13 +1712,13 @@ convert to P3
 						<l>γνώμη δ’ ἀρίστη μάντις ἥ τ’ εὐβουλία.</l>
 						<milestone ed="p" n="758" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐς ταὐτὸ κἀμοὶ δόξα μαντειῶν πέρι</l>
 						<l>χωρεῖ γέροντι· τοὺς θεοὺς ἔχων τις ἂν</l>
 						<l n="760">φίλους ἀρίστην μαντικὴν ἔχοι δόμοις.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>εἶἑν· τὰ μὲν δὴ δεῦρ’ ἀεὶ καλῶς ἔχει.</l>
 						<l>ὅπως δ’ ἐσώθης, ὦ τάλας, Τροίας ἄπο,</l>
@@ -1735,7 +1735,7 @@ convert to P3
 						<l n="770">μύθων, λέγων τ’ ἄν σοι κάκ’ ἀλγοίην ἔτι,</l>
 						<l>πάσχων τ’ ἔκαμνον· δὶς δὲ λυπηθεῖμεν ἄν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>κάλλιον εἶπας ἤ σ’ ἀνηρόμην ἐγώ.</l>
 						<l>ἓν δ’ εἰπὲ πάντα παραλιπών, πόσον χρόνον</l>
@@ -1746,7 +1746,7 @@ convert to P3
 						<l n="775">ἐν ναυσὶν ὢν πρὸς τοῖσιν ἐν Τροίᾳ δέκα</l>
 						<l>ἔτεσι διῆλθον ἑπτὰ περιδρομὰς ἐτῶν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>φεῦ φεῦ· μακρόν γ’ ἔλεξας, ὦ τάλας, χρόνον</l>
 						<l>σωθεὶς δ’ ἐκεῖθεν ἐνθάδ’ ἦλθες ἐς σφαγάς.</l>
@@ -1755,7 +1755,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>πῶς φῄς; τί λέξεις; ὥς μ’ ἀπώλεσας, γύναι.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="780">φεῦγ’ ὡς τάχιστα τῆσδ’ ἀπαλλαχθεὶς χθονός. </l>
 						<l>θανῇ πρὸς ἀνδρὸς οὗ τάδ’ ἐστὶ δώματα.</l>
@@ -1764,7 +1764,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τί χρῆμα δράσας ἄξιον τῆς συμφορᾶς;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἥκεις ἄελπτος ἐμποδὼν ἐμοῖς γάμοις.</l>
 					</sp>
@@ -1772,7 +1772,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἦ γὰρ γαμεῖν τις τἄμ’ ἐβουλήθη λέχη;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="785">ὕβριν θ’ ὑβρίζειν εἰς ἔμ’, ἣν ἔτλην ἐγώ.</l>
 					</sp>
@@ -1780,7 +1780,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἰδίᾳ σθένων τις ἢ τυραννεύων χθονός;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὃς γῆς ἀνάσσει τῆσδε Πρωτέως γόνος.</l>
 					</sp>
@@ -1788,7 +1788,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τόδ’ ἔστ’ ἐκεῖν’ αἴνιγμ’ ὃ προσπόλου κλύω.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ποίοις ἐπιστὰς βαρβάροις πυλώμασιν;</l>
 					</sp>
@@ -1796,7 +1796,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="790">τοῖσδ’, ἔνθεν ὥσπερ πτωχὸς ἐξηλαυνόμην.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὔ που προσῄτεις βίοτον; ὦ τάλαιν’ ἐγώ.</l>
 					</sp>
@@ -1805,7 +1805,7 @@ convert to P3
 						<l>τοὔργον μὲν ἦν τοῦτ’, ὄνομα δ’ οὐκ εἶχεν τόδε.</l>
 						<milestone ed="p" n="793" unit="card"/>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>πάντ’ οἶσθ’ ἄρ’, ὡς ἔοικας, ἀμφ’ ἐμῶν γάμων.</l>
 					</sp>
@@ -1813,7 +1813,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οἶδ’· εἰ δὲ λέκτρα διέφυγες τάδ’ οὐκ ἔχω.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="795">ἄθικτον εὐνὴν ἴσθι σοι σεσῳσμένην.</l>
 					</sp>
@@ -1821,7 +1821,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τίς τοῦδε πειθώ; φίλα γάρ, εἰ σαφῆ λέγεις.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὁρᾷς τάφου τοῦδ’ ἀθλίους ἕδρας ἐμάς;</l>
 					</sp>
@@ -1829,7 +1829,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ὁρῶ ταλαίνας στιβάδας, ὧν τί σοὶ μέτα;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἐνταῦθα λέκτρων ἱκετεύομεν φυγάς.</l>
 					</sp>
@@ -1837,7 +1837,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="800">βωμοῦ σπανίζουσ’ ἢ νόμοισι βαρβάροις;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἐρρύεθ’ ἡμᾶς τοῦτ’ ἴσον ναοῖς θεῶν.</l>
 					</sp>
@@ -1845,7 +1845,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οὐδ’ ἄρα πρὸς οἴκους ναυστολεῖν &lt;σ’&gt; ἔξεστί μοι;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ξίφος μένει σε μᾶλλον ἢ τοὐμὸν λέχος.</l>
 					</sp>
@@ -1853,7 +1853,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>οὕτως ἂν εἴην ἀθλιώτατος βροτῶν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="805">μή νυν καταιδοῦ, φεῦγε δ’ ἐκ τῆσδε χθονός.</l>
 					</sp>
@@ -1861,7 +1861,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>λιπών σε; Τροίαν ἐξέπερσα σὴν χάριν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>κρεῖσσον γὰρ ἤ σε τἄμ’ ἀποκτεῖναι λέχη. </l>
 					</sp>
@@ -1869,7 +1869,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἄνανδρά γ’ εἶπας Ἰλίου τ’ οὐκ ἄξια.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὐκ ἂν κτάνοις τύραννον, ὃ σπεύδεις ἴσως.</l>
 					</sp>
@@ -1877,7 +1877,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="810">οὕτω σιδήρῳ τρωτὸν οὐκ ἔχει δέμας;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>εἴσῃ. τὸ τολμᾶν δ’ ἀδύνατ’ ἀνδρὸς οὐ σοφοῦ.</l>
 					</sp>
@@ -1885,7 +1885,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>σιγῇ παράσχω δῆτ’ ἐμὰς δῆσαι χέρας;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἐς ἄπορον ἥκεις· δεῖ δὲ μηχανῆς τινος.</l>
 					</sp>
@@ -1893,7 +1893,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>δρῶντας γὰρ ἢ μὴ δρῶντας ἥδιον θανεῖν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="815">μί’ ἔστιν ἐλπίς, ᾗ μόνῃ σωθεῖμεν ἄν.</l>
 					</sp>
@@ -1901,7 +1901,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ὠνητὸς ἢ τολμητὸς ἢ λόγων ὕπο;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>εἰ μὴ τύραννός &lt;σ’&gt; ἐκπύθοιτ’ ἀφιγμένον.</l>
 					</sp>
@@ -1909,7 +1909,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἐρεῖ δὲ τίς μ’; οὐ γνώσεταί γ’ ὅς εἰμ’ ἐγώ.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἔστ’ ἔνδον αὐτῷ ξύμμαχος θεοῖς ἴση.</l>
 					</sp>
@@ -1917,7 +1917,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="820">φήμη τις οἴκων ἐν μυχοῖς ἱδρυμένη;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οὔκ, ἀλλ’ ἀδελφή· Θεονόην καλοῦσί νιν.</l>
 					</sp>
@@ -1925,7 +1925,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>χρηστήριον μὲν τοὔνομ’· ὅ τι δὲ δρᾷ φράσον.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>πάντ’ οἶδ’, ἐρεῖ τε συγγόνῳ παρόντα σε.</l>
 					</sp>
@@ -1933,7 +1933,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>θνῄσκοιμεν ἄν· λαθεῖν γὰρ οὐχ οἷόν τέ μοι.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="825">ἴσως ἂν ἀναπείσαιμεν ἱκετεύοντέ νιν — </l>
 					</sp>
@@ -1941,7 +1941,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τί χρῆμα δρᾶσαι; τίν’ ὑπάγεις μ’ ἐς ἐλπίδα;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>παρόντα γαίᾳ μὴ φράσαι σε συγγόνῳ.</l>
 					</sp>
@@ -1949,7 +1949,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>πείσαντε δ’ ἐκ γῆς διορίσαιμεν ἂν πόδα;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>κοινῇ γ’ ἐκείνῃ ῥᾳδίως, λάθρᾳ δ’ ἂν οὔ.</l>
 					</sp>
@@ -1957,7 +1957,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="830">σὸν ἔργον, ὡς γυναικὶ πρόσφορον γυνή.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὡς οὐκ ἄχρωστα γόνατ’ ἐμῶν ἕξει χερῶν.</l>
 						<milestone ed="p" n="832" unit="card"/>
@@ -1966,7 +1966,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>φέρ’, ἢν δὲ δὴ νῷν μὴ ἀποδέξηται λόγους;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>θανῇ· γαμοῦμαι δ’ ἡ τάλαιν’ ἐγὼ βίᾳ.</l>
 					</sp>
@@ -1974,7 +1974,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>προδότις ἂν εἴης· τὴν βίαν σκήψασ’ ἔχεις. </l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="835">ἀλλ’ ἁγνὸν ὅρκον σὸν κάρα κατώμοσα . . .</l>
 					</sp>
@@ -1982,7 +1982,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>τί φῄς; θανεῖσθαι; κοὔποτ’ ἀλλάξεις λέχη;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ταὐτῷ ξίφει γε· κείσομαι δὲ σοῦ πέλας.</l>
 					</sp>
@@ -1990,7 +1990,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l>ἐπὶ τοῖσδε τοίνυν δεξιᾶς ἐμῆς θίγε.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ψαύω, θανόντος σοῦ τόδ’ ἐκλείψειν φάος.</l>
 					</sp>
@@ -1998,7 +1998,7 @@ convert to P3
 						<speaker>Μενελέως</speaker>
 						<l n="840">κἀγὼ στερηθεὶς σοῦ τελευτήσειν βίον.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>πῶς οὖν θανούμεθ’ ὥστε καὶ δόξαν λαβεῖν;</l>
 					</sp>
@@ -2018,12 +2018,12 @@ convert to P3
 						<l>κούφῃ καταμπίσχουσιν ἐν τύμβῳ χθονί,</l>
 						<l>κακοὺς δ’ ἐφ’ ἕρμα στερεὸν ἐκβάλλουσι γῆς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="855">ὦ θεοί, γενέσθω δή ποτ’ εὐτυχὲς γένος</l>
 						<l>τὸ Ταντάλειον καὶ μεταστήτω κακῶν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>οἲ ἐγὼ τάλαινα· τῆς τύχης γὰρ ὧδ’ ἔχω.</l>
 						<l>Μενέλαε, διαπεπράγμεθ’· ἐκβαίνει δόμων</l>
@@ -2074,7 +2074,7 @@ convert to P3
 						<l>παρόνθ’, ὅπως ἂν τοὐμὸν ἀσφαλῶς ἔχῃ;</l>
 						<milestone ed="p" n="894" unit="card"/>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὦ παρθέν’, ἱκέτις ἀμφὶ σὸν πίτνω γόνυ</l>
 						<l n="895">καὶ προσκαθίζω θᾶκον οὐκ εὐδαίμονα</l>
@@ -2131,7 +2131,7 @@ convert to P3
 						<l>ἐς ταὐτὸν ἦλθε τοῖς τεκοῦσι τοὺς τρόπους.</l>
 						<milestone ed="p" n="944" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἰκτρὸν μὲν οἱ παρόντες ἐν μέσῳ λόγοι,</l>
 						<l n="945">οἰκτρὰ δὲ καὶ σύ. τοὺς δὲ Μενέλεω ποθῶ</l>
@@ -2199,7 +2199,7 @@ convert to P3
 						<l>μᾶλλόν γε μέντοι τοῖς ἐμοῖς πείθου λόγοις,</l>
 						<l n="995">ἵν’ ᾖς δικαία καὶ δάμαρτ’ ἐγὼ λάβω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐν σοὶ βραβεύειν, ὦ νεᾶνι, τοὺς λόγους·</l>
 						<l>οὕτω δὲ κρῖνον, ὡς ἅπασιν ἁνδάνῃς.</l>
@@ -2243,13 +2243,13 @@ convert to P3
 						<l>σὺ δ’, ὦ θανών μοι πάτερ, ὅσον γ’ ἐγὼ σθένω,</l>
 						<l>οὔποτε κεκλήσῃ δυσσεβὴς ἀντ’ εὐσεβοῦς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1030">οὐδείς ποτ’ εὐτύχησεν ἔκδικος γεγώς,</l>
 						<l>ἐν τῷ δικαίῳ δ’ ἐλπίδες σωτηρίας.</l>
 						<milestone ed="p" n="1032" unit="card"/>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>Μενέλαε, πρὸς μὲν παρθένου σεσῴσμεθα·</l>
 						<l>τοὐνθένδε δὴ σὲ τοὺς λόγους φέροντα χρὴ</l>
@@ -2260,7 +2260,7 @@ convert to P3
 						<l n="1035">ἄκουε δή νυν· χρόνιος εἶ κατὰ στέγας</l>
 						<l>καὶ συντέθραψαι προσπόλοισι βασιλέως.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>τί τοῦτ’ ἔλεξας; ἐσφέρεις γὰρ ἐλπίδας</l>
 						<l>ὡς δή τι δράσων χρηστὸν ἐς κοινόν γε νῷν.</l>
@@ -2270,7 +2270,7 @@ convert to P3
 						<l>πείσειας ἄν τιν’ οἵτινες τετραζύγων</l>
 						<l n="1040">ὄχων ἀνάσσουσ’, ὥστε νῷν δοῦναι δίφρους;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>πείσαιμ’ &lt;ἄν&gt;· ἀλλὰ τίνα φυγὴν φευξούμεθα</l>
 						<l>πεδίων ἄπειροι βαρβάρου τ’ ὄντες χθονός;</l>
@@ -2280,7 +2280,7 @@ convert to P3
 						<l>ἀδύνατον εἶπας. φέρε, τί δ’, εἰ κρυφθεὶς δόμοις</l>
 						<l>κτάνοιμ’ ἄνακτα τῷδε διστόμῳ ξίφει;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="1045">οὐκ ἄν σ’ ἀνάσχοιτ’ οὐδὲ σιγήσειεν ἂν</l>
 						<l>μέλλοντ’ ἀδελφὴ σύγγονον κατακτενεῖν.</l>
@@ -2290,7 +2290,7 @@ convert to P3
 						<l>ἀλλ’ οὐδὲ μὴν ναῦς ἔστιν ᾗ σωθεῖμεν ἂν</l>
 						<l>φεύγοντες· ἣν γὰρ εἴχομεν θάλασσ’ ἔχει. </l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἄκουσον, ἤν τι καὶ γυνὴ λέξῃ σοφόν.</l>
 						<l n="1050">βούλῃ λέγεσθαι, μὴ θανών, λόγῳ θανεῖν;</l>
@@ -2300,7 +2300,7 @@ convert to P3
 						<l>κακὸς μὲν ὄρνις· εἰ δὲ κερδανῶ, λέγειν</l>
 						<l>ἕτοιμός εἰμι μὴ θανὼν λόγῳ θανεῖν.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>καὶ μὴν γυναικείοις σ’ ἂν οἰκτισαίμεθα</l>
 						<l>κουραῖσι καὶ θρήνοισι πρὸς τὸν ἀνόσιον.</l>
@@ -2310,7 +2310,7 @@ convert to P3
 						<l n="1055">σωτηρίας δὲ τοῦτ’ ἔχει τί νῷν ἄκος;</l>
 						<l>παλαιότης γὰρ τῷ λόγῳ γ’ ἔνεστί τις.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ὡς δὴ θανόντα σ’ ἐνάλιον κενῷ τάφῳ</l>
 						<l>θάψαι τύραννον τῆσδε γῆς αἰτήσομαι.</l>
@@ -2320,7 +2320,7 @@ convert to P3
 						<l>καὶ δὴ παρεῖκεν· εἶτα πῶς ἄνευ νεὼς</l>
 						<l n="1060">σωθησόμεσθα κενοταφοῦντ’ ἐμὸν δέμας;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>δοῦναι κελεύσω πορθμίδ’, ᾗ καθήσομαι</l>
 						<l>κόσμον τάφῳ σῷ πελαγίους ἐς ἀγκάλας.</l>
@@ -2330,7 +2330,7 @@ convert to P3
 						<l>ὡς εὖ τόδ’ εἶπας πλὴν ἕν· εἰ χέρσῳ ταφὰς</l>
 						<l>θεῖναι κελεύσει σ’, οὐδὲν ἡ σκῆψις φέρει.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="1065">ἀλλ’ οὐ νομίζειν φήσομεν καθ’ Ἑλλάδα</l>
 						<l>χέρσῳ καλύπτειν τοὺς θανόντας ἐναλίους.</l>
@@ -2341,7 +2341,7 @@ convert to P3
 						<l>τοῦτ’ αὖ κατορθοῖς· εἶτ’ ἐγὼ συμπλεύσομαι</l>
 						<l>καὶ συγκαθήσω κόσμον ἐν ταὐτῷ σκάφει.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>σὲ καὶ παρεῖναι δεῖ μάλιστα τούς τε σοὺς</l>
 						<l n="1070">πλωτῆρας οἵπερ ἔφυγον ἐκ ναυαγίας.</l>
@@ -2351,7 +2351,7 @@ convert to P3
 						<l>καὶ μὴν ἐάνπερ ναῦν ἐπ’ ἀγκύρας λάβω,</l>
 						<l>ἀνὴρ παρ’ ἄνδρα στήσεται ξιφηφόρος.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>σὲ χρὴ βραβεύειν πάντα· πόμπιμοι μόνον </l>
 						<l>λαίφει πνοαὶ γένοιντο καὶ νεὼς δρόμος.</l>
@@ -2361,7 +2361,7 @@ convert to P3
 						<l n="1075">ἔσται· πόνους γὰρ δαίμονες παύσουσί μου.</l>
 						<l>ἀτὰρ θανόντα τοῦ μ’ ἐρεῖς πεπυσμένη;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>σοῦ· καὶ μόνος γε φάσκε διαφυγεῖν μόρον</l>
 						<l>Ἀτρέως πλέων σὺν παιδὶ καὶ θανόνθ’ ὁρᾶν.</l>
@@ -2371,7 +2371,7 @@ convert to P3
 						<l>καὶ μὴν τάδ’ ἀμφίβληστρα σώματος ῥάκη</l>
 						<l n="1080">ξυμμαρτυρήσει ναυτικῶν ἐρειπίων.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἐς καιρὸν ἦλθε, τότε δ’ ἄκαιρ’ ἀπώλλυτο·</l>
 						<l>τὸ δ’ ἄθλιον κεῖν’ εὐτυχὲς τάχ’ ἂν πέσοι.</l>
@@ -2381,7 +2381,7 @@ convert to P3
 						<l>πότερα δ’ ἐς οἴκους σοὶ συνεισελθεῖν με χρὴ</l>
 						<l>ἢ πρὸς τάφῳ τῷδ’ ἥσυχοι καθώμεθα;</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l n="1085">αὐτοῦ μέν’· ἢν γὰρ καί τι πλημμελές σε δρᾷ,</l>
 						<l>τάφος σ’ ὅδ’ ἂν ῥύσαιτο φάσγανόν τε σόν.</l>
@@ -2414,7 +2414,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὲ τὰν ἐναύλοις ὑπὸ δενδροκόμοις</l>
 						<l>μουσεῖα καὶ θάκους ἐνί‐</l>
@@ -2437,7 +2437,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλοὶ δ’ Ἀχαιῶν δορὶ καὶ πετρίναις</l>
 						<l>ῥιπαῖσιν ἐκπνεύσαντες Ἅι‐</l>
@@ -2460,7 +2460,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅ τι θεὸς ἢ μὴ θεὸς ἢ τὸ μέσον,</l>
 						<l>τίς φησ’ ἐρευνήσας βροτῶν</l>
@@ -2480,7 +2480,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄφρονες ὅσοι τὰς ἀρετὰς πολέμῳ</l>
 						<l>λόγχαισί τ’ ἀλκαίου δορὸς</l>
@@ -2539,7 +2539,7 @@ convert to P3
 					<l>στένεις ὀνείροις, ἢ φάτιν τιν’ οἴκοθεν</l>
 					<l>κλύουσα λύπῃ σὰς διέφθαρσαι φρένας;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ὦ δέσποτ’ — ἤδη γὰρ τόδ’ ὀνομάζω σ’ ἔπος — </l>
 					<l>ὄλωλα· φροῦδα τἀμὰ κοὐδέν εἰμ’ ἔτι.</l>
@@ -2548,7 +2548,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1195">ἐν τῷ δὲ κεῖσαι συμφορᾶς; τίς ἡ τύχη; </l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>Μενέλαος — οἴμοι, πῶς φράσω;  — τέθνηκέ μοι.</l>
 				</sp>
@@ -2557,7 +2557,7 @@ convert to P3
 					<l>οὐδέν τι χαίρω σοῖς λόγοις, τὰ δ’ εὐτυχῶ.</l>
 					<l>πῶς &lt;δ’&gt; οἶσθα; μῶν σοι Θεονόη λέγει τάδε;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>κείνη τε φησὶν ὅ τε παρὼν ὅτ’ ὤλλυτο.</l>
 				</sp>
@@ -2565,7 +2565,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1200">ἥκει γὰρ ὅστις καὶ τάδ’ ἀγγέλλει σαφῆ;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἥκει· μόλοι γὰρ οἷ σφ’ ἐγὼ χρῄζω μολεῖν.</l>
 				</sp>
@@ -2573,7 +2573,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>τίς ἐστι; ποῦ ’στιν; ἵνα σαφέστερον μάθω.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ὅδ’ ὃς κάθηται τῷδ’ ὑποπτήξας τάφῳ.</l>
 				</sp>
@@ -2581,7 +2581,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>Ἄπολλον, ὡς ἐσθῆτι δυσμόρφῳ πρέπει.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="1205">οἴμοι, δοκῶ μὲν κἀμὸν ὧδ’ ἔχειν πόσιν.</l>
 					<milestone ed="p" n="1206" unit="card"/>
@@ -2590,7 +2590,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>ποδαπὸς δ’ ὅδ’ ἁνὴρ καὶ πόθεν κατέσχε γῆν;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>Ἕλλην, Ἀχαιῶν εἷς ἐμῷ σύμπλους πόσει.</l>
 				</sp>
@@ -2598,7 +2598,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>θανάτῳ δὲ ποίῳ φησὶ Μενέλεων θανεῖν;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οἰκτρόταθ’, ὑγροῖσιν ἐν κλυδωνίοις ἁλός.</l>
 				</sp>
@@ -2606,7 +2606,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1210">ποῦ βαρβάροισι πελάγεσιν ναυσθλούμενον;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>Λιβύης ἀλιμένοις ἐκπεσόντα πρὸς πέτραις.</l>
 				</sp>
@@ -2614,7 +2614,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>καὶ πῶς ὅδ’ οὐκ ὄλωλε κοινωνῶν πλάτης;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἐσθλῶν κακίους ἐνίοτ’ εὐτυχέστεροι.</l>
 				</sp>
@@ -2622,7 +2622,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>λιπὼν δὲ ναὸς ποῦ πάρεστιν ἔκβολα;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="1215">ὅπου κακῶς ὄλοιτο, Μενέλεως δὲ μή.</l>
 				</sp>
@@ -2630,7 +2630,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>ὄλωλ’ ἐκεῖνος. ἦλθε δ’ ἐν ποίῳ σκάφει;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ναῦταί σφ’ ἀνείλοντ’ ἐντυχόντες, ὡς λέγει.</l>
 				</sp>
@@ -2638,7 +2638,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>ποῦ δὴ τὸ πεμφθὲν ἀντὶ σοῦ Τροίᾳ κακόν;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>νεφέλης λέγεις ἄγαλμα; ἐς αἰθέρ’ οἴχεται.</l>
 				</sp>
@@ -2646,7 +2646,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1220">ὦ Πρίαμε καὶ γῆ Τρῳάς, &lt;ὡς&gt; ἔρρεις μάτην.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>κἀγὼ μετέσχον Πριαμίδαις δυσπραξίας.</l>
 				</sp>
@@ -2654,7 +2654,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>πόσιν δ’ ἄθαπτον ἔλιπεν ἢ κρύπτει χθονί; </l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἄθαπτον· οἲ ἐγὼ τῶν ἐμῶν τλήμων κακῶν.</l>
 				</sp>
@@ -2662,7 +2662,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>τῶνδ’ οὕνεκ’ ἔταμες βοστρύχους ξανθῆς κόμης·</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="1225">φίλος γάρ ἐστιν, ὅς ποτ’ ἐστίν, ἐνθάδ’ ὤν.</l>
 				</sp>
@@ -2670,7 +2670,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>ὀρθῶς μὲν ἥδε συμφορὰ δακρύεται — </l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἐν εὐμαρεῖ γοῦν σὴν κασιγνήτην λαθεῖν.</l>
 				</sp>
@@ -2678,7 +2678,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>οὐ δῆτα. πῶς οὖν; τόνδ’ ἔτ’ οἰκήσεις τάφον;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>τί κερτομεῖς με, τὸν θανόντα δ’ οὐκ ἐᾷς;</l>
 				</sp>
@@ -2686,7 +2686,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1230">πιστὴ γὰρ εἶ σὺ σῷ πόσει φεύγουσά με.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἀλλ’ οὐκέτ’· ἤδη δ’ ἄρχε τῶν ἐμῶν γάμων.</l>
 				</sp>
@@ -2694,7 +2694,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>χρόνια μὲν ἦλθεν, ἀλλ’ ὅμως αἰνῶ τάδε.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οἶσθ’ οὖν ὃ δρᾶσον; τῶν πάρος λαθώμεθα.</l>
 				</sp>
@@ -2702,7 +2702,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>ἐπὶ τῷ; χάρις γὰρ ἀντὶ χάριτος ἐλθέτω.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="1235">σπονδὰς τέμωμεν καὶ διαλλάχθητί μοι.</l>
 				</sp>
@@ -2710,7 +2710,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>μεθίημι νεῖκος τὸ σόν, ἴτω δ’ ὑπόπτερον.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>πρός νύν σε γονάτων τῶνδ’, ἐπείπερ εἶ φίλος — </l>
 				</sp>
@@ -2718,7 +2718,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>τί χρῆμα θηρῶσ’ ἱκέτις ὠρέχθης ἐμοῦ;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>τὸν κατθανόντα πόσιν ἐμὸν θάψαι θέλω.</l>
 				</sp>
@@ -2726,7 +2726,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1240">τί δ’; ἔστ’ ἀπόντων τύμβος; ἢ θάψεις σκιάν;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>Ἕλλησίν ἐστι νόμος, ὃς ἂν πόντῳ θάνῃ — </l>
 				</sp>
@@ -2734,7 +2734,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>τί δρᾶν; σοφοί τοι Πελοπίδαι τὰ τοιάδε.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>κενοῖσι θάπτειν ἐν πέπλων ὑφάσμασιν.</l>
 				</sp>
@@ -2742,7 +2742,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>κτέριζ’· ἀνίστη τύμβον οὗ χρῄζεις χθονός.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="1245">οὐχ ὧδε ναύτας ὀλομένους τυμβεύομεν.</l>
 				</sp>
@@ -2750,7 +2750,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>πῶς δαί; λέλειμμαι τῶν ἐν Ἕλλησιν νόμων.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἐς πόντον ὅσα χρὴ νέκυσιν ἐξορμίζομεν.</l>
 				</sp>
@@ -2758,7 +2758,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>τί σοι παράσχω δῆτα τῷ τεθνηκότι;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ὅδ’ οἶδ’, ἐγὼ δ’ ἄπειρος, εὐτυχοῦσα πρίν. </l>
 					<milestone ed="p" n="1250" unit="card"/>
@@ -2897,7 +2897,7 @@ convert to P3
 					<l n="1293">παύσω ψόγου σε τοῦ πρίν, ἢν γυνὴ γένῃ</l>
 					<l n="1292">οἵαν γενέσθαι χρή σε σῷ ξυνευνέτῃ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="1294">ἔσται τάδ’· οὐδὲ μέμψεται πόσις ποτὲ</l>
 					<l n="1295">ἡμῖν· σὺ δ’ αὐτὸς ἐγγὺς ὢν εἴσῃ τάδε.</l>
@@ -2911,7 +2911,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ὀρεία ποτὲ δρομάδι κώ‐</l>
 						<l>λῳ μάτηρ θεῶν ἐσύθη ἀν’</l>
@@ -2936,7 +2936,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δρομαῖον δ’ ὅτε πολυπλάνη‐</l>
 						<l n="1320">τον μάτηρ ἔπαυσε πόνον,</l>
@@ -2961,7 +2961,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεὶ δ’ ἔπαυσ’ εἰλαπίνας</l>
 						<l>θεοῖς βροτείῳ τε γένει,</l>
@@ -2983,7 +2983,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὧν οὐ θέμις &lt;σ’&gt; οὔθ’ ὁσία</l>
 						<l>’πύρωσας ἐν &lt;θεῶν&gt; θαλάμοις,</l>
@@ -3006,7 +3006,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>τὰ μὲν κατ’ οἴκους εὐτυχοῦμεν, ὦ φίλαι·</l>
 					<l n="1370">ἡ γὰρ συνεκκλέπτουσα Πρωτέως κόρη</l>
@@ -3047,7 +3047,7 @@ convert to P3
 					<l>τοῦ πρόσθεν ἀνδρὸς χάρισιν ἐκπεπληγμένην·</l>
 					<l>ἄγαν γὰρ αὐτὸν οὐ παρόνθ’ ὅμως στένεις.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ὦ καινὸς ἡμῖν πόσις, ἀναγκαίως ἔχει</l>
 					<l n="1400">τὰ πρῶτα λέκτρα νυμφικάς θ’ ὁμιλίας</l>
@@ -3069,7 +3069,7 @@ convert to P3
 					<l>χώρει σὺ καὶ ναῦν τοῖσδε πεντηκόντορον</l>
 					<l>Σιδωνίαν δὸς κἀρετμῶν ἐπιστάτας.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οὔκουν ὅδ’ ἄρξει ναὸς ὃς κοσμεῖ τάφον;</l>
 				</sp>
@@ -3077,7 +3077,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1415">μάλιστ’· ἀκούειν τοῦδε χρὴ ναύτας ἐμούς.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>αὖθις κέλευσον, ἵνα σαφῶς μάθωσί σου.</l>
 				</sp>
@@ -3085,7 +3085,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>αὖθις κελεύω καὶ τρίτον γ’, εἴ σοι φίλον.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ὄναιο· κἀγὼ τῶν ἐμῶν βουλευμάτων.</l>
 				</sp>
@@ -3093,7 +3093,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>μή νυν ἄγαν σὸν δάκρυσιν ἐκτήξῃς χρόα.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="1420">ἥδ’ ἡμέρα σοι τὴν ἐμὴν δείξει χάριν.</l>
 				</sp>
@@ -3101,7 +3101,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>τὰ τῶν θανόντων οὐδέν, ἀλλ’ ἄλλως πόνος.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἔστιν τι κἀκεῖ κἀνθάδ’ ὧν ἐγὼ λέγω.</l>
 				</sp>
@@ -3109,7 +3109,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>οὐδὲν κακίω Μενέλεώ μ’ ἕξεις πόσιν.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οὐδὲν σὺ μεμπτός· τῆς τύχης με δεῖ μόνον.</l>
 				</sp>
@@ -3117,7 +3117,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l n="1425">ἐν σοὶ τόδ’, ἢν σὴν εἰς ἔμ’ εὔνοιαν διδῷς.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>οὐ νῦν διδαξόμεσθα τοὺς φίλους φιλεῖν.</l>
 				</sp>
@@ -3125,7 +3125,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>βούλῃ ξυνεργῶν αὐτὸς ἐκπέμψω στόλον;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἥκιστα· μὴ δούλευε σοῖς δούλοις, ἄναξ. </l>
 				</sp>
@@ -3161,7 +3161,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Φοίνισσα Σιδωνιὰς ὦ</l>
 						<l>ταχεῖα κώπα, ῥοθίοισι μάτηρ</l>
@@ -3181,7 +3181,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1465">ἦ που κόρας ἂν ποταμοῦ</l>
 						<l>παρ’ οἶδμα Λευκιππίδας ἢ πρὸ ναοῦ</l>
@@ -3201,7 +3201,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δῑ ἀέρος εἴθε ποτανοὶ</l>
 						<l>γενοίμεσθ’ ᾇ Λιβύας </l>
@@ -3223,7 +3223,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1495">μόλοιτέ ποθ’ ἵππιον οἶμον</l>
 						<l>δῑ αἰθέρος ἱέμενοι</l>
@@ -3246,7 +3246,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>† ἄναξ, τὰ κάκιστ’ ἐν δόμοις εὑρήκαμεν· †</l>
 					<l>ὡς καίν’ ἀκούσῃ πήματ’ ἐξ ἐμοῦ τάχα.</l>
@@ -3255,7 +3255,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>τί δ’ ἔστιν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἄλλης ἐκπόνει μνηστεύματα</l>
 					<l n="1515">γυναικός· Ἑλένη γὰρ βέβηκ’ ἔξω χθονός.</l>
@@ -3264,7 +3264,7 @@ convert to P3
 					<speaker>Θεοκλύμενος</speaker>
 					<l>πτεροῖσιν ἀρθεῖσ’ ἢ πεδοστιβεῖ ποδί;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>Μενέλαος αὐτὴν ἐκπεπόρθμευται χθονός,</l>
 					<l>ὃς αὐτὸς αὑτὸν ἦλθεν ἀγγέλλων θανεῖν.</l>
@@ -3274,7 +3274,7 @@ convert to P3
 					<l>ὦ δεινὰ λέξας· τίς δέ νιν ναυκληρία</l>
 					<l n="1520">ἐκ τῆσδ’ ἀπῆρε χθονός; ἄπιστα γὰρ λέγεις.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἥν γε ξένῳ δίδως σύ· τούς τε σοὺς ἔχων</l>
 					<l>ναύτας βέβηκεν, ὡς ἂν ἐν βραχεῖ μάθῃς.</l>
@@ -3285,7 +3285,7 @@ convert to P3
 					<l>ἔσω βέβηκα μίαν ὑπερδραμεῖν χέρα</l>
 					<l n="1525">τοσούσδε ναύτας, ὧν ἀπεστάλης μέτα.</l>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐπεὶ λιποῦσα τούσδε βασιλείους δόμους</l>
 					<l>ἡ τοῦ Διὸς παῖς πρὸς θάλασσαν ἐστάλη</l>
@@ -3398,7 +3398,7 @@ convert to P3
 					<l>τάδ’ ἀγγελοῦντα. σώφρονος δ’ ἀπιστίας</l>
 					<l>οὐκ ἔστιν οὐδὲν χρησιμώτερον βροτοῖς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ ἄν ποτ’ ηὔχουν οὔτε σ’ οὔθ’ ἡμᾶς λαθεῖν</l>
 					<l n="1620">Μενέλαον, ὦναξ, ὡς ἐλάνθανεν παρών.</l>
@@ -3578,7 +3578,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλαὶ μορφαὶ τῶν δαιμονίων,</l>
 						<l>πολλὰ δ’ ἀέλπτως κραίνουσι θεοί·</l>

--- a/tei/euripides-heracles.xml
+++ b/tei/euripides-heracles.xml
@@ -54,22 +54,22 @@
 					<person xml:id="lyssa">
 						<persName>Λύσσα</persName>
 					</person>
-					<person xml:id="theseys">
+					<person xml:id="theseus">
 						<persName>Θησεύς</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<person xml:id="amfitryon">
+					<person xml:id="amphitryon">
 						<persName>Ἀμφιτρύων</persName>
 					</person>
-					<person xml:id="erakles">
+					<person xml:id="herakles">
 						<persName>Ἡρακλῆς</persName>
 					</person>
 					<person xml:id="megara">
 						<persName>Μεγάρα</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="lykos">
@@ -166,7 +166,7 @@ convert to P3
 		<body>
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp n="Ἀμφιτρύων" who="#amfitryon">
+				<sp n="Ἀμφιτρύων" who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>Τίς τὸν Διὸς σύλλεκτρον οὐκ οἶδεν βροτῶν,</l>
 					<l>Ἀργεῖον Ἀμφιτρύων’, ὃν Ἀλκαῖός ποτε</l>
@@ -260,7 +260,7 @@ convert to P3
 					<l n="85">ἔτ’ εἰσὶν ἡμῖν. ἥντιν’ οὖν γνώμην ἔχεις</l>
 					<l>λέγ’ ἐς τὸ κοινόν, μὴ θανεῖν ἕτοιμον ᾖ.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l n="88">ὦ θύγατερ, οὔτοι ῥᾴδιον τὰ τοιάδε</l>
 					<l>φαύλως παραινεῖν, σπουδάσαντ’ ἄνευ πόνου·</l>
@@ -270,7 +270,7 @@ convert to P3
 					<speaker>Μεγάρα</speaker>
 					<l n="90">λύπης τι προσδεῖς ἢ φιλεῖς οὕτω φάος;</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>καὶ τῷδε χαίρω καὶ φιλῶ τὰς ἐλπίδας.</l>
 				</sp>
@@ -278,7 +278,7 @@ convert to P3
 					<speaker>Μεγάρα</speaker>
 					<l>κἀγώ· δοκεῖν δὲ τἀδόκητ’ οὐ χρή, γέρον.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>ἐν ταῖς ἀναβολαῖς τῶν κακῶν ἔνεστ’ ἄκη.</l>
 				</sp>
@@ -286,7 +286,7 @@ convert to P3
 					<speaker>Μεγάρα</speaker>
 					<l>ὁ δ’ ἐν μέσῳ με λυπρὸς ὢν δάκνει χρόνος.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l n="95">ἔτ’ ἂν γένοιτ’, ὦ θύγατερ, οὔριος δρόμος</l>
 					<l>ἐκ τῶν παρόντων τῶνδ’ ἐμοὶ καὶ σοὶ κακῶν,</l>
@@ -305,7 +305,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὑπώροφα μέλαθρα καὶ</l>
 						<l>γεραιὰ δέμνῑ, ἀμφὶ βάκτροις</l>
@@ -323,7 +323,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μὴ προκάμητε πόδα βαρύ τε</l>
 						<l n="120">κῶλον ὥστε πρὸς πετραῖον</l>
@@ -341,7 +341,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="130">ἴδετε, πατέρος ὡς γορ‐</l>
 						<l>γῶπες αἵδε προσφερεῖς</l>
@@ -356,7 +356,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εἰσορῶ γὰρ τῆσδε κοίρανον χθονὸς</l>
 					<l>Λύκον περῶντα τῶνδε δωμάτων πέλας.</l>
@@ -395,7 +395,7 @@ convert to P3
 					<l>χρῄζω λιπέσθαι τῶν δεδραμένων δίκην.</l>
 				</sp>
 				<milestone ed="p" n="170" unit="card"/>
-				<sp n="Ἀμφιτρύων" who="#amfitryon">
+				<sp n="Ἀμφιτρύων" who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l n="170">τῷ τοῦ Διὸς μὲν Ζεὺς ἀμυνέτω μέρει</l>
 					<l>παιδός· τὸ δ’ εἰς ἔμ’, Ἡράκλεις, ἐμοὶ μέλει</l>
@@ -466,7 +466,7 @@ convert to P3
 					<l>καθῃμάτωσ’ ἄν, ὥστ’ Ἀτλαντικῶν πέραν</l>
 					<l n="235">φεύγειν ὅρων ἂν δειλίᾳ τοὐμὸν δόρυ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἆρ’ οὐκ ἀφορμὰς τοῖς λόγοισιν ἁγαθοὶ</l>
 					<l>θνητῶν ἔχουσι, κἂν βραδύς τις ᾖ λέγειν;</l>
@@ -489,7 +489,7 @@ convert to P3
 					<l>δοῦλοι γεγῶτες τῆς ἐμῆς τυραννίδος.</l>
 					<milestone ed="p" n="252" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l> — ὦ γῆς λοχεύμαθ’, οὓς Ἄρης σπείρει ποτὲ</l>
 					<l>λάβρον δράκοντος ἐξερημώσας γένυν,</l>
@@ -556,7 +556,7 @@ convert to P3
 					<l n="310">πρόθυμός ἐστιν, ἡ προθυμία δ’ ἄφρων·</l>
 					<l>ὃ χρὴ γὰρ οὐδεὶς μὴ χρεὼν θήσει ποτέ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἰ μὲν σθενόντων τῶν ἐμῶν βραχιόνων</l>
 					<l>ἦν τίς σ’ ὑβρίζων, ῥᾳδίως ἐπαύσατ’ ἄν·</l>
@@ -564,7 +564,7 @@ convert to P3
 					<l n="315">ὅπως διώσῃ τὰς τύχας, Ἀμφιτρύων.</l>
 					<milestone ed="p" n="316" unit="card"/>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>οὔτοι τὸ δειλὸν οὐδὲ τοῦ βίου πόθος</l>
 					<l>θανεῖν ἐρύκει μ’, ἀλλὰ παιδὶ βούλομαι</l>
@@ -599,7 +599,7 @@ convert to P3
 					<l>πατρῷον ἐς μέλαθρον, οὗ τῆς οὐσίας</l>
 					<l>ἄλλοι κρατοῦσι, τὸ δ’ ὄνομ’ ἔσθ’ ἡμῶν ἔτι.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>ὦ Ζεῦ, μάτην ἄρ’ ὁμόγαμόν σ’ ἐκτησάμην,</l>
 					<l n="340">μάτην δὲ παιδὸς κοινεῶν’ ἐκλῄζομεν·</l>
@@ -615,7 +615,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἲ Λίνον μὲν ἐπ’ εὐτυχεῖ</l>
 						<l>μολπᾷ Φοῖβος ἰαχεῖ</l>
@@ -633,7 +633,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρῶτον μὲν Διὸς ἄλσος</l>
 						<l n="360">ἠρήμωσε λέοντος,</l>
@@ -644,7 +644,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάν τ’ ὀρεινόμον ἀγρίων</l>
 						<l n="365">Κενταύρων ποτὲ γένναν</l>
@@ -662,7 +662,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="375">τάν τε χρυσοκάρανον</l>
 						<l>δόρκαν ποικιλόνωτον</l>
@@ -673,7 +673,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="380">τεθρίππων τ’ ἐπέβα</l>
 						<l>καὶ ψαλίοις ἐδάμασε πώλους</l>
@@ -688,7 +688,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄν τε Πηλιάδ’ ἀκτὰν</l>
 						<l n="390">Ἀναύρου παρὰ πηγὰς</l>
@@ -699,7 +699,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὑμνῳδούς τε κόρας</l>
 						<l n="395">ἤλυθεν ἑσπέριον ἐς αὐλάν,</l>
@@ -714,7 +714,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐρανοῦ θ’ ὑπὸ μέσσαν</l>
 						<l>ἐλαύνει χέρας ἕδραν,</l>
@@ -725,7 +725,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν ἱππευτάν τ’ Ἀμαζό‐</l>
 						<l>νων στρατὸν Μαιῶτιν ἀμφὶ</l>
@@ -743,7 +743,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάν τε μυριόκρανον</l>
 						<l n="420">πολύφονον κύνα Λέρνας</l>
@@ -755,7 +755,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="425">δρόμων τ’ ἄλλων ἀγάλματ’</l>
 						<l>εὐτυχῆ διῆλθε· τόν τε</l>
@@ -773,7 +773,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="ephymnion">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δ’ ἐγὼ σθένος ἥβων</l>
 						<l>δόρυ τ’ ἔπαλλον ἐν αἰχμᾷ,</l>
@@ -787,7 +787,7 @@ convert to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἐσορῶ γὰρ τούσδε φθιμένων</l>
 						<l>ἔνδυτ’ ἔχοντας, τοὺς τοῦ μεγάλου</l>
@@ -850,7 +850,7 @@ convert to P3
 						<l>κακοὶ γάρ εἰσιν οἳ τέκνα κτείνουσι σά.</l>
 						<milestone ed="p" n="497" unit="card"/>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>σὺ μὲν τὰ νέρθεν εὐτρεπῆ ποιοῦ, γύναι·</l>
 						<l>ἐγὼ δὲ σέ, ὦ Ζεῦ, χεῖρ’ ἐς οὐρανὸν δικὼν</l>
@@ -875,7 +875,7 @@ convert to P3
 						<l>ἔα·</l>
 						<l>ὦ πρέσβυ, λεύσσω τἀμὰ φίλτατ’· ἢ τί φῶ;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="515">οὐκ οἶδα, θύγατερ· ἀφασία δὲ κἄμ’ ἔχει.</l>
 					</sp>
@@ -889,7 +889,7 @@ convert to P3
 						<l>ἴτ’ ἐγκονεῖτε, μὴ μεθῆτ’, ἐπεὶ Διὸς</l>
 						<l>σωτῆρος ὑμῖν οὐδέν ἐσθ’ ὅδ’ ὕστερος.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ὦ χαῖρε, μέλαθρον πρόπυλά θ’ ἑστίας ἐμῆς,</l>
 						<l>ὡς ἄσμενός σ’ ἐσεῖδον ἐς φάος μολών.</l>
@@ -904,7 +904,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>ὦ φίλτατ’ ἀνδρῶν . . .</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">ὦ φάος μολὼν πατρί . . .</l>
 					</sp>
@@ -912,7 +912,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>ἥκεις, ἐσώθης εἰς ἀκμὴν ἐλθὼν φίλοις;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί φῄς; τίν’ ἐς ταραγμὸν ἥκομεν, πάτερ;</l>
 						<milestone ed="p" n="534" unit="card"/>
@@ -924,7 +924,7 @@ convert to P3
 						<l>τὸ θῆλυ γάρ πως μᾶλλον οἰκτρὸν ἀρσένων,</l>
 						<l>καὶ τἄμ’ ἔθνῃσκε τέκν’, ἀπωλλύμην δ’ ἐγώ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>Ἄπολλον, οἵοις φροιμίοις ἄρχῃ λόγου.</l>
 					</sp>
@@ -932,7 +932,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>τεθνᾶσ’ ἀδελφοὶ καὶ πατὴρ οὑμὸς γέρων.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="540">πῶς φῄς; τί δράσας ἢ δορὸς ποίου τυχών;</l>
 					</sp>
@@ -940,7 +940,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>Λύκος σφ’ ὁ καινὸς γῆς ἄναξ διώλεσεν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ὅπλοις ἀπαντῶν ἢ νοσησάσης χθονός;</l>
 					</sp>
@@ -948,7 +948,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>στάσει· τὸ Κάδμου δ’ ἑπτάπυλον ἔχει κράτος.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί δῆτα πρὸς σὲ καὶ γέροντ’ ἦλθεν φόβος;</l>
 					</sp>
@@ -956,7 +956,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l n="545">κτείνειν ἔμελλε πατέρα κἀμὲ καὶ τέκνα.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί φῄς; τί ταρβῶν ὀρφάνευμ’ ἐμῶν τέκνων;</l>
 					</sp>
@@ -964,7 +964,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>μή ποτε Κρέοντος θάνατον ἐκτεισαίατο.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>κόσμος δὲ παίδων τίς ὅδε νερτέροις πρέπων;</l>
 					</sp>
@@ -972,7 +972,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>θανάτου τάδ’ ἤδη περιβόλαῑ ἀνήμμεθα.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="550">καὶ πρὸς βίαν ἐθνῄσκετ’; ὦ τλήμων ἐγώ.</l>
 					</sp>
@@ -980,7 +980,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>φίλων &lt;γ’&gt; ἔρημοι· σὲ δὲ θανόντ’ ἠκούομεν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>πόθεν δ’ ἐς ὑμᾶς ἥδ’ ἐσῆλθ’ ἀθυμία;</l>
 					</sp>
@@ -988,7 +988,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>Εὐρυσθέως κήρυκες ἤγγελλον τάδε.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί δ’ ἐξελείπετ’ οἶκον ἑστίαν τ’ ἐμήν;</l>
 					</sp>
@@ -996,7 +996,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l n="555">βίᾳ, πατὴρ μὲν ἐκπεσὼν στρωτοῦ λέχους . . .</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>κοὐκ ἔσχεν αἰδῶ τὸν γέροντ’ ἀτιμάσαι;</l>
 					</sp>
@@ -1004,7 +1004,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>αἰδώς γ’ ἀποικεῖ τῆσδε τῆς θεοῦ πρόσω.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οὕτω δ’ ἀπόντες ἐσπανίζομεν φίλων;</l>
 					</sp>
@@ -1012,7 +1012,7 @@ convert to P3
 						<speaker>Μεγάρα</speaker>
 						<l>φίλοι γάρ εἰσιν ἀνδρὶ δυστυχεῖ τίνες;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="560">μάχας δὲ Μινυῶν ἃς ἔτλην ἀπέπτυσαν;</l>
 					</sp>
@@ -1021,7 +1021,7 @@ convert to P3
 						<l>ἄφιλον, ἵν’ αὖθίς σοι λέγω, τὸ δυστυχές.</l>
 						<milestone ed="p" n="562" unit="card"/>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οὐ ῥίψεθ’ Ἅιδου τάσδε περιβολὰς κόμης</l>
 						<l>καὶ φῶς ἀναβλέψεσθε, τοῦ κάτω σκότου</l>
@@ -1045,21 +1045,21 @@ convert to P3
 						<l>οὐκ ἐκπονήσω θάνατον; οὐκ ἄρ’ Ἡρακλῆς</l>
 						<l>ὁ καλλίνικος ὡς πάροιθε λέξομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δίκαια τοὺς τεκόντας ὠφελεῖν τέκνα,</l>
 						<l>πατέρα τε πρέσβυν τήν τε κοινωνὸν γάμων.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="585">πρὸς σοῦ μέν, ὦ παῖ, τοῖς φίλοις &lt;τ’&gt; εἶναι φίλον</l>
 						<l>τά τ’ ἐχθρὰ μισεῖν· ἀλλὰ μὴ ’πείγου λίαν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί δ’ ἐστὶ τῶνδε θᾶσσον ἢ χρεών, πάτερ;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>πολλοὺς πένητας, ὀλβίους δὲ τῷ λόγῳ</l>
 						<l>δοκοῦντας εἶναι συμμάχους ἄναξ ἔχει,</l>
@@ -1069,7 +1069,7 @@ convert to P3
 						<l>ὤφθης ἐσελθὼν πόλιν· ἐπεὶ δ’ ὤφθης, ὅρα</l>
 						<l>ἐχθροὺς ἀθροίσας μὴ παρὰ γνώμην πέσῃς.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="595">μέλει μὲν οὐδὲν εἴ με πᾶσ’ εἶδεν πόλις·</l>
 						<l>ὄρνιν δ’ ἰδών τιν’ οὐκ ἐν αἰσίοις ἕδραις,</l>
@@ -1077,7 +1077,7 @@ convert to P3
 						<l>ὥστ’ ἐκ προνοίας κρύφιος εἰσῆλθον χθόνα.</l>
 						<milestone ed="p" n="599" unit="card"/>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>καλῶς· παρελθὼν νῦν πρόσειπέ θ’ ἑστίαν</l>
 						<l n="600">καὶ δὸς πατρῴοις δώμασιν σὸν ὄμμ’ ἰδεῖν.</l>
@@ -1087,58 +1087,58 @@ convert to P3
 						<l>τῇ τ’ ἀσφαλείᾳ κερδανεῖς· πόλιν δὲ σὴν</l>
 						<l n="605">μὴ πρὶν ταράξῃς πρὶν τόδ’ εὖ θέσθαι, τέκνον.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>δράσω τάδ’· εὖ γὰρ εἶπας· εἶμ’ ἔσω δόμων.</l>
 						<l>χρόνῳ δ’ ἀνελθὼν ἐξ ἀνηλίων μυχῶν</l>
 						<l>Ἅιδου Κόρης &lt;τ’&gt; ἔνερθεν, οὐκ ἀτιμάσω</l>
 						<l>θεοὺς προσειπεῖν πρῶτα τοὺς κατὰ στέγας.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="610">ἦλθες γὰρ ὄντως δώματ’ εἰς Ἅιδου, τέκνον;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>καὶ θῆρά γ’ ἐς φῶς τὸν τρίκρανον ἤγαγον.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>μάχῃ κρατήσας ἢ θεᾶς δωρήμασιν;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>μάχῃ· τὰ μυστῶν δ’ ὄργῑ εὐτύχησ’ ἰδών.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἦ καὶ κατ’ οἴκους ἐστὶν Εὐρυσθέως ὁ θήρ;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="615">Χθονίας νιν ἄλσος Ἑρμιών τ’ ἔχει πόλις.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>οὐδ’ οἶδεν Εὐρυσθεύς σε γῆς ἥκοντ’ ἄνω;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οὐκ οἶδ’· ἵν’ ἐλθὼν τἀνθάδ’ εἰδείην πάρος.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>χρόνον δὲ πῶς τοσοῦτον ἦσθ’ ὑπὸ χθονί;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>Θησέα κομίζων ἐχρόνισ’ &lt;ἐξ&gt; Ἅιδου, πάτερ.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="620">καὶ ποῦ ’στιν; ἢ γῆς πατρίδος οἴχεται πέδον;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>βέβηκ’ Ἀθήνας νέρθεν ἄσμενος φυγών.</l>
 						<l>ἀλλ’ εἶ’, ὁμαρτεῖτ’, ὦ τέκν’, ἐς δόμους πατρί·</l>
@@ -1163,7 +1163,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἁ νεότας μοι φίλον αἰ‐</l>
 						<l>εί· τὸ δὲ γῆρας ἄχθος</l>
@@ -1186,7 +1186,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="655">εἰ δὲ θεοῖς ἦν ξύνεσις</l>
 						<l>καὶ σοφία κατ’ ἄνδρας,</l>
@@ -1209,7 +1209,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐ παύσομαι τὰς Χάριτας</l>
 						<l>Μούσαις συγκαταμειγνύς,</l>
@@ -1229,7 +1229,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παιᾶνα μὲν Δηλιάδες</l>
 						<l>ὑμνοῦσ’ ἀμφὶ πύλας τὸν</l>
@@ -1259,7 +1259,7 @@ convert to P3
 					<l n="705">ἔξω κέλευε τῶνδε φαίνεσθαι δόμων,</l>
 					<l>ἐφ’ οἷς ὑπέστητ’ αὐτεπάγγελτοι θανεῖν.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>ἄναξ, διώκεις μ’ ἀθλίως πεπραγότα</l>
 					<l>ὕβριν θ’ ὑβρίζεις ἐπὶ θανοῦσι τοῖς ἐμοῖς·</l>
@@ -1271,7 +1271,7 @@ convert to P3
 					<speaker>Λύκος</speaker>
 					<l>ποῦ δῆτα Μεγάρα; ποῦ τέκν’ Ἀλκμήνης γόνου;</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>δοκῶ μὲν αὐτήν, ὡς θύραθεν εἰκάσαι — </l>
 				</sp>
@@ -1279,7 +1279,7 @@ convert to P3
 					<speaker>Λύκος</speaker>
 					<l>τί χρῆμα δόξης; τοῦ δ’ ἔχεις τεκμήριον;</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l n="715">ἱκέτιν πρὸς ἁγνοῖς Ἑστίας θάσσειν βάθροις . . .</l>
 				</sp>
@@ -1287,7 +1287,7 @@ convert to P3
 					<speaker>Λύκος</speaker>
 					<l>ἀνόνητά γ’ ἱκετεύουσαν ἐκσῷσαι βίον.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>καὶ τὸν θανόντα γ’ ἀνακαλεῖν μάτην πόσιν.</l>
 				</sp>
@@ -1295,7 +1295,7 @@ convert to P3
 					<speaker>Λύκος</speaker>
 					<l>ὃ δ’ οὐ πάρεστιν οὐδὲ μὴ μόλῃ ποτέ.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>οὔκ, εἴ γε μή τις θεῶν ἀναστήσειέ νιν.</l>
 				</sp>
@@ -1303,7 +1303,7 @@ convert to P3
 					<speaker>Λύκος</speaker>
 					<l n="720">χώρει πρὸς αὐτὴν κἀκκόμιζε δωμάτων.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>μέτοχος ἂν εἴην τοῦ φόνου δράσας τόδε.</l>
 				</sp>
@@ -1314,7 +1314,7 @@ convert to P3
 					<l>σὺν μητρὶ παῖδας. δεῦρ’ ἕπεσθε, πρόσπολοι,</l>
 					<l n="725">ὡς ἂν σχολὴν λύσωμεν ἄσμενοι πόνων.</l>
 				</sp>
-				<sp who="#amfitryon">
+				<sp who="#amphitryon">
 					<speaker>Ἀμφιτρύων</speaker>
 					<l>σὺ δ’ οὖν ἴθ’, ἔρχῃ δ’ οἷ χρεών· τὰ δ’ ἄλλ’ ἴσως</l>
 					<l>ἄλλῳ μελήσει. προσδόκα δὲ δρῶν κακῶς</l>
@@ -1329,7 +1329,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="735">μεταβολὰ κακῶν· μέγας ὁ πρόσθ’ ἄναξ</l>
 						<l>πάλιν ὑποστρέφει βίοτον ἐξ Ἅιδα.</l>
@@ -1353,7 +1353,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τόδε κατάρχεται μέλος ἐμοὶ κλύειν</l>
 						<l>φίλιον ἐν δόμοις· θάνατος οὐ πόρσω.</l>
@@ -1365,7 +1365,7 @@ convert to P3
 						<speaker>Λύκος</speaker>
 						<l>ὦ πᾶσα Κάδμου γαῖ’, ἀπόλλυμαι δόλῳ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="755">καὶ γὰρ διώλλυς· ἀντίποινα δ’ ἐκτίνων</l>
 						<l>τόλμα, διδούς γε τῶν δεδραμένων δίκην.</l>
@@ -1381,7 +1381,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χοροὶ χοροὶ</l>
 						<l>καὶ θαλίαι μέλουσι Θή‐</l>
@@ -1397,7 +1397,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θεοὶ θεοὶ</l>
 						<l n="772b">τῶν ἀδίκων μέλουσι καὶ</l>
@@ -1413,7 +1413,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἰσμήν’ ὦ στεφαναφόρει,</l>
 						<l>ξεσταί θ’ ἑπταπύλου πόλεως</l>
@@ -1436,7 +1436,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ λέκτρων δύο συγγενεῖς</l>
 						<l>εὐναί, θνατογενοῦς τε καὶ</l>
@@ -1460,7 +1460,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="815"> — ἔα ἔα·</l>
 					<l>ἆρ’ ἐς τὸν αὐτὸν πίτυλον ἥκομεν φόβου,</l>
@@ -1558,7 +1558,7 @@ convert to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="875">ὀτοτοτοτοτοῖ, στέναξον· ἀποκείρεται</l>
 						<l>σὸν ἄνθος πόλεος, ὁ Διὸς ἔκγονος·</l>
@@ -1575,13 +1575,13 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἰώ μοι μέλεος.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ Ζεῦ, τὸ σὸν γένος ἄγονον αὐτίκα</l>
 						<l>λυσσάδες ὠμοβρῶτες ἄδικοι Ποιναὶ</l>
@@ -1589,39 +1589,39 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἰὼ στέγαι.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κατάρχεται χόρευμα τυμπάνων ἄτερ,</l>
 						<l>οὐ βρομίῳ κεχαρισμένα θύρσῳ . . .</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἰὼ δόμοι.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρὸς αἵματ’, οὐχὶ τᾶς Διονυσιάδος</l>
 						<l n="895">βοτρύων ἐπὶ χεύμασι λοιβᾶς.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>φυγῇ, τέκν’, ἐξορμᾶτε.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">δάιον τόδε</l>
 						<l>δάιον μέλος ἐπαυλεῖται.</l>
@@ -1630,13 +1630,13 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="900">αἰαῖ κακῶν.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ δῆτα τὸν γεραιὸν ὡς στένω</l>
 						<l>πατέρα τάν τε παιδοτρόφον, &lt;ᾇ&gt; μάταν</l>
@@ -1646,7 +1646,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἢ ἤ· τί δρᾷς, ὦ Διὸς παῖ, μελάθρῳ;</l>
 						<l>τάραγμα ταρτάρειον, ὡς ἐπ’ Ἐγκελάδῳ ποτέ, Παλλάς,</l>
@@ -1655,55 +1655,55 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὦ λευκὰ γήρᾳ σώματ’ . . .</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἀνακαλεῖς με τίνα</l>
 						<l n="910">βοάν;</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l part="Y">ἄλαστα τἀν δόμοισι.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">μάντιν οὐχ</l>
 						<l n="912">ἕτερον ἄξομαι.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>τεθνᾶσι παῖδες.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">αἰαῖ.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>στενάζεθ’, ὡς στενακτά.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">δάιοι φόνοι,</l>
 						<l n="915">δάιοι δὲ τοκέων χέρες· ὤ.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>οὐκ ἄν τις εἴποι μᾶλλον ἢ πεπόνθαμεν.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς παισὶ στενακτὰν ἄταν ἄταν</l>
 						<l>πατέρος ἀμφαίνεις;</l>
@@ -1712,7 +1712,7 @@ convert to P3
 						<l>τλήμονάς τε παίδων τύχας;</l>
 						<milestone ed="p" n="922" unit="card"/>
 					</sp>
-					<sp n="Ἄγγελος" who="#aggelos">
+					<sp n="Ἄγγελος" who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ἱερὰ μὲν ἦν πάροιθεν ἐσχάρας Διὸς</l>
 						<l>καθάρσῑ οἴκων, γῆς ἄνακτ’ ἐπεὶ κτανὼν</l>
@@ -1816,7 +1816,7 @@ convert to P3
 			<milestone ed="p" n="1016" unit="card"/>
 			<div1 type="choral">
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ φόνος ἦν ὃν Ἀργολὶς ἔχει πέτρα</l>
 						<l>τότε μὲν περισαμότατος καὶ ἄπιστος Ἑλλάδι</l>
@@ -1844,7 +1844,7 @@ convert to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὁ δ’ ὥς τις ὄρνις ἄπτερον καταστένων</l>
 					<l n="1040">ὠδῖνα τέκνων, πρέσβυς ὑστέρῳ ποδὶ</l>
@@ -1852,7 +1852,7 @@ convert to P3
 					<milestone ed="p" n="1042" unit="card"/>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>Καδμεῖοι γέροντες, οὐ σῖγα σῖ‐</l>
 						<l>γα τὸν ὕπνῳ παρειμένον ἐάσετ’ ἐκ‐</l>
@@ -1860,14 +1860,14 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1045">κατὰ σὲ δακρύοις στένω, πρέσβυ, καὶ</l>
 						<l>τέκεα καὶ τὸ καλλίνικον κάρα.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἑκαστέρω πρόβατε, μὴ</l>
 						<l>κτυπεῖτε, μὴ βοᾶτε, μὴ</l>
@@ -1877,27 +1877,27 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">οἴμοι.</l>
 						<l>φόνος ὅσος ὅδ’ . . .</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">ἆ ἆ,</l>
 						<l>διά μ’ ὀλεῖτε.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">κεχυμένος ἐπαντέλλει.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>οὐκ ἀτρεμαῖα θρῆνον αἰ‐</l>
 						<l>άξετ’, ὦ γέροντες;</l>
@@ -1906,26 +1906,26 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀδύνατ’ ἀδύνατά μοι.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">σῖγα, πνοὰς μάθω·</l>
 						<l n="1060">φέρε πρὸς οὖς βάλω.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">εὕδει;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">ναί, εὕδει</l>
 						<l>ὕπνον γ’ ἄυπνον ὀλόμενον, ὃς ἔκανεν ἄλο‐</l>
@@ -1933,49 +1933,49 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1065">στέναζέ νυν — </l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">στενάζω.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τέκνων ὄλεθρον — </l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">ὤμοι.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σέθεν τε παιδὸς — </l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">αἰαῖ.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πρέσβυ . . .</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">σῖγα σῖγα·</l>
 						<l>παλίντροπος ἐξεγειρόμενος στρέφεται· φέρε,</l>
@@ -1983,13 +1983,13 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θάρσει· νὺξ ἔχει βλέφαρα παιδὶ σῷ.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ὁρᾶθ’ ὁρᾶτε. τὸ φάος ἐκ‐</l>
 						<l>λιπεῖν μὲν ἐπὶ κακοῖσιν οὐ</l>
@@ -1999,7 +1999,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1078">τότε θανεῖν σ’ ἐχρῆν, ὅτε δάμαρτι σᾷ</l>
 						<l>φόνον ὁμοσπόρων ἔμολες ἐκπράξας</l>
@@ -2007,7 +2007,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>φυγὰν φυγάν, γέροντες, ἀποπρὸ δωμάτων</l>
 						<l>διώκετε· φεύγετε μάργον</l>
@@ -2016,12 +2016,12 @@ convert to P3
 						<l n="1085">ἀν’ αὖ βακχεύσει Καδμείων πόλιν.</l>
 						<milestone ed="p" n="1086" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Ζεῦ, τί παῖδ’ ἤχθηρας ὧδ’ ὑπερκότως</l>
 						<l>τὸν σόν, κακῶν δὲ πέλαγος ἐς τόδ’ ἤγαγες;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἔα·</l>
 						<l>ἔμπνους μέν εἰμι καὶ δέδορχ’ ἅπερ με δεῖ,</l>
@@ -2045,153 +2045,153 @@ convert to P3
 						<l>δύσγνοιαν ὅστις τὴν ἐμὴν ἰάσεται;</l>
 						<l>σαφῶς γὰρ οὐδὲν οἶδα τῶν εἰωθότων.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>γέροντες, ἔλθω τῶν ἐμῶν κακῶν πέλας;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1110">κἀγώ γε σὺν σοί, μὴ προδοὺς τὰς συμφοράς.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>πάτερ, τί κλαίεις καὶ συναμπίσχῃ κόρας,</l>
 						<l>τοῦ φιλτάτου σοι τηλόθεν παιδὸς βεβώς;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ὦ τέκνον· εἶ γὰρ καὶ κακῶς πράσσων ἐμός.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>πράσσω δ’ ἐγὼ τί λυπρόν, οὗ δακρυρροεῖς;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1115">ἃ κἂν θεῶν τις, εἰ μάθοι, καταστένοι.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>μέγας γ’ ὁ κόμπος, τὴν τύχην δ’ οὔπω λέγεις.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ὁρᾷς γὰρ αὐτός, εἰ φρονῶν ἤδη κυρεῖς.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>εἴπ’, εἴ τι καινὸν ὑπογράφῃ τὠμῷ βίῳ.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>εἰ μηκέθ’ Ἅιδου βάκχος εἶ, φράσαιμεν ἄν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1120">παπαῖ, τόδ’ ὡς ὕποπτον ᾐνίξω πάλιν.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>καί σ’ εἰ βεβαίως εὖ φρονεῖς ἤδη σκοπῶ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οὐ γάρ τι βακχεύσας γε μέμνημαι φρένας.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>λύσω, γέροντες, δεσμὰ παιδός; ἢ τί δρῶ;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>καὶ τόν γε δήσαντ’ εἴπ’· ἀναινόμεσθα γάρ.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1125">τοσοῦτον ἴσθι τῶν κακῶν· τὰ δ’ ἄλλ’ ἔα.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἀρκεῖ σιωπὴ γὰρ μαθεῖν ὃ βούλομαι;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ὦ Ζεῦ, παρ’ Ἥρας ἆρ’ ὁρᾷς θρόνων τάδε;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἀλλ’ ἦ τι κεῖθεν πολέμιον πεπόνθαμεν;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>τὴν θεὸν ἐάσας τὰ σὰ περιστέλλου κακά.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1130">ἀπωλόμεσθα· συμφορὰν λέξεις τινά.</l>
 						<milestone ed="p" n="1131" unit="card"/>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἰδού, θέασαι τάδε τέκνων πεσήματα.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οἴμοι· τίν’ ὄψιν τήνδε δέρκομαι τάλας;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἀπόλεμον, ὦ παῖ, πόλεμον ἔσπευσας τέκνοις.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί πόλεμον εἶπας; τούσδε τίς διώλεσε;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1135">σὺ καὶ σὰ τόξα καὶ θεῶν ὃς αἴτιος.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί φῄς; τί δράσας; ὦ κάκ’ ἀγγέλλων πάτερ.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>μανείς· ἐρωτᾷς δ’ ἄθλῑ ἑρμηνεύματα.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἦ καὶ δάμαρτός εἰμ’ ἐγὼ φονεὺς ἐμῆς;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>μιᾶς ἅπαντα χειρὸς ἔργα σῆς τάδε.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1140">αἰαῖ· στεναγμῶν γάρ με περιβάλλει νέφος.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>τούτων ἕκατι σὰς καταστένω τύχας.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>† ἦ γὰρ συνήραξ’ οἶκον ἢ βάκχευσ’ ἐμόν; †</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>οὐκ οἶδα πλὴν ἕν· πάντα δυστυχεῖ τὰ σά.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ποῦ δ’ οἶστρος ἡμᾶς ἔλαβε; ποῦ διώλεσεν;</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1145">ὅτ’ ἀμφὶ βωμὸν χεῖρας ἡγνίζου πυρί.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οἴμοι· τί δῆτα φείδομαι ψυχῆς ἐμῆς</l>
 						<l>τῶν φιλτάτων μοι γενόμενος παίδων φονεύς;</l>
@@ -2211,7 +2211,7 @@ convert to P3
 						<l>καὶ τῶνδε προστρόπαιον αἷμα προσλαβὼν</l>
 						<l>οὐδὲν κακῶσαι τοὺς ἀναιτίους θέλω.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἥκω σὺν ἄλλοις, οἳ παρ’ Ἀσωποῦ ῥοὰς</l>
 						<l>μένουσιν, ἔνοπλοι γῆς Ἀθηναίων κόροι,</l>
@@ -2233,105 +2233,105 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ὦ τὸν ἐλαιοφόρον ὄχθον ἔχων &lt;ἄναξ&gt; . . .</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>τί χρῆμά μ’ οἰκτροῖς ἐκάλεσας προοιμίοις;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1180">ἐπάθομεν πάθεα μέλεα πρὸς θεῶν.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>οἱ παῖδες οἵδε τίνες, ἐφ’ οἷς δακρυρροεῖς;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἔτεκε μέν &lt;νιν&gt; οὑμὸς ἶνις τάλας,</l>
 						<l>τεκόμενος δ’ ἔκανε, φόνιον αἷμα τλάς.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>εὔφημα φώνει.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1185">βουλομένοισιν ἐπαγγέλλῃ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ὦ δεινὰ λέξας.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>οἰχόμεθ’ οἰχόμεθα πτανοί.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>τί φῄς; τί δράσας;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>μαινομένῳ πιτύλῳ πλαγχθεὶς</l>
 						<l n="1190">ἑκατογκεφάλου &lt;τε&gt; βαφαῖς ὕδρας.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>Ἥρας ὅδ’ ἁγών· τίς δ’ ὅδ’ οὑν νεκροῖς, γέρον;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἐμὸς ἐμὸς ὅδε γόνος ὁ πολύπονος, &lt;ὃς&gt; ἐπὶ</l>
 						<l>δόρυ γιγαντοφόνον ἦλθεν σὺν θεοῖ‐</l>
 						<l>σι Φλεγραῖον ἐς πεδίον ἀσπιστάς.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="1195">φεῦ φεῦ· τίς ἀνδρῶν ὧδε δυσδαίμων ἔφυ;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>οὐκ ἂν εἰδείης ἕτερον</l>
 						<l>πολυμοχθότερον πολυπλαγκτότερόν</l>
 						<l>τε θνατῶν.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>τί γὰρ πέπλοισιν ἄθλιον κρύπτει κάρα;</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>αἰδόμενος τὸ σὸν ὄμμα</l>
 						<l n="1200">καὶ φιλίαν ὁμόφυλον</l>
 						<l>αἷμά τε παιδοφόνον.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἀλλ’, εἰ συναλγῶν γ’ ἦλθον, ἐκκάλυπτέ νιν.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1204">ὦ τέκνον· πάρες ἀπ’ ὀμμάτων</l>
 						<l n="1205">πέπλον, ἀπόδικε, ῥέθος ἀελίῳ δεῖξον.</l>
@@ -2344,7 +2344,7 @@ convert to P3
 						<l>κακὰ θέλων κακοῖς συνάψαι, τέκνον.</l>
 						<milestone ed="p" n="1214" unit="card"/>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>εἶἑν· σὲ τὸν θάσσοντα δυστήνους ἕδρας</l>
 						<l n="1215">αὐδῶ, φίλοισιν ὄμμα δεικνύναι τὸ σόν.</l>
@@ -2362,112 +2362,112 @@ convert to P3
 						<l>βλέψον πρὸς ἡμᾶς. ὅστις εὐγενὴς βροτῶν,</l>
 						<l>φέρει τά γ’ ἐκ θεῶν πτώματ’ οὐδ’ ἀναίνεται.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>Θησεῦ, δέδορκας τόνδ’ ἀγῶν’ ἐμῶν τέκνων;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="1230">ἤκουσα, καὶ βλέποντι σημαίνεις κακά.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τί δῆτά μου κρᾶτ’ ἀνεκάλυψας ἡλίῳ;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>τί δ’; οὐ μιαίνεις θνητὸς ὢν τὰ τῶν θεῶν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>φεῦγ’, ὦ ταλαίπωρ’, ἀνόσιον μίασμ’ ἐμόν.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>οὐδεὶς ἀλάστωρ τοῖς φίλοις ἐκ τῶν φίλων.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1235">ἐπῄνεσ’· εὖ δράσας δέ σ’ οὐκ ἀναίνομαι.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἐγὼ δὲ πάσχων εὖ τότ’ οἰκτίρω σε νῦν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οἰκτρὸς γάρ εἰμι τἄμ’ ἀποκτείνας τέκνα.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>κλαίω χάριν σὴν ἐφ’ ἑτέραισι συμφοραῖς.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ηὗρες δέ γ’ ἄλλους ἐν κακοῖσι μείζοσιν;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="1240">ἅπτῃ κάτωθεν οὐρανοῦ δυσπραξίᾳ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>τοιγὰρ παρεσκευάσμεθ’ ὥστε κατθανεῖν.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>δοκεῖς ἀπειλῶν σῶν μέλειν τι δαίμοσιν;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>αὔθαδες ὁ θεός, πρὸς δὲ τοὺς θεοὺς ἐγώ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἴσχε στόμ’, ὡς μὴ μέγα λέγων μεῖζον πάθῃς.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1245">γέμω κακῶν δή, κοὐκέτ’ ἔσθ’ ὅπῃ τεθῇ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>δράσεις δὲ δὴ τί; ποῖ φέρῃ θυμούμενος;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>θανών, ὅθενπερ ἦλθον, εἶμι γῆς ὕπο.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>εἴρηκας ἐπιτυχόντος ἀνθρώπου λόγους.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>σὺ δ’ ἐκτὸς ὤν γε συμφορᾶς με νουθετεῖς.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="1250">ὁ πολλὰ δὴ τλὰς Ἡρακλῆς λέγει τάδε;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οὐκ οὖν τοσαῦτά γ’, εἰ μέτρῳ μοχθητέον.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>εὐεργέτης βροτοῖσι καὶ μέγας φίλος;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>οἱ δ’ οὐδὲν ὠφελοῦσί μ’, ἀλλ’ Ἥρα κρατεῖ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>οὐκ ἄν &lt;σ’&gt; ἀνάσχοιθ’ Ἑλλὰς ἀμαθίᾳ θανεῖν.</l>
 						<milestone ed="p" n="1255" unit="card"/>
 					</sp>
-					<sp n="Ἡρακλῆς" who="#erakles">
+					<sp n="Ἡρακλῆς" who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1255">ἄκουε δή νυν, ὡς ἁμιλληθῶ λόγοις</l>
 						<l>πρὸς νουθετήσεις σάς· ἀναπτύξω δέ σοι</l>
@@ -2527,12 +2527,12 @@ convert to P3
 						<l>λέκτρων φθονοῦσα Ζηνὶ τοὺς εὐεργέτας</l>
 						<l n="1310">Ἑλλάδος ἀπώλεσ’ οὐδὲν ὄντας αἰτίους.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἔστιν ἄλλου δαιμόνων ἀγὼν ὅδε</l>
 						<l>ἢ τῆς Διὸς δάμαρτος· εὖ τόδ’ αἰσθάνῃ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>.      .      .      .      .      .      .</l>
 						<l>παραινέσαιμ’ ἂν μᾶλλον ἢ πάσχειν κακῶς.</l>
@@ -2564,7 +2564,7 @@ convert to P3
 						<l>ἅλις γὰρ ὁ θεὸς ὠφελῶν, ὅταν θέλῃ.</l>
 						<milestone ed="p" n="1340" unit="card"/>
 					</sp>
-					<sp n="Ἡρακλῆς" who="#erakles">
+					<sp n="Ἡρακλῆς" who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1340">οἴμοι· πάρεργα &lt;μὲν&gt; τάδ’ ἔστ’ ἐμῶν κακῶν,</l>
 						<l>ἐγὼ δὲ τοὺς θεοὺς οὔτε λέκτρ’ ἃ μὴ θέμις</l>
@@ -2622,137 +2622,137 @@ convert to P3
 						<l>νεκρούς τε κἀμέ· πάντες ἐξολώλαμεν</l>
 						<l>Ἥρας μιᾷ πληγέντες ἄθλιοι τύχῃ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἀνίστασ’, ὦ δύστηνε· δακρύων δ’ ἅλις.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1395">οὐκ ἂν δυναίμην· ἄρθρα γὰρ πέπηγέ μου.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>καὶ τοὺς σθένοντας γὰρ καθαιροῦσιν τύχαι.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>φεῦ·</l>
 						<l>αὐτοῦ γενοίμην πέτρος ἀμνήμων κακῶν.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>παῦσαι· δίδου δὲ χεῖρ’ ὑπηρέτῃ φίλῳ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἀλλ’ αἷμα μὴ σοῖς ἐξομόρξωμαι πέπλοις.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="1400">ἔκμασσε, φείδου μηδέν· οὐκ ἀναίνομαι.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>παίδων στερηθεὶς παῖδ’ ὅπως ἔχω σ’ ἐμόν.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>δίδου δέρῃ σὴν χεῖρ’, ὁδηγήσω δ’ ἐγώ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ζεῦγός γε φίλιον· ἅτερος δὲ δυστυχής.</l>
 						<l>ὦ πρέσβυ, τοιόνδ’ ἄνδρα χρὴ κτᾶσθαι φίλον.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l n="1405">ἡ γὰρ τεκοῦσα τόνδε πατρὶς εὔτεκνος.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>Θησεῦ, πάλιν με στρέψον, ὡς ἴδω τέκνα.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ὡς δὴ τί; φίλτρον τοῦτ’ ἔχων ῥᾴων ἔσῃ;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ποθῶ· πατρός τε στέρνα προσθέσθαι θέλω.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>ἰδοὺ τάδ’, ὦ παῖ· τἀμὰ γὰρ σπεύδεις φίλα.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="1410">οὕτως πόνων σῶν οὐκέτι μνήμην ἔχεις;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἅπαντ’ ἐλάσσω κεῖνα τῶνδ’ ἔτλην κακά.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>εἴ σ’ ὄψεταί τις θῆλυν ὄντ’, οὐκ αἰνέσει.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ζῶ σοι ταπεινός; ἀλλὰ πρόσθεν οὐ δοκῶ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἄγαν γ’· ὁ κλεινὸς Ἡρακλῆς οὐκ εἶ νοσῶν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1415">σὺ ποῖος ἦσθα νέρθεν ἐν κακοῖσιν ὤν;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ὡς ἐς τὸ λῆμα παντὸς ἦν ἥσσων ἀνήρ.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>πῶς οὖν ἔτ’ † εἴπης † ὅτι συνέσταλμαι κακοῖς;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>πρόβαινε.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">χαῖρ’, ὦ πρέσβυ.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">καὶ σύ μοι, τέκνον.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>θάφθ’ ὥσπερ εἶπον παῖδας.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">ἐμὲ δὲ τίς, τέκνον;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l n="1420">ἐγώ.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l part="Y">πότ’ ἐλθών;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">ἡνίκ’ ἂν θάψῃς τέκνα.</l>
 					</sp>
-					<sp who="#amfitryon">
+					<sp who="#amphitryon">
 						<speaker>Ἀμφιτρύων</speaker>
 						<l>πῶς;</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l part="Y">εἰς Ἀθήνας πέμψομαι Θηβῶν ἄπο.</l>
 						<l>ἀλλ’ ἐσκόμιζε τέκνα δυσκόμιστα γῇ·</l>
@@ -2764,7 +2764,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στείχομεν οἰκτροὶ καὶ πολύκλαυτοι,</l>
 						<l>τὰ μέγιστα φίλων ὀλέσαντες.</l>

--- a/tei/euripides-ion.xml
+++ b/tei/euripides-ion.xml
@@ -51,13 +51,13 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="ksoythos">
+					<person xml:id="xouthos">
 						<persName>Ξοῦθος</persName>
 					</person>
 					<person xml:id="ion">
 						<persName>Ἴων</persName>
 					</person>
-					<person xml:id="profetis">
+					<person xml:id="prophetis">
 						<persName>Προφῆτις</persName>
 					</person>
 					<person xml:id="presbytes">
@@ -69,13 +69,13 @@
 					<person xml:id="athena">
 						<persName>Ἀθήνα</persName>
 					</person>
-					<person xml:id="ermes">
+					<person xml:id="hermes">
 						<persName>Ἑρμῆς</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="kreoysa">
+					<person xml:id="kreousa">
 						<persName>Κρέουσα</persName>
 					</person>
 				</listPerson>
@@ -166,7 +166,7 @@ bring up to P3
 		<body>
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp n="Ἑρμῆς" who="#ermes">
+				<sp n="Ἑρμῆς" who="#hermes">
 					<speaker>Ἑρμῆς</speaker>
 					<l>Ἄτλας, ὁ χαλκέοισι † νώτοις οὐρανὸν</l>
 					<l>θεῶν παλαιὸν οἶκον ἐκτρίβων, θεῶν</l>
@@ -393,7 +393,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — οὐκ ἐν ταῖς ζαθέαις Ἀθά‐</l>
 						<l n="185">ναις εὐκίονες ἦσαν αὐ‐</l>
@@ -410,7 +410,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — ὁρῶ. καὶ πέλας ἄλλος αὐ‐</l>
 						<l n="195">τοῦ πανὸν πυρίφλεκτον αἴ‐</l>
@@ -427,7 +427,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="205"> — πάντᾳ τοι βλέφαρον διώ‐</l>
 						<l>κω. σκέψαι κλόνον ἐν τείχες‐</l>
@@ -448,7 +448,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σέ τοι, τὸν παρὰ ναὸν αὐ‐</l>
 						<l n="220">δῶ· θέμις γυάλων ὑπερ‐</l>
@@ -459,7 +459,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>οὐ θέμις, ὦ ξέναι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδ’ ἂν</l>
 						<l>ἐκ σέθεν ἂν πυθοίμεθ’ αὐδάν;</l>
@@ -468,7 +468,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τίνα τήνδε θέλεις;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἆρ’ ὄντως μέσον ὀμφαλὸν</l>
 						<l>γᾶς Φοίβου κατέχει δόμος;</l>
@@ -477,7 +477,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>στέμμασί γ’ ἐνδυτόν, ἀμφὶ δὲ Γοργόνες.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="225">οὕτω καὶ φάτις αὐδᾷ.</l>
 					</sp>
@@ -488,7 +488,7 @@ bring up to P3
 						<l>πάριτ’ ἐς θυμέλας· ἐπὶ δ’ ἀσφάκτοις</l>
 						<l>μήλοισι δόμων μὴ πάριτ’ ἐς μυχόν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="230">ἔχω μαθοῦσα· θεοῦ δὲ νόμον</l>
 						<l>οὐ παραβαίνομεν,</l>
@@ -498,7 +498,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πάντα θεᾶσθ’, ὅ τι καὶ θέμις, ὄμμασι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μεθεῖσαν δεσπόται</l>
 						<l>με θεοῦ γύαλα τάδ’ εἰσιδεῖν.</l>
@@ -507,7 +507,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>δμῳαὶ δὲ τίνων κλῄζεσθε δόμων;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="235">Παλλάδι σύνοικα τρόφιμα μέλα‐</l>
 						<l n="235b">θρα τῶν ἐμῶν τυράννων·</l>
@@ -531,7 +531,7 @@ bring up to P3
 					<l n="245">ὃ πάντες ἄλλοι γύαλα λεύσσοντες θεοῦ</l>
 					<l>χαίρουσιν, ἐνταῦθ’ ὄμμα σὸν δακρυρροεῖ;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ὦ ξένε, τὸ μὲν σὸν οὐκ ἀπαιδεύτως ἔχει</l>
 					<l>ἐς θαύματ’ ἐλθεῖν δακρύων ἐμῶν πέρι·</l>
@@ -546,7 +546,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="255">τί χρῆμ’ ἀνερμήνευτα δυσθυμῇ, γύναι;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὐδέν· μεθῆκα τόξα· τἀπὶ τῷδε δὲ</l>
 					<l>ἐγώ τε σιγῶ, καὶ σὺ μὴ φρόντιζ’ ἔτι.</l>
@@ -556,7 +556,7 @@ bring up to P3
 					<l>τίς δ’ εἶ; πόθεν γῆς ἦλθες; ἐκ ποίας πάτρας</l>
 					<l>πέφυκας; ὄνομα τί σε καλεῖν ἡμᾶς χρεών;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="260">Κρέουσα μέν μοι τοὔνομ’, ἐκ δ’ Ἐρεχθέως</l>
 					<l>πέφυκα, πατρὶς γῆ δ’ Ἀθηναίων πόλις.</l>
@@ -566,7 +566,7 @@ bring up to P3
 					<l>ὦ κλεινὸν οἰκοῦσ’ ἄστυ γενναίων τ’ ἄπο</l>
 					<l>τραφεῖσα πατέρων, ὥς σε θαυμάζω, γύναι.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τοσαῦτα κεὐτυχοῦμεν, ὦ ξέν’, οὐ πέρα.</l>
 				</sp>
@@ -574,7 +574,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="265">πρὸς θεῶν ἀληθῶς, ὡς μεμύθευται βροτοῖς . . .;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τί χρῆμ’ ἐρωτᾷς, ὦ ξέν’, ἐκμαθεῖν θέλων;</l>
 				</sp>
@@ -582,7 +582,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ἐκ γῆς πατρός σου πρόγονος ἔβλαστεν πατήρ;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>Ἐριχθόνιός γε· τὸ δὲ γένος μ’ οὐκ ὠφελεῖ.</l>
 				</sp>
@@ -590,7 +590,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ἦ καί σφ’ Ἀθάνα γῆθεν ἐξανείλετο;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="270">ἐς παρθένους γε χεῖρας, οὐ τεκοῦσά νιν.</l>
 				</sp>
@@ -598,7 +598,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>δίδωσι δ’, ὥσπερ ἐν γραφῇ νομίζεται . . .;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>Κέκροπός γε σῴζειν παισὶν οὐχ ὁρώμενον.</l>
 				</sp>
@@ -606,7 +606,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ἤκουσα λῦσαι παρθένους τεῦχος θεᾶς.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τοιγὰρ θανοῦσαι σκόπελον ᾕμαξαν πέτρας.</l>
 					<milestone ed="p" n="275" unit="card"/>
@@ -616,7 +616,7 @@ bring up to P3
 					<l n="275">εἶἑν·</l>
 					<l>τί δαὶ τόδ’; ἆρ’ ἀληθὲς ἢ μάτην λόγος . . .</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τί χρῆμ’ ἐρωτᾷς; καὶ γὰρ οὐ κάμνω σχολῇ.</l>
 				</sp>
@@ -624,7 +624,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>πατὴρ Ἐρεχθεὺς σὰς ἔθυσε συγγόνους;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἔτλη πρὸ γαίας σφάγια παρθένους κτανεῖν.</l>
 				</sp>
@@ -632,7 +632,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>σὺ δ’ ἐξεσώθης πῶς κασιγνήτων μόνη;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="280">βρέφος νεογνὸν μητρὸς ἦν ἐν ἀγκάλαις.</l>
 				</sp>
@@ -640,7 +640,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>πατέρα δ’ ἀληθῶς χάσμα σὸν κρύπτει χθονός;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>πληγαὶ τριαίνης ποντίου σφ’ ἀπώλεσαν.</l>
 				</sp>
@@ -648,7 +648,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>Μακραὶ δὲ χῶρός ἐστ’ ἐκεῖ κεκλημένος;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τί δ’ ἱστορεῖς τόδ’; ὥς μ’ ἀνέμνησάς τινος.</l>
 				</sp>
@@ -656,7 +656,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="285">τιμᾷ σφε Πύθιος ἀστραπαί τε Πύθιαι.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>† τιμᾶ τιμᾶ †· ὡς μήποτ’ ὤφελόν σφ’ ἰδεῖν.</l>
 				</sp>
@@ -664,7 +664,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>τί δὲ στυγεῖς σὺ τοῦ θεοῦ τὰ φίλτατα;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὐδέν· ξύνοιδ’ ἄντροισιν αἰσχύνην τινά.</l>
 				</sp>
@@ -672,7 +672,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>πόσις δὲ τίς σ’ ἔγημ’ Ἀθηναίων, γύναι;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="290">οὐκ ἀστός, ἀλλ’ ἐπακτὸς ἐξ ἄλλης χθονός.</l>
 				</sp>
@@ -680,7 +680,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>τίς; εὐγενῆ νιν δεῖ πεφυκέναι τινά.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>Ξοῦθος, πεφυκὼς Αἰόλου Διός τ’ ἄπο.</l>
 				</sp>
@@ -688,7 +688,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>καὶ πῶς ξένος σ’ ὢν ἔσχεν οὖσαν ἐγγενῆ;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>Εὔβοῑ Ἀθήναις ἔστι τις γείτων πόλις . . .</l>
 				</sp>
@@ -696,7 +696,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="295">ὅροις ὑγροῖσιν, ὡς λέγουσ’, ὡρισμένη.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ταύτην ἔπερσε Κεκροπίδαις κοινῷ δορί.</l>
 				</sp>
@@ -704,7 +704,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ἐπίκουρος ἐλθών; κᾆτα σὸν γαμεῖ λέχος;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>φερνάς γε πολέμου καὶ δορὸς λαβὼν γέρας.</l>
 				</sp>
@@ -712,7 +712,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>σὺν ἀνδρὶ δ’ ἥκεις ἢ μόνη χρηστήρια;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="300">σὺν ἀνδρί. σηκοὺς δ’ ἐκστρέφει Τροφωνίου.</l>
 				</sp>
@@ -720,7 +720,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>πότερα θεατὴς ἢ χάριν μαντευμάτων;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>κείνου τε Φοίβου θ’ ἓν θέλων μαθεῖν ἔπος.</l>
 				</sp>
@@ -728,7 +728,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>καρποῦ δ’ ὕπερ γῆς ἥκετ’, ἢ παίδων πέρι;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἄπαιδές ἐσμεν, χρόνῑ ἔχοντ’ εὐνήματα.</l>
 				</sp>
@@ -736,7 +736,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="305">οὐδ’ ἔτεκες οὐδὲν πώποτ’, ἀλλ’ ἄτεκνος εἶ;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ὁ Φοῖβος οἶδε τὴν ἐμὴν ἀπαιδίαν.</l>
 				</sp>
@@ -745,7 +745,7 @@ bring up to P3
 					<l>ὦ τλῆμον, ὡς τἄλλ’ εὐτυχοῦσ’ οὐκ εὐτυχεῖς.</l>
 					<milestone ed="p" n="308" unit="card"/>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>σὺ δ’ εἶ τίς; ὥς σου τὴν τεκοῦσαν ὤλβισα.</l>
 				</sp>
@@ -753,7 +753,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>τοῦ θεοῦ καλοῦμαι δοῦλος εἰμί τ’, ὦ γύναι.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="310">ἀνάθημα πόλεως, ἤ τινος πραθεὶς ὕπο;</l>
 				</sp>
@@ -761,7 +761,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>οὐκ οἶδα πλὴν ἕν· Λοξίου κεκλήμεθα.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἡμεῖς σ’ ἄρ’ αὖθις, ὦ ξέν’, ἀντοικτίρομεν.</l>
 				</sp>
@@ -769,7 +769,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ὡς μὴ εἰδόθ’ ἥτις μ’ ἔτεκεν ἐξ ὅτου τ’ ἔφυν.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ναοῖσι δ’ οἰκεῖς τοισίδ’ ἢ κατὰ στέγας;</l>
 				</sp>
@@ -777,7 +777,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="315">ἅπαν θεοῦ μοι δῶμ’, ἵν’ ἂν λάβῃ μ’ ὕπνος.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>παῖς δ’ ὢν ἀφίκου ναὸν ἢ νεανίας;</l>
 				</sp>
@@ -785,7 +785,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>βρέφος λέγουσιν οἱ δοκοῦντες εἰδέναι.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>καὶ τίς γάλακτί σ’ ἐξέθρεψε Δελφίδων;</l>
 				</sp>
@@ -793,7 +793,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>οὐπώποτ’ ἔγνων μαστόν· ἣ δ’ ἔθρεψέ με . . .</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="320">τίς, ὦ ταλαίπωρ’; ὡς νοσοῦσ’ ηὗρον νόσους.</l>
 				</sp>
@@ -801,7 +801,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>Φοίβου προφῆτις, μητέρ’ ὣς νομίζομεν.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἐς δ’ ἄνδρ’ ἀφίκου τίνα τροφὴν κεκτημένος;</l>
 				</sp>
@@ -809,7 +809,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>βωμοί μ’ ἔφερβον οὑπιών τ’ ἀεὶ ξένος.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τάλαινά σ’ ἡ τεκοῦσα· τίς ποτ’ ἦν ἄρα;</l>
 				</sp>
@@ -817,7 +817,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="325">ἀδίκημά του γυναικὸς ἐγενόμην ἴσως.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἔχεις δὲ βίοτον· εὖ γὰρ ἤσκησαι πέπλοις.</l>
 				</sp>
@@ -825,7 +825,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>τοῖς τοῦ θεοῦ κοσμούμεθ’, ᾧ δουλεύομεν.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὐδ’ ᾖξας εἰς ἔρευναν ἐξευρεῖν γονάς;</l>
 				</sp>
@@ -833,7 +833,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ἔχω γὰρ οὐδέν, ὦ γύναι, τεκμήριον.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="330">φεῦ·</l>
 					<l>πέπονθέ τις σῇ μητρὶ ταὔτ’ ἄλλη γυνή.</l>
@@ -842,7 +842,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>τίς; εἰ πόνου μοι ξυλλάβοι, χαίροιμεν ἄν.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἧς οὕνεκ’ ἦλθον δεῦρο πρὶν πόσιν μολεῖν.</l>
 				</sp>
@@ -850,7 +850,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ποῖόν τι χρῄζουσ’; ὡς ὑπουργήσω, γύναι.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>μάντευμα κρυπτὸν δεομένη Φοίβου μαθεῖν.</l>
 				</sp>
@@ -858,7 +858,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="335">λέγοις ἄν· ἡμεῖς τἄλλα προξενήσομεν.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἄκουε δὴ τὸν μῦθον.  — ἀλλ’ αἰδούμεθα.</l>
 				</sp>
@@ -866,7 +866,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>οὔ τἄρα πράξεις οὐδέν· ἀργὸς ἡ θεός.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>Φοίβῳ μιγῆναί φησί τις φίλων ἐμῶν.</l>
 				</sp>
@@ -874,7 +874,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>Φοίβῳ γυνὴ γεγῶσα; μὴ λέγ’, ὦ ξένη.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="340">καὶ παῖδά γ’ ἔτεκε τῷ θεῷ λάθρα πατρός.</l>
 				</sp>
@@ -882,7 +882,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>οὐκ ἔστιν· ἀνδρὸς ἀδικίαν αἰσχύνεται.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὔ φησιν αὐτή, καὶ πέπονθεν ἄθλια.</l>
 				</sp>
@@ -890,7 +890,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>τί χρῆμα δράσασ’, εἰ θεῷ συνεζύγη;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τὸν παῖδ’ ὃν ἔτεκεν ἐξέθηκε δωμάτων.</l>
 				</sp>
@@ -898,7 +898,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="345">ὁ δ’ ἐκτεθεὶς παῖς ποῦ ’στιν; εἰσορᾷ φάος;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὐκ οἶδεν οὐδείς. ταῦτα καὶ μαντεύομαι.</l>
 				</sp>
@@ -906,7 +906,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>εἰ δ’ οὐκέτ’ ἔστι, τίνι τρόπῳ διεφθάρη;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>θῆράς σφε τὸν δύστηνον ἐλπίζει κτανεῖν.</l>
 				</sp>
@@ -914,7 +914,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ποίῳ τόδ’ ἔγνω χρωμένη τεκμηρίῳ;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="350">ἐλθοῦσ’ ἵν’ αὐτὸν ἐξέθηκ’ οὐχ ηὗρ’ ἔτι.</l>
 				</sp>
@@ -922,7 +922,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>ἦν δὲ σταλαγμὸς ἐν στίβῳ τις αἵματος;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὔ φησι. καίτοι πόλλ’ ἐπεστράφη πέδον.</l>
 				</sp>
@@ -930,7 +930,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>χρόνος δὲ τίς τῷ παιδὶ διαπεπραγμένῳ;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>σοὶ ταὐτὸν ἥβης, εἴπερ, εἶχεν ἂν μέτρον.</l>
 					<milestone ed="p" n="355" unit="card"/>
@@ -939,7 +939,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="355">ἀδικεῖ νιν ὁ θεός· ἡ τεκοῦσα δ’ ἀθλία.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὔκουν ἔτ’ ἄλλον γ’ ὕστερον τίκτει γόνον.</l>
 				</sp>
@@ -947,7 +947,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>τί δ’, εἰ λάθρα νιν Φοῖβος ἐκτρέφει λαβών;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τὰ κοινὰ χαίρων οὐ δίκαια δρᾷ μόνος.</l>
 				</sp>
@@ -955,7 +955,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>οἴμοι· προσῳδὸς ἡ τύχη τὠμῷ πάθει.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="360">καὶ σέ, ὦ ξέν’, οἶμαι μητέρ’ ἀθλίαν ποθεῖν.</l>
 				</sp>
@@ -963,7 +963,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>καὶ μή γ’ ἐπ’ οἶκτόν μ’ ἔξαγ’ οὗ ’λελήσμεθα.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>σιγῶ· πέραινε δ’ ὧν σ’ ἀνιστορῶ πέρι.</l>
 				</sp>
@@ -971,7 +971,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>οἶσθ’ οὖν ὃ κάμνει τοῦ λόγου μάλιστά σοι;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τί δ’ οὐκ ἐκείνῃ τῇ ταλαιπώρῳ νοσεῖ;</l>
 				</sp>
@@ -979,7 +979,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l n="365">πῶς ὁ θεὸς ὃ λαθεῖν βούλεται μαντεύσεται;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>εἴπερ καθίζει τρίποδα κοινὸν Ἑλλάδος.</l>
 				</sp>
@@ -987,7 +987,7 @@ bring up to P3
 					<speaker>Ἴων</speaker>
 					<l>αἰσχύνεται τὸ πρᾶγμα· μὴ ’ξέλεγχέ νιν.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἀλγύνεται δέ γ’ ἡ παθοῦσα τῇ τύχῃ.</l>
 				</sp>
@@ -1006,13 +1006,13 @@ bring up to P3
 					<l>ἄκοντα κεκτήμεσθα τἀγάθ’, ὦ γύναι·</l>
 					<l n="380">ἃ δ’ ἂν διδῶσ’ ἑκόντες, ὠφελούμεθα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πολλαί γε πολλοῖς εἰσι συμφοραὶ βροτῶν,</l>
 					<l>μορφαὶ δὲ διαφέρουσιν· ἓν δ’ ἂν εὐτυχὲς</l>
 					<l>μόλις ποτ’ ἐξεύροι τις ἀνθρώπων βίῳ.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ὦ Φοῖβε, κἀκεῖ κἀνθάδ’ οὐ δίκαιος εἶ</l>
 					<l n="385">ἐς τὴν ἀποῦσαν, ἧς πάρεισιν οἱ λόγοι·</l>
@@ -1036,31 +1036,31 @@ bring up to P3
 					<l n="400">μισούμεθ’· οὕτω δυστυχεῖς πεφύκαμεν.</l>
 					<milestone ed="p" n="401" unit="card"/>
 				</sp>
-				<sp who="#ksoythos">
+				<sp who="#xouthos">
 					<speaker>Ξοῦθος</speaker>
 					<l>πρῶτον μὲν ὁ θεὸς τῶν ἐμῶν προσφθεγμάτων</l>
 					<l>λαβὼν ἀπαρχὰς χαιρέτω, σύ τ’, ὦ γύναι.</l>
 					<l>μῶν χρόνιος ἐλθών σ’ ἐξέπληξ’ ὀρρωδίᾳ;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>οὐδέν γ’· ἀφίκου δ’ ἐς μέριμναν. ἀλλά μοι</l>
 					<l n="405">λέξον, τί θέσπισμ’ ἐκ Τροφωνίου φέρεις,</l>
 					<l>παίδων ὅπως νῷν σπέρμα συγκραθήσεται;</l>
 				</sp>
-				<sp who="#ksoythos">
+				<sp who="#xouthos">
 					<speaker>Ξοῦθος</speaker>
 					<l>οὐκ ἠξίωσε τοῦ θεοῦ προλαμβάνειν</l>
 					<l>μαντεύμαθ’· ἓν δ’ οὖν εἶπεν· οὐκ ἄπαιδά με</l>
 					<l>πρὸς οἶκον ἥξειν οὐδὲ σὲ ἐκ χρηστηρίων.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="410">ὦ πότνια Φοίβου μῆτερ, εἰ γὰρ αἰσίως</l>
 					<l>ἔλθοιμεν, ἅ τε νῷν συμβόλαια πρόσθεν ἦν</l>
 					<l>ἐς παῖδα τὸν σόν, μεταπέσοι βελτίονα.</l>
 				</sp>
-				<sp who="#ksoythos">
+				<sp who="#xouthos">
 					<speaker>Ξοῦθος</speaker>
 					<l>ἔσται τάδ’· ἀλλὰ τίς προφητεύει θεοῦ;</l>
 				</sp>
@@ -1070,7 +1070,7 @@ bring up to P3
 					<l n="415">οἳ πλησίον θάσσουσι τρίποδος, ὦ ξένε,</l>
 					<l>Δελφῶν ἀριστῆς, οὓς ἐκλήρωσεν πάλος.</l>
 				</sp>
-				<sp who="#ksoythos">
+				<sp who="#xouthos">
 					<speaker>Ξοῦθος</speaker>
 					<l>καλῶς· ἔχω δὴ πάνθ’ ὅσων ἐχρῄζομεν.</l>
 					<l>στείχοιμ’ ἂν εἴσω· καὶ γάρ, ὡς ἐγὼ κλύω,</l>
@@ -1081,7 +1081,7 @@ bring up to P3
 					<l>λαβοῦσα κλῶνας, εὐτέκνους εὔχου θεοῖς</l>
 					<l>χρησμούς μ’ ἐνεγκεῖν ἐξ Ἀπόλλωνος δόμων.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="425">ἔσται τάδ’, ἔσται. Λοξίας δ’ ἐὰν θέλῃ</l>
 					<l>νῦν ἀλλὰ τὰς πρὶν ἀναλαβεῖν ἁμαρτίας,</l>
@@ -1118,7 +1118,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὲ τὰν ὠδίνων λοχιᾶν</l>
 						<l>ἀνειλείθυιαν, ἐμὰν</l>
@@ -1144,7 +1144,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὑπερβαλλούσας γὰρ ἔχει</l>
 						<l>θνατοῖς εὐδαιμονίας</l>
@@ -1170,7 +1170,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Πανὸς θακήματα καὶ</l>
 						<l>παραυλίζουσα πέτρα</l>
@@ -1203,13 +1203,13 @@ bring up to P3
 						<l>ἐκλέλοιπ’ ἤδη τὸν ἱερὸν τρίποδα καὶ χρηστήριον</l>
 						<l>Ξοῦθος, ἢ μίμνει κατ’ οἶκον ἱστορῶν ἀπαιδίαν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐν δόμοις ἔστ’, ὦ ξέν’· οὔπω δῶμ’ ὑπερβαίνει τόδε.</l>
 						<l n="515">ὡς δ’ ἐπ’ ἐξόδοισιν ὄντος, τῶνδ’ ἀκούομεν πυλῶν</l>
 						<l>δοῦπον, ἐξιόντα τ’ ἤδη δεσπότην ὁρᾶν πάρα.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l>ὦ τέκνον, χαῖρ’· ἡ γὰρ ἀρχὴ τοῦ λόγου πρέπουσά μοι.</l>
 					</sp>
@@ -1217,7 +1217,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>χαίρομεν· σὺ δ’ εὖ φρόνει γε, καὶ δύ’ ὄντ’ εὖ πράξομεν.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l>δὸς χερὸς φίλημά μοι σῆς σώματός τ’ ἀμφιπτυχάς.</l>
 					</sp>
@@ -1225,7 +1225,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="520">εὖ φρονεῖς μέν; ἤ σ’ ἔμηνε θεοῦ τις, ὦ ξένε, βλάβη;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l>σωφρονῶ· τὰ φίλταθ’ εὑρὼν οὐ φυγεῖν ἐφίεμαι.</l>
 					</sp>
@@ -1233,7 +1233,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>παῦε, μὴ ψαύσας τὰ τοῦ θεοῦ στέμματα ῥήξῃς χερί.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l>ἅψομαι· κοὐ ῥυσιάζω, τἀμὰ δ’ εὑρίσκω φίλα.</l>
 					</sp>
@@ -1241,7 +1241,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>οὐκ ἀπαλλάξῃ, πρὶν εἴσω τόξα πλευμόνων λαβεῖν;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l n="525">ὡς τί δὴ φεύγεις με; σαυτοῦ γνωρίσας τὰ φίλτατα — </l>
 					</sp>
@@ -1249,7 +1249,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>οὐ φιλῶ φρενοῦν ἀμούσους καὶ μεμηνότας ξένους.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l>κτεῖνε καὶ πίμπρη· πατρὸς γάρ, ἢν κτάνῃς, ἔσῃ φονεύς.</l>
 					</sp>
@@ -1257,7 +1257,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ποῦ δέ μοι πατὴρ σύ; ταῦτ’ οὖν οὐ γέλως κλύειν ἐμοῦ;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l>οὔ· τρέχων ὁ μῦθος ἄν σοι τἀμὰ σημήνειεν ἄν.</l>
 					</sp>
@@ -1265,7 +1265,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="530">καὶ τί μοι λέξεις;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">πατὴρ σός εἰμι καὶ σὺ παῖς ἐμός.</l>
 					</sp>
@@ -1273,7 +1273,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τίς λέγει τάδε;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ὅς σ’ ἔθρεψεν ὄντα Λοξίας ἐμόν.</l>
 					</sp>
@@ -1281,7 +1281,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>μαρτυρεῖς σαυτῷ.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">τὰ τοῦ θεοῦ γ’ ἐκμαθὼν χρηστήρια.</l>
 					</sp>
@@ -1289,7 +1289,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἐσφάλης αἴνιγμ’ ἀκούσας.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">οὐκ ἄρ’ ὄρθ’ ἀκούομεν.</l>
 					</sp>
@@ -1297,7 +1297,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὁ δὲ λόγος τίς ἐστι Φοίβου;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">τὸν συναντήσαντά μοι — </l>
 					</sp>
@@ -1305,7 +1305,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="535">τίνα συνάντησιν;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">δόμων τῶνδ’ ἐξιόντι τοῦ θεοῦ</l>
 					</sp>
@@ -1313,7 +1313,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>συμφορᾶς τίνος κυρῆσαι;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">παῖδ’ ἐμὸν πεφυκέναι.</l>
 					</sp>
@@ -1321,7 +1321,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>σὸν γεγῶτ’, ἢ δῶρον ἄλλως;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">δῶρον, ὄντα δ’ ἐξ ἐμοῦ.</l>
 					</sp>
@@ -1329,7 +1329,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πρῶτα δῆτ’ ἐμοὶ ξυνάπτεις πόδα σόν;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">οὐκ ἄλλῳ, τέκνον.</l>
 					</sp>
@@ -1337,7 +1337,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἡ τύχη πόθεν ποθ’ ἥκει;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">δύο μίαν θαυμάζομεν.</l>
 					</sp>
@@ -1345,7 +1345,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="540">ἔα. τίνος δέ σοι πέφυκα μητρός;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">οὐκ ἔχω φράσαι.</l>
 					</sp>
@@ -1353,7 +1353,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>οὐδὲ Φοῖβος εἶπε;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">τερφθεὶς τοῦτο, κεῖν’ οὐκ ἠρόμην.</l>
 					</sp>
@@ -1361,7 +1361,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>γῆς ἄρ’ ἐκπέφυκα μητρός.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">οὐ πέδον τίκτει τέκνα.</l>
 					</sp>
@@ -1369,7 +1369,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πῶς ἂν οὖν εἴην σός;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">οὐκ οἶδ’, ἀναφέρω δ’ ἐς τὸν θεόν.</l>
 						<milestone ed="p" n="544" unit="card"/>
@@ -1378,7 +1378,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>φέρε λόγων ἁψώμεθ’ ἄλλων.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ταῦτ’ ἀμείνον’, ὦ τέκνον.</l>
 					</sp>
@@ -1386,7 +1386,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="545">ἦλθες ἐς νόθον τι λέκτρον;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">μωρίᾳ γε τοῦ νέου.</l>
 					</sp>
@@ -1394,7 +1394,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πρὶν κόρην λαβεῖν Ἐρεχθέως;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">οὐ γὰρ ὕστερόν γέ πω.</l>
 					</sp>
@@ -1402,7 +1402,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἆρα δῆτ’ ἐκεῖ μ’ ἔφυσας;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">τῷ χρόνῳ γε συντρέχει.</l>
 					</sp>
@@ -1410,7 +1410,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>κᾆτα πῶς ἀφικόμεσθα δεῦρο — </l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ταῦτ’ ἀμηχανῶ.</l>
 					</sp>
@@ -1418,7 +1418,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>διὰ μακρᾶς ἐλθὼν κελεύθου;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">τοῦτο κἄμ’ ἀπαιολεῖ.</l>
 					</sp>
@@ -1426,7 +1426,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="550">Πυθίαν δ’ ἦλθες πέτραν πρίν;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ἐς φανάς γε Βακχίου.</l>
 					</sp>
@@ -1434,7 +1434,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>προξένων δ’ ἔν του κατέσχες;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ὅς με Δελφίσιν κόραις . . .</l>
 					</sp>
@@ -1442,7 +1442,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἐθιάσευσ’, ἢ πῶς τάδ’ αὐδᾷς;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">Μαινάσιν γε Βακχίου.</l>
 					</sp>
@@ -1450,7 +1450,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἔμφρον’ ἢ κάτοινον ὄντα;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">Βακχίου πρὸς ἡδοναῖς.</l>
 					</sp>
@@ -1458,7 +1458,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τοῦτ’ ἐκεῖν’ ἵν’ ἐσπάρημεν.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ὁ πότμος ἐξηῦρεν, τέκνον.</l>
 					</sp>
@@ -1466,7 +1466,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="555">πῶς δ’ ἀφικόμεσθα ναούς;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ἔκβολον κόρης ἴσως.</l>
 					</sp>
@@ -1474,7 +1474,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἐκπεφεύγαμεν τὸ δοῦλον.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">πατέρα νυν δέχου, τέκνον.</l>
 					</sp>
@@ -1482,7 +1482,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τῷ θεῷ γοῦν οὐκ ἀπιστεῖν εἰκός.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">εὖ φρονεῖς ἄρα.</l>
 					</sp>
@@ -1490,7 +1490,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>καὶ τί βουλόμεσθά γ’ ἄλλο — </l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">νῦν ὁρᾷς ἃ χρή σ’ ὁρᾶν.</l>
 					</sp>
@@ -1498,7 +1498,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἢ Διὸς παιδὸς γενέσθαι παῖς;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">ὃ σοί γε γίγνεται.</l>
 					</sp>
@@ -1506,7 +1506,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="560">ἦ θίγω δῆθ’ οἵ μ’ ἔφυσαν;</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">πιθόμενός γε τῷ θεῷ.</l>
 					</sp>
@@ -1514,7 +1514,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>χαῖρέ μοι, πάτερ — </l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">φίλον γε φθέγμ’ ἐδεξάμην τόδε.</l>
 					</sp>
@@ -1522,7 +1522,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἡμέρα θ’ ἡ νῦν παροῦσα.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l part="Y">μακάριόν γ’ ἔθηκέ με.</l>
 					</sp>
@@ -1535,13 +1535,13 @@ bring up to P3
 					<milestone ed="p" n="566" unit="card"/>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κοιναὶ μὲν ἡμῖν δωμάτων εὐπραξίαι·</l>
 						<l>ὅμως δὲ καὶ δέσποιναν ἐς τέκν’ εὐτυχεῖν</l>
 						<l>ἐβουλόμην ἂν τούς τ’ Ἐρεχθέως δόμους.</l>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l>ὦ τέκνον, ἐς μὲν σὴν ἀνεύρεσιν θεὸς</l>
 						<l n="570">ὀρθῶς ἔκρανε, καὶ συνῆψ’ ἐμοί τε σέ,</l>
@@ -1636,13 +1636,13 @@ bring up to P3
 						<l>ἔα δ’ ἔμ’ αὐτοῦ ζῆν· ἴση γὰρ ἡ χάρις,</l>
 						<l>μεγάλοισι χαίρειν σμικρά θ’ ἡδέως ἔχειν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καλῶς ἔλεξας, εἴπερ οὓς ἐγὼ φιλῶ</l>
 						<l>ἐν τοῖσι σοῖσιν εὐτυχήσουσιν φίλοις.</l>
 						<milestone ed="p" n="650" unit="card"/>
 					</sp>
-					<sp who="#ksoythos">
+					<sp who="#xouthos">
 						<speaker>Ξοῦθος</speaker>
 						<l n="650">παῦσαι λόγων τῶνδ’, εὐτυχεῖν δ’ ἐπίστασο·</l>
 						<l>θέλω γὰρ οὗπέρ σ’ ηὗρον ἄρξασθαι, τέκνον,</l>
@@ -1681,7 +1681,7 @@ bring up to P3
 				 
 
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρῶ δάκρυα καὶ πενθίμους</l>
 						<l>&lt;ἀλαλαγὰς&gt; στεναγμάτων τ’ ἐσβολάς,</l>
@@ -1704,7 +1704,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="695"> — φίλαι, πότερ’ ἐμᾷ δεσποίνᾳ</l>
 						<l>τάδε τορῶς ἐς οὖς γεγωνήσομεν;</l>
@@ -1727,7 +1727,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ δειράδες Παρνασοῦ πέτρας</l>
 						<l n="715">ἔχουσαι σκόπελον οὐράνιόν θ’ ἕδραν,</l>
@@ -1747,7 +1747,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="725">ὦ πρέσβυ παιδαγώγ’ Ἐρεχθέως πατρὸς</l>
 					<l>τοὐμοῦ ποτ’ ὄντος, ἡνίκ’ ἦν ἔτ’ ἐν φάει,</l>
@@ -1769,7 +1769,7 @@ bring up to P3
 					<l>αἰπεινά τοι μαντεῖα· τοῦ γήρως δέ μοι</l>
 					<l n="740">συνεκπονοῦσα κῶλον ἰατρὸς γενοῦ.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>ἕπου νυν· ἴχνος δ’ ἐκφύλασσ’ ὅπου τίθης.</l>
 				</sp>
@@ -1778,7 +1778,7 @@ bring up to P3
 					<l>ἰδού.</l>
 					<l>τὸ τοῦ ποδὸς μὲν βραδύ, τὸ τοῦ δὲ νοῦ ταχύ.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>βάκτρῳ δ’ ἐρείδου περιφερῆ στίβον χθονός.</l>
 				</sp>
@@ -1786,7 +1786,7 @@ bring up to P3
 					<speaker>Πρεσβύτης</speaker>
 					<l>καὶ τοῦτο τυφλόν, ὅταν ἐγὼ βλέπω βραχύ.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l n="745">ὀρθῶς ἔλεξας· ἀλλὰ μὴ παρῇς κόπῳ.</l>
 				</sp>
@@ -1794,7 +1794,7 @@ bring up to P3
 					<speaker>Πρεσβύτης</speaker>
 					<l>οὔκουν ἑκών γε· τοῦ δ’ ἀπόντος οὐ κρατῶ.</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>γυναῖκες, ἱστῶν τῶν ἐμῶν καὶ κερκίδος</l>
 					<l>δούλευμα πιστόν, τίνα τύχην λαβὼν πόσις</l>
@@ -1803,7 +1803,7 @@ bring up to P3
 					<l>οὐκ εἰς ἀπίστους δεσπότας βαλεῖς χάριν.</l>
 				</sp>
 				<!--  the two interjections were marked as "lyric" -->
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἰὼ δαῖμον.</l>
 				</sp>
@@ -1811,7 +1811,7 @@ bring up to P3
 					<speaker>Πρεσβύτης</speaker>
 					<l>τὸ φροίμιον μὲν τῶν λόγων οὐκ εὐτυχές.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἰὼ τλᾶμον.</l>
 				</sp>
@@ -1819,30 +1819,30 @@ bring up to P3
 					<speaker>Πρεσβύτης</speaker>
 					<l n="755">ἀλλ’ ἦ τι θεσφάτοισι δεσποτῶν νοσῶ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἶἑν· τί δρῶμεν; θάνατος ὧν κεῖται πέρι . . .</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>τίς ἥδε μοῦσα, χὡ φόβος τίνων πέρι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἴπωμεν ἢ σιγῶμεν; ἢ τί δράσομεν;</l>
 				</sp>
-				<sp who="#kreoysa">
+				<sp who="#kreousa">
 					<speaker>Κρέουσα</speaker>
 					<l>εἴφ’· ὡς ἔχεις γε συμφοράν τιν’ εἰς ἐμέ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="760">εἰρήσεταί τοι, κεἰ θανεῖν μέλλω διπλῇ.</l>
 					<l>οὐκ ἔστι σοι, δέσποιν’, ἐπ’ ἀγκάλαις λαβεῖν</l>
 					<l>τέκν’, οὐδὲ μαστῷ σῷ προσαρμόσαι ποτέ.</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ὤμοι, θάνοιμι.</l>
 					</sp>
@@ -1850,7 +1850,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>θύγατερ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">ὦ τάλαιν’</l>
 						<l>ἐγὼ συμφορᾶς, ἔλαβον ἔπαθον ἄχος</l>
@@ -1861,7 +1861,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τέκνον.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">αἰαῖ αἰαῖ·</l>
 						<l n="767">διανταῖος ἔτυπεν ὀδύνα με πλευ‐</l>
@@ -1871,7 +1871,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>μήπω στενάξῃς — </l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">ἀλλὰ πάρεισι γόοι.</l>
 					</sp>
@@ -1879,7 +1879,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="770">πρὶν ἂν μάθωμεν — </l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">ἀγγελίαν τίνα μοι;</l>
 					</sp>
@@ -1891,12 +1891,12 @@ bring up to P3
 						<l>κοινωνός ἐστιν, ἢ μόνη σὺ δυστυχεῖς.</l>
 						<milestone ed="p" n="774" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κείνῳ μέν, ὦ γεραιέ, παῖδα Λοξίας</l>
 						<l n="775">ἔδωκεν, ἰδίᾳ δ’ εὐτυχεῖ ταύτης δίχα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τόδ’ ἐπὶ τῷδε κακὸν ἄκρον ἔλακες</l>
 						<l>ἄχος ἐμοὶ στένειν.</l>
@@ -1906,13 +1906,13 @@ bring up to P3
 						<l>πότερα δὲ φῦναι δεῖ γυναικὸς ἔκ τινος</l>
 						<l>τὸν παῖδ’ ὃν εἶπας, ἢ γεγῶτ’ ἐθέσπισεν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="780">ἤδη πεφυκότ’ ἐκτελῆ νεανίαν</l>
 						<l>δίδωσιν αὐτῷ Λοξίας· παρῆ δ’ ἐγώ.</l>
 					</sp>
 					<!-- lyrics? -->
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>πῶς φῄς; ἄφατον ἄφατον ἀναύδητον</l>
 						<l>λόγον ἐμοὶ θροεῖς.</l>
@@ -1922,13 +1922,13 @@ bring up to P3
 						<l n="785">κἄμοιγε. πῶς δ’ ὁ χρησμὸς ἐκπεραίνεται,</l>
 						<l>σαφέστερόν μοι φράζε, χὥστις ἔσθ’ ὁ παῖς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅτῳ ξυναντήσειεν ἐκ θεοῦ συθεὶς</l>
 						<l>πρώτῳ πόσις σός, παῖδ’ ἔδωκ’ αὐτῷ θεός.</l>
 					</sp>
 					<!-- marked lyric -->
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ὀττοτοττοτοῖ· τὸν δ’ ἐμὸν ἄτεκνον ἄτεκνον ἔλακεν</l>
 						<l n="790">ἄρα βίοτον; ἐρημίᾳ δ’ ὀρφανοὺς</l>
@@ -1939,13 +1939,13 @@ bring up to P3
 						<l>τίς οὖν ἐχρήσθη; τῷ συνῆψ’ ἴχνος ποδὸς</l>
 						<l>πόσις ταλαίνης; πῶς δὲ ποῦ νιν εἰσιδών;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἶσθ’, ὦ φίλη δέσποινα, τὸν νεανίαν</l>
 						<l n="795">ὃς τόνδ’ ἔσαιρε ναόν; οὗτος ἔσθ’ ὁ παῖς.</l>
 					</sp>
 					<!-- marked lyric -->
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἀν’ ὑγρὸν ἀμπταίην αἰθέρα πόρσω γαί‐</l>
 						<l>ας Ἑλλανίας, ἀστέρας ἑσπέρους,</l>
@@ -1956,7 +1956,7 @@ bring up to P3
 						<l n="800">ὄνομα δὲ ποῖον αὐτὸν ὀνομάζει πατήρ;</l>
 						<l>οἶσθ’, ἢ σιωπῇ τοῦτ’ ἀκύρωτον μένει;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἴων’, ἐπείπερ πρῶτος ἤντησεν πατρί.</l>
 					</sp>
@@ -1964,7 +1964,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>μητρὸς δ’ ὁποίας ἐστὶν — </l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">οὐκ ἔχω φράσαι.</l>
 						<l>φροῦδος δ’ — ἵν’ εἰδῇς πάντα τἀπ’ ἐμοῦ, γέρον — </l>
@@ -2000,7 +2000,7 @@ bring up to P3
 						<l n="830">καινὸν δὲ τοὔνομ’ ἀνὰ χρόνον πεπλασμένον</l>
 						<l>Ἴων, ἰόντι δῆθεν ὅτι συνήντετο.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἴμοι, κακούργους ἄνδρας ὡς αἰεὶ στυγῶ,</l>
 						<l>οἳ συντιθέντες τἄδικ’ εἶτα μηχαναῖς</l>
@@ -2032,7 +2032,7 @@ bring up to P3
 						<l n="855">τοὔνομα· τὰ δ’ ἄλλα πάντα τῶν ἐλευθέρων</l>
 						<l>οὐδὲν κακίων δοῦλος, ὅστις ἐσθλὸς ᾖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κἀγώ, φίλη δέσποινα, συμφορὰν θέλω</l>
 						<l>κοινουμένη τήνδ’ ἢ θανεῖν ἢ ζῆν καλῶς.</l>
@@ -2040,7 +2040,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp n="Κρέουσα" who="#kreoysa">
+					<sp n="Κρέουσα" who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ὦ ψυχά, πῶς σιγάσω;</l>
 						<l n="860">πῶς δὲ σκοτίας ἀναφήνω</l>
@@ -2111,7 +2111,7 @@ bring up to P3
 						<l>Λατὼ Δίοισί σε καρποῖς.</l>
 					</sp>
 					<milestone ed="p" n="923" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἴμοι, μέγας θησαυρὸς ὡς ἀνοίγνυται</l>
 						<l>κακῶν, ἐφ’ οἷσι πᾶς ἂν ἐκβάλοι δάκρυ.</l>
@@ -2128,7 +2128,7 @@ bring up to P3
 						<l>ποῖον τεκεῖν φὴ|ς παῖδα; ποῦ θεῖναι πόλεως</l>
 						<l>θηρσὶν φίλον τύμβευμ’; ἄνελθέ μοι πάλιν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>αἰσχύνομαι μέν σ’, ὦ γέρον, λέξω δ’ ὅμως.</l>
 					</sp>
@@ -2136,7 +2136,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="935">ὡς συστενάζειν γ’ οἶδα γενναίως φίλοις.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἄκουε τοίνυν· οἶσθα Κεκροπίας πέτρας</l>
 						<l>πρόσβορρον ἄντρον, ἃς Μακρὰς κικλήσκομεν;</l>
@@ -2145,7 +2145,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>οἶδ’, ἔνθα Πανὸς ἄδυτα καὶ βωμοὶ πέλας.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐνταῦθ’ ἀγῶνα δεινὸν ἠγωνίσμεθα.</l>
 					</sp>
@@ -2153,7 +2153,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="940">τίν’; ὡς ἀπαντᾷ δάκρυά μοι τοῖς σοῖς λόγοις.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>Φοίβῳ ξυνῆψ’ ἄκουσα δύστηνον γάμον.</l>
 					</sp>
@@ -2161,7 +2161,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ὦ θύγατερ, ἆρ’ ἦν ταῦθ’ ἅ γ’ ᾐσθόμην ἐγώ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οὐκ οἶδ’· ἀληθῆ δ’ εἰ λέγεις φαίημεν ἄν.</l>
 					</sp>
@@ -2169,7 +2169,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>νόσον κρυφαίαν ἡνίκ’ ἔστενες λάθρα;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="945">τότ’ ἦν ἃ νῦν σοι φανερὰ σημαίνω κακά.</l>
 					</sp>
@@ -2177,7 +2177,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>κᾆτ’ ἐξέκλεψας πῶς Ἀπόλλωνος γάμους;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἔτεκον — ἀνάσχου ταῦτ’ ἐμοῦ κλύων, γέρον.</l>
 					</sp>
@@ -2185,7 +2185,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ποῦ; τίς λοχεύει σ’; ἢ μόνη μοχθεῖς τάδε;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>μόνη κατ’ ἄντρον οὗπερ ἐζεύχθην γάμοις.</l>
 					</sp>
@@ -2193,7 +2193,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="950">ὁ παῖς δὲ ποῦ ’στιν; ἵνα σὺ μηκέτ’ ᾖς ἄπαις.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τέθνηκεν, ὦ γεραιέ, θηρσὶν ἐκτεθείς.</l>
 					</sp>
@@ -2201,7 +2201,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τέθνηκ’; Ἀπόλλων δ’ ὁ κακὸς οὐδὲν ἤρκεσεν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οὐκ ἤρκεσ’· Ἅιδου δ’ ἐν δόμοις παιδεύεται.</l>
 					</sp>
@@ -2209,7 +2209,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τίς γάρ νιν ἐξέθηκεν; οὐ γὰρ δὴ σύ γε.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="955">ἡμεῖς, ἐν ὄρφνῃ σπαργανώσαντες πέπλοις.</l>
 					</sp>
@@ -2217,7 +2217,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>οὐδὲ ξυνῄδει σοί τις ἔκθεσιν τέκνου;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>αἱ ξυμφοραί γε καὶ τὸ λανθάνειν μόνον.</l>
 					</sp>
@@ -2225,7 +2225,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>καὶ πῶς ἐν ἄντρῳ παῖδα σὸν λιπεῖν ἔτλης;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>πῶς δ’ οἰκτρὰ πολλὰ στόματος ἐκβαλοῦσ’ ἔπη — </l>
 					</sp>
@@ -2234,7 +2234,7 @@ bring up to P3
 						<l n="960">φεῦ·</l>
 						<l>τλήμων σὺ τόλμης, ὁ δὲ θεὸς μᾶλλον σέθεν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>εἰ παῖδά γ’ εἶδες χεῖρας ἐκτείνοντά μοι.</l>
 					</sp>
@@ -2242,7 +2242,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>μαστὸν διώκοντ’ ἦ πρὸς ἀγκάλαις πεσεῖν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐνταῦθ’, ἵν’ οὐκ ὢν ἄδικ’ ἔπασχεν ἐξ ἐμοῦ.</l>
 					</sp>
@@ -2250,7 +2250,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>σοὶ δ’ ἐς τί δόξ’ ἐσῆλθεν ἐκβαλεῖν τέκνον;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="965">ὡς τὸν θεὸν σῴζοντα τόν γ’ αὑτοῦ γόνον.</l>
 						<milestone ed="p" n="966" unit="card"/>
@@ -2259,7 +2259,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>οἴμοι, δόμων σῶν ὄλβος ὡς χειμάζεται.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τί κρᾶτα κρύψας, ὦ γέρον, δακρυρροεῖς;</l>
 					</sp>
@@ -2267,7 +2267,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>σὲ καὶ πατέρα σὸν δυστυχοῦντας εἰσορῶ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τὰ θνητὰ τοιαῦτ’· οὐδὲν ἐν ταὐτῷ μένει.</l>
 					</sp>
@@ -2275,7 +2275,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="970">μή νυν ἔτ’ οἴκτων, θύγατερ, ἀντεχώμεθα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τί γάρ με χρὴ δρᾶν; ἀπορία τὸ δυστυχεῖν.</l>
 					</sp>
@@ -2283,7 +2283,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τὸν πρῶτον ἀδικήσαντά σ’ ἀποτίνου θεόν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>καὶ πῶς τὰ κρείσσω θνητὸς οὖσ’ ὑπερδράμω;</l>
 					</sp>
@@ -2291,7 +2291,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>πίμπρη τὰ σεμνὰ Λοξίου χρηστήρια.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="975">δέδοικα· καὶ νῦν πημάτων ἄδην ἔχω.</l>
 					</sp>
@@ -2299,7 +2299,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τὰ δυνατά νυν τόλμησον, ἄνδρα σὸν κτανεῖν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>αἰδούμεθ’ εὐνὰς τὰς τόθ’ ἡνίκ’ ἐσθλὸς ἦν.</l>
 					</sp>
@@ -2307,7 +2307,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>νῦν δ’ ἀλλὰ παῖδα τὸν ἐπὶ σοὶ πεφηνότα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>πῶς; εἰ γὰρ εἴη δυνατόν· ὡς θέλοιμί γ’ ἄν.</l>
 					</sp>
@@ -2315,7 +2315,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="980">ξιφηφόρους σοὺς ὁπλίσασ’ ὀπάονας.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>στείχοιμ’ ἄν· ἀλλὰ ποῦ γενήσεται τόδε;</l>
 					</sp>
@@ -2323,7 +2323,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἱεραῖσιν ἐν σκηναῖσιν, οὗ θοινᾷ φίλους.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐπίσημον ὁ φόνος, καὶ τὸ δοῦλον ἀσθενές.</l>
 					</sp>
@@ -2331,7 +2331,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ὤμοι, κακίζῃ· φέρε, σὺ νῦν βούλευέ τι.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="985">καὶ μὴν ἔχω γε δόλια καὶ δραστήρια.</l>
 					</sp>
@@ -2339,7 +2339,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἀμφοῖν ἂν εἴην τοῖνδ’ ὑπηρέτης ἐγώ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἄκουε τοίνυν· οἶσθα γηγενῆ μάχην;</l>
 					</sp>
@@ -2347,7 +2347,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>οἶδ’, ἣν Φλέγρᾳ Γίγαντες ἔστησαν θεοῖς.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐνταῦθα Γοργόν’ ἔτεκε Γῆ, δεινὸν τέρας.</l>
 					</sp>
@@ -2355,7 +2355,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="990">ἦ παισὶν αὑτῆς σύμμαχον, θεῶν πόνον;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ναί· καί νιν ἔκτειν’ ἡ Διὸς Παλλὰς θεά.</l>
 					</sp>
@@ -2363,7 +2363,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>[ποῖόν τι μορφῆς σχῆμ’ ἔχουσαν ἀγρίας;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>θώρακ’ ἐχίδνης περιβόλοις ὡπλισμένον.]</l>
 					</sp>
@@ -2371,7 +2371,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἆρ’ οὗτός ἐσθ’ ὁ μῦθος ὃν κλύω πάλαι;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="995">ταύτης Ἀθάναν δέρος ἐπὶ στέρνοις ἔχειν.</l>
 					</sp>
@@ -2379,7 +2379,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἣν αἰγίδ’ ὀνομάζουσι, Παλλάδος στολήν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τόδ’ ἔσχεν ὄνομα θεῶν ὅτ’ ᾖξεν ἐς δόρυ.</l>
 						<milestone ed="p" n="998" unit="card"/>
@@ -2388,7 +2388,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τί δῆτα, θύγατερ, τοῦτο σοῖς ἐχθροῖς βλάβος;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>Ἐριχθόνιον οἶσθ’, ἢ — ; τί δ’ οὐ μέλλεις, γέρον;</l>
 					</sp>
@@ -2396,7 +2396,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="1000">ὃν πρῶτον ὑμῶν πρόγονον ἐξανῆκε γῆ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τούτῳ δίδωσι Παλλὰς ὄντι νεογόνῳ — </l>
 					</sp>
@@ -2404,7 +2404,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τί χρῆμα; μέλλον γάρ τι προσφέρεις ἔπος.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>δισσοὺς σταλαγμοὺς αἵματος Γοργοῦς ἄπο.</l>
 					</sp>
@@ -2412,7 +2412,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἰσχὺν ἔχοντας τίνα πρὸς ἀνθρώπου φύσιν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1005">τὸν μὲν θανάσιμον, τὸν δ’ ἀκεσφόρον νόσων.</l>
 					</sp>
@@ -2420,7 +2420,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἐν τῷ καθάψασ’ ἀμφὶ παιδὶ σώματος;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>χρυσοῖσι δεσμοῖς· ὁ δὲ δίδωσ’ ἐμῷ πατρί.</l>
 					</sp>
@@ -2428,7 +2428,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>κείνου δὲ κατθανόντος ἐς σὲ ἀφίκετο;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ναί· κἀπὶ καρπῷ γ’ αὔτ’ ἐγὼ χερὸς φέρω.</l>
 					</sp>
@@ -2436,7 +2436,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="1010">πῶς οὖν κέκρανται δίπτυχον δῶρον θεᾶς;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>κοίλης μὲν ὅστις φλεβὸς ἀπέσταξεν φόνῳ — </l>
 					</sp>
@@ -2444,7 +2444,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>τί τῷδε χρῆσθαι; δύνασιν ἐκφέρει τίνα;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>νόσους ἀπείργει καὶ τροφὰς ἔχει βίου.</l>
 					</sp>
@@ -2452,7 +2452,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ὁ δεύτερος δ’ ἀριθμὸς ὧν λέγεις τί δρᾷ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1015">κτείνει, δρακόντων ἰὸς ὢν τῶν Γοργόνος.</l>
 					</sp>
@@ -2460,7 +2460,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἐς ἓν δὲ κραθέντ’ αὐτὸν ἢ χωρὶς φορεῖς;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>χωρίς· κακῷ γὰρ ἐσθλὸν οὐ συμμείγνυται.</l>
 					</sp>
@@ -2468,7 +2468,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ὦ φιλτάτη παῖ, πάντ’ ἔχεις ὅσων σε δεῖ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τούτῳ θανεῖται παῖς· σὺ δ’ ὁ κτείνων ἔσῃ.</l>
 					</sp>
@@ -2476,7 +2476,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="1020">ποῦ καὶ τί δράσας; σὸν λέγειν, τολμᾶν δ’ ἐμόν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐν ταῖς Ἀθήναις, δῶμ’ ὅταν τοὐμὸν μόλῃ.</l>
 					</sp>
@@ -2484,7 +2484,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>οὐκ εὖ τόδ’ εἶπας· καὶ σὺ γὰρ τοὐμὸν ψέγεις.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>πῶς; ἆρ’ ὑπείδου τοῦθ’ ὃ κἄμ’ ἐσέρχεται;</l>
 					</sp>
@@ -2492,7 +2492,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>σὺ παῖδα δόξεις διολέσαι, κεἰ μὴ κτενεῖς.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1025">ὀρθῶς· φθονεῖν γάρ φασι μητρυιὰς τέκνοις.</l>
 					</sp>
@@ -2500,7 +2500,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>αὐτοῦ νυν αὐτὸν κτεῖν’, ἵν’ ἀρνήσῃ φόνους.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>προλάζυμαι γοῦν τῷ χρόνῳ τῆς ἡδονῆς.</l>
 					</sp>
@@ -2508,7 +2508,7 @@ bring up to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>καὶ σόν γε λήσεις πόσιν ἅ σε σπεύδει λαθεῖν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οἶσθ’ οὖν ὃ δρᾶσον; χειρὸς ἐξ ἐμῆς λαβὼν</l>
 						<l n="1030">χρύσωμ’ Ἀθάνας τόδε, παλαιὸν ὄργανον,</l>
@@ -2538,7 +2538,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Εἰνοδία θύγατερ Δάματρος, ἃ τῶν</l>
 						<l>νυκτιπόλων ἐφόδων ἀνάσσεις</l>
@@ -2557,7 +2557,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δ’ ἀτελὴς θάνατος σπουδαί τε δεσποί‐</l>
 						<l>νας, ὅ τε καιρὸς ἄπεισι τόλμας,</l>
@@ -2576,7 +2576,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰσχύνομαι τὸν πολύυ‐</l>
 						<l n="1075">μνον θεόν, εἰ παρὰ καλλιχόροισι παγαῖς</l>
@@ -2598,7 +2598,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1090">ὁρᾶθ’ ὅσοι δυσκελάδοι‐</l>
 						<l>σιν κατὰ μοῦσαν ἰόντες ἀείδεθ’ ὕμνοις</l>
@@ -2627,7 +2627,7 @@ bring up to P3
 					<l>δέσποιναν εὕρω; πανταχῇ γὰρ ἄστεως</l>
 					<l>ζητῶν νιν ἐξέπλησα κοὐκ ἔχω λαβεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἔστιν, ὦ ξύνδουλε; τίς προθυμία</l>
 					<l n="1110">ποδῶν ἔχει σε, καὶ λόγους τίνας φέρεις;</l>
@@ -2637,7 +2637,7 @@ bring up to P3
 					<l>θηρώμεθ’· ἀρχαὶ δ’ ἁπιχώριοι χθονὸς</l>
 					<l>ζητοῦσιν αὐτήν, ὡς θάνῃ πετρουμένη.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οἴμοι, τί λέξεις; οὔτι που λελήμμεθα</l>
 					<l>κρυφαῖον ἐς παῖδ’ ἐκπορίζουσαι φόνον;</l>
@@ -2646,7 +2646,7 @@ bring up to P3
 					<speaker>Θεράπων</speaker>
 					<l n="1115">ἔγνως;  — μεθέξεις οὐκ ἐν ὑστάτοις κακοῦ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὤφθη δὲ πῶς τὰ κρυπτὰ μηχανήματα;</l>
 				</sp>
@@ -2655,7 +2655,7 @@ bring up to P3
 					<l>τὸ μὴ δίκαιον τῆς δίκης ἡσσώμενον</l>
 					<l>ἐξηῦρεν ὁ θεός, οὐ μιανθῆναι θέλων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς; ἀντιάζω σ’ ἱκέτις ἐξειπεῖν τάδε.</l>
 					<l n="1120">πεπυσμέναι γάρ, εἰ θανεῖν ὅμως χρεών,</l>
@@ -2785,7 +2785,7 @@ bring up to P3
 				</sp>
 				<milestone ed="p" n="1229" unit="card"/>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἔστ’ οὐκ ἔστιν θανάτου</l>
 						<l n="1230">παρατροπὰ μελέᾳ μοι·</l>
@@ -2806,7 +2806,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἔστι λαθεῖν, ὅτε μὴ χρῄζων</l>
 						<l n="1245">θεὸς ἐκκλέπτει.</l>
@@ -2818,46 +2818,46 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1250">πρόσπολοι, διωκόμεσθα θανασίμους ἐπὶ σφαγάς,</l>
 						<l>Πυθίᾳ ψήφῳ κρατηθεῖσ’, ἔκδοτος δὲ γίγνομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴσμεν, ὦ τάλαινα, τὰς σὰς συμφοράς, ἵν’ εἶ τύχης.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ποῖ φύγω δῆτ’; ἐκ γὰρ οἴκων προύλαβον μόγις πόδα</l>
 						<l>μὴ θανεῖν, κλοπῇ δ’ ἀφῖγμαι διαφυγοῦσα πολεμίους.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1255">ποῖ δ’ ἂν ἄλλοσ’ ἢ ’πὶ βωμόν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">καὶ τί μοι πλέον τόδε;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἱκέτιν οὐ θέμις φονεύειν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">τῷ νόμῳ δέ γ’ ὄλλυμαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χειρία γ’ ἁλοῦσα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">καὶ μὴν οἵδ’ ἀγωνισταὶ πικροὶ</l>
 						<l>δεῦρ’ ἐπείγονται ξιφήρεις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἵζε νυν πυρᾶς ἔπι.</l>
 						<l>κἂν θάνῃς γὰρ ἐνθάδ’ οὖσα, τοῖς ἀποκτείνασί σε</l>
@@ -2891,7 +2891,7 @@ bring up to P3
 						<l>ὡς οὐ δίκην δώσουσα τῶν εἰργασμένων.</l>
 						<milestone ed="p" n="1282" unit="card"/>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἀπεννέπω σε μὴ κατακτείνειν ἐμὲ</l>
 						<l>ὑπέρ τ’ ἐμαυτῆς τοῦ θεοῦ θ’ ἵν’ ἕσταμεν.</l>
@@ -2900,7 +2900,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τί δ’ ἐστὶ Φοίβῳ σοί τε κοινὸν ἐν μέσῳ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1285">ἱερὸν τὸ σῶμα τῷ θεῷ δίδωμ’ ἔχειν.</l>
 					</sp>
@@ -2908,7 +2908,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>κἄπειτ’ ἔκαινες φαρμάκοις τὸν τοῦ θεοῦ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἀλλ’ οὐκέτ’ ἦσθα Λοξίου, πατρὸς δὲ σοῦ.</l>
 					</sp>
@@ -2916,7 +2916,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἀλλ’ ἐγενόμεσθα πατρός· οὐσίαν λέγω.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οὐκοῦν τότ’ ἦσθα· νῦν δ’ ἐγώ, σὺ δ’ οὐκέτι.</l>
 					</sp>
@@ -2924,7 +2924,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1290">οὐκ εὐσεβεῖς γε· τἀμὰ δ’ εὐσεβῆ τότ’ ἦν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἔκτεινά σ’ ὄντα πολέμιον δόμοις ἐμοῖς.</l>
 					</sp>
@@ -2932,7 +2932,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>οὔτοι σὺν ὅπλοις ἦλθον ἐς τὴν σὴν χθόνα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>μάλιστα· κἀπίμπρης γ’ Ἐρεχθέως δόμους.</l>
 					</sp>
@@ -2940,7 +2940,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ποίοισι πανοῖς ἢ πυρὸς ποίᾳ φλογί;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1295">ἔμελλες οἰκεῖν τἄμ’, ἐμοῦ βίᾳ λαβών.</l>
 					</sp>
@@ -2948,7 +2948,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πατρός γε γῆν διδόντος ἣν ἐκτήσατο.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τοῖς Αἰόλου δὲ πῶς μετῆν τῶν Παλλάδος;</l>
 					</sp>
@@ -2956,7 +2956,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὅπλοισιν αὐτήν, οὐ λόγοις ἐρρύσατο.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐπίκουρος οἰκήτωρ γ’ ἂν οὐκ εἴη χθονός.</l>
 					</sp>
@@ -2964,7 +2964,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1300">κἄπειτα τοῦ μέλλειν μ’ ἀπέκτεινες φόβῳ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ὡς μὴ θάνοιμί γ’, εἰ σὺ μὴ μέλλων τύχοις.</l>
 					</sp>
@@ -2972,7 +2972,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>φθονεῖς ἄπαις οὖσ’, εἰ πατὴρ ἐξηῦρέ με.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>σὺ τῶν ἀτέκνων δῆτ’ ἀναρπάσεις δόμους;</l>
 					</sp>
@@ -2980,7 +2980,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἡμῖν δέ γ’ ἀλλὰ πατρικῆς οὐκ ἦν μέρος;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1305">ὅσ’ ἀσπὶς ἔγχος θ’· ἥδε σοι παμπησία.</l>
 					</sp>
@@ -2988,7 +2988,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἔκλειπε βωμὸν καὶ θεηλάτους ἕδρας.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τὴν σὴν ὅπου σοι μητέρ’ ἐστὶ νουθέτει.</l>
 					</sp>
@@ -2996,7 +2996,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>σὺ δ’ οὐχ ὑφέξεις ζημίαν, κτείνουσ’ ἐμέ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἤν γ’ ἐντὸς ἀδύτων τῶνδέ με σφάξαι θέλῃς.</l>
 					</sp>
@@ -3004,7 +3004,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1310">τίς ἡδονή σοι θεοῦ θανεῖν ἐν στέμμασι;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>λυπήσομέν τιν’, ὧν λελυπήμεσθ’ ὕπο.</l>
 					</sp>
@@ -3021,7 +3021,7 @@ bring up to P3
 						<l>τόν τ’ ἐσθλὸν ὄντα τόν τε μὴ θεῶν πάρα.</l>
 						<milestone ed="p" n="1320" unit="card"/>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l n="1320">ἐπίσχες, ὦ παῖ· τρίποδα γὰρ χρηστήριον</l>
 						<l>λιποῦσα θριγκοῦ τοῦδ’ ὑπερβάλλω πόδα</l>
@@ -3032,7 +3032,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>χαῖρ’, ὦ φίλη μοι μῆτερ, οὐ τεκοῦσά περ.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l n="1325">ἀλλ’ οὖν λεγώμεθ’· ἡ φάτις δ’ οὔ μοι πικρά.</l>
 					</sp>
@@ -3040,7 +3040,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἤκουσας ὥς μ’ ἔκτεινεν ἥδε μηχαναῖς;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>ἤκουσα· καὶ σὺ δ’ ὠμὸς ὢν ἁμαρτάνεις.</l>
 					</sp>
@@ -3048,7 +3048,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>οὐ χρή με τοὺς κτείνοντας ἀνταπολλύναι;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>προγονοῖς δάμαρτες δυσμενεῖς ἀεί ποτε.</l>
 					</sp>
@@ -3056,7 +3056,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1330">ἡμεῖς δὲ μητρυιαῖς γε πάσχοντες κακῶς.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>μὴ ταῦτα· λείπων ἱερὰ καὶ στείχων πάτραν — </l>
 					</sp>
@@ -3064,7 +3064,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τί δή με δρᾶσαι νουθετούμενον χρεών;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>καθαρὸς Ἀθήνας ἔλθ’ ὑπ’ οἰωνῶν καλῶν.</l>
 					</sp>
@@ -3072,7 +3072,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>καθαρὸς ἅπας τοι πολεμίους ὃς ἂν κτάνῃ.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l n="1335">μὴ σύ γε· παρ’ ἡμῶν δ’ ἔκλαβ’ οὓς ἔχω λόγους.</l>
 					</sp>
@@ -3080,7 +3080,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>λέγοις ἄν· εὔνους δ’ οὖσ’ ἐρεῖς ὅσ’ ἂν λέγῃς.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>ὁρᾷς τόδ’ ἄγγος χερὸς ὑπ’ ἀγκάλαις ἐμαῖς;</l>
 					</sp>
@@ -3088,7 +3088,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὁρῶ παλαιὰν ἀντίπηγ’ ἐν στέμμασιν.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>ἐν τῇδέ σ’ ἔλαβον νεόγονον βρέφος ποτέ.</l>
 					</sp>
@@ -3096,7 +3096,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1340">τί φῄς; ὁ μῦθος εἰσενήνεκται νέος.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>σιγῇ γὰρ εἶχον αὐτά· νῦν δὲ δείκνυμεν.</l>
 					</sp>
@@ -3104,7 +3104,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πῶς οὖν ἔκρυπτες τόδε λαβοῦσ’ ἡμᾶς πάλαι;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>ὁ θεός σ’ ἐβούλετ’ ἐν δόμοις ἔχειν λάτριν.</l>
 					</sp>
@@ -3112,7 +3112,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>νῦν δ’ οὐχὶ χρῄζει; τῷ τόδε γνῶναί με χρή;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l n="1345">πατέρα κατειπὼν τῆσδέ σ’ ἐκπέμπει χθονός.</l>
 					</sp>
@@ -3120,7 +3120,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>σὺ δ’ ἐκ κελευσμῶν ἢ πόθεν σῴζεις τάδε;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>ἐνθύμιόν μοι τότε τίθησι Λοξίας — </l>
 					</sp>
@@ -3128,7 +3128,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τί χρῆμα δρᾶσαι; λέγε, πέραινε σοὺς λόγους.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>σῶσαι τόδ’ εὕρημ’ ἐς τὸν ὄντα νῦν χρόνον.</l>
 					</sp>
@@ -3136,7 +3136,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1350">ἔχει δέ μοι τί κέρδος — ἢ τίνα βλάβην;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>ἐνθάδε κέκρυπται σπάργαν’ οἷς ἐνῆσθα σύ.</l>
 					</sp>
@@ -3144,7 +3144,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>μητρὸς τάδ’ ἡμῖν ἐκφέρεις ζητήματα;</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>ἐπεί γ’ ὁ δαίμων βούλεται· πάροιθε δ’ οὔ.</l>
 					</sp>
@@ -3152,7 +3152,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὦ μακαρίων μοι φασμάτων ἥδ’ ἡμέρα.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l n="1355">λαβών νυν αὐτὰ τὴν τεκοῦσαν ἐκπόνει.</l>
 					</sp>
@@ -3160,7 +3160,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πᾶσάν γ’ ἐπελθὼν Ἀσιάδ’ Εὐρώπης θ’ ὅρους.</l>
 					</sp>
-					<sp who="#profetis">
+					<sp who="#prophetis">
 						<speaker>Προφῆτις</speaker>
 						<l>γνώσῃ τάδ’ αὐτός. τοῦ θεοῦ δ’ ἕκατί σε</l>
 						<l>ἔθρεψά τ’, ὦ παῖ, καὶ τάδ’ ἀποδίδωμί σοι,</l>
@@ -3209,7 +3209,7 @@ bring up to P3
 						<l>χρόνος πολὺς δὴ τοῖσδε θησαυρίσμασιν.</l>
 						<milestone ed="p" n="1395" unit="card"/>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1395">τί δῆτα φάσμα τῶν ἀνελπίστων ὁρῶ;</l>
 					</sp>
@@ -3217,7 +3217,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>σίγα σύ· πολλὰ καὶ πάροιθεν οἶσθά μοι — </l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οὐκ ἐν σιωπῇ τἀμά· μή με νουθέτει.</l>
 						<l>ὁρῶ γὰρ ἄγγος οὗ ’ξέθηκ’ ἐγώ ποτε — </l>
@@ -3230,7 +3230,7 @@ bring up to P3
 						<l>λάζυσθε τήνδε· θεομανὴς γὰρ ἥλατο</l>
 						<l>βωμοῦ λιποῦσα ξόανα· δεῖτε δ’ ὠλένας.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>σφάζοντες οὐ λήγοιτ’ ἄν· ὡς ἀνθέξομαι</l>
 						<l n="1405">καὶ τῆσδε καὶ σοῦ τῶν τε σῶν κεκρυμμένων.</l>
@@ -3239,7 +3239,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τάδ’ οὐχὶ δεινά; ῥυσιάζομαι λόγῳ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οὔκ, ἀλλὰ σοῖς φίλοισιν εὑρίσκῃ φίλος.</l>
 					</sp>
@@ -3247,7 +3247,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἐγὼ φίλος σός; κᾆτά μ’ ἔκτεινες λάθρα;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>παῖς γ’, εἰ τόδ’ ἐστὶ τοῖς τεκοῦσι φίλτατον.</l>
 					</sp>
@@ -3255,7 +3255,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1410">παῦσαι πλέκουσα.  — λήψομαί σ’ ἐγὼ καλῶς.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐς τοῦθ’ ἱκοίμην, τοῦδε τοξεύω, τέκνον.</l>
 					</sp>
@@ -3263,7 +3263,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>κενὸν τόδ’ ἄγγος ἢ στέγει πλήρωμά τι;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>σά γ’ ἔνδυθ’, οἷσί σ’ ἐξέθηκ’ ἐγώ ποτε.</l>
 					</sp>
@@ -3271,7 +3271,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>καὶ τοὔνομ’ αὐτῶν ἐξερεῖς πρὶν εἰσιδεῖν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1415">κἂν μὴ φράσω γε, κατθανεῖν ὑφίσταμαι.</l>
 					</sp>
@@ -3279,7 +3279,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>λέγ’· ὡς ἔχει τι δεινὸν ἥ γε τόλμα σου.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>σκέψασθ’· ὃ παῖς ποτ’ οὖσ’ ὕφασμ’ ὕφην’ ἐγὼ — </l>
 					</sp>
@@ -3287,7 +3287,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ποῖόν τι; πολλὰ παρθένων ὑφάσματα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οὐ τέλεον, οἷον δ’ ἐκδίδαγμα κερκίδος.</l>
 					</sp>
@@ -3295,7 +3295,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1420">μορφὴν ἔχον τίν’; ὥς με μὴ ταύτῃ λάβῃς.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>Γοργὼ μὲν ἐν μέσοισιν ἠτρίοις πέπλων.</l>
 					</sp>
@@ -3303,7 +3303,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὦ Ζεῦ, τίς ἡμᾶς ἐκκυνηγετεῖ πότμος;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>κεκρασπέδωται δ’ ὄφεσιν αἰγίδος τρόπον.</l>
 					</sp>
@@ -3312,7 +3312,7 @@ bring up to P3
 						<l>ἰδού·</l>
 						<l>τόδ’ ἔσθ’ ὕφασμα, θέσφαθ’ ὡς εὑρίσκομεν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1425">ὦ χρόνιον ἱστῶν παρθένευμα τῶν ἐμῶν.</l>
 					</sp>
@@ -3320,7 +3320,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἔστιν τι πρὸς τῷδ’, ἢ μόνῳ τῷδ’ εὐτυχεῖς;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>δράκοντες· ἀρχαῖόν τι παγχρύσῳ γένει</l>
 						<l>δώρημ’ Ἀθάνας, ἣ τέκν’ ἐντρέφειν λέγει — </l>
@@ -3330,7 +3330,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1430">τί δρᾶν, τί χρῆσθαι, φράζε μοι, χρυσώματι;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>δέραια παιδὶ νεογόνῳ φέρειν, τέκνον.</l>
 					</sp>
@@ -3338,7 +3338,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ἔνεισιν οἵδε· τὸ δὲ τρίτον ποθῶ μαθεῖν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>στέφανον ἐλαίας ἀμφέθηκά σοι τότε,</l>
 						<l>ἣν πρῶτ’ Ἀθάνα σκόπελον εἰσηνέγκατο,</l>
@@ -3351,7 +3351,7 @@ bring up to P3
 						<l>ὦ φιλτάτη μοι μῆτερ, ἄσμενός σ’ ἰδὼν</l>
 						<l>πρὸς ἀσμένας πέπτωκα σὰς παρηίδας.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ὦ τέκνον, ὦ φῶς μητρὶ κρεῖσσον ἡλίου — </l>
 						<l n="1440">συγγνώσεται γὰρ ὁ θεός — ἐν χεροῖν σ’ ἔχω,</l>
@@ -3366,7 +3366,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1445">ἰὼ ἰώ, λαμπρᾶς αἰθέρος ἀμπτυχαί,</l>
 						<l>τίν’ αὐδὰν ἀύσω,</l>
@@ -3379,7 +3379,7 @@ bring up to P3
 						<l n="1450">ἐμοὶ γενέσθαι πάντα μᾶλλον ἄν ποτε,</l>
 						<l>μῆτερ, παρέστη τῶνδ’, ὅπως σός εἰμ’ ἐγώ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἔτι φόβῳ τρέμω.</l>
 					</sp>
@@ -3387,7 +3387,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>μῶν οὐκ ἔχειν μ’ ἔχουσα;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">τὰς γὰρ ἐλπίδας</l>
 						<l>ἀπέβαλον πρόσω.</l>
@@ -3400,7 +3400,7 @@ bring up to P3
 						<l>θεῖον τόδ’· ἀλλὰ τἀπίλοιπα τῆς τύχης</l>
 						<l>εὐδαιμονοῖμεν, ὡς τὰ πρόσθε δυστυχῆ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τέκνον, οὐκ ἀδάκρυτος ἐκλοχεύῃ,</l>
 						<l>γόοις δὲ ματρὸς ἐκ χερῶν ὁρίζῃ·</l>
@@ -3411,7 +3411,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>τοὐμὸν λέγουσα καὶ τὸ σὸν κοινῶς λέγεις.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἄπαιδες οὐκέτ’ ἐσμὲν οὐδ’ ἄτεκνοι·</l>
 						<l>δῶμ’ ἑστιοῦται, γᾶ δ’ ἔχει τυράννους·</l>
@@ -3425,7 +3425,7 @@ bring up to P3
 						<l>μῆτερ, παρών μοι καὶ πατὴρ μετασχέτω</l>
 						<l>τῆς ἡδονῆς τῆσδ’ ἧς ἔδωχ’ ὑμῖν ἐγώ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1470">ὦ τέκνον,</l>
 						<l>τί φῄς; οἷον οἷον ἀνελέγχομαι.</l>
@@ -3434,7 +3434,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>πῶς εἶπας;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">ἄλλοθεν γέγονας, ἄλλοθεν.</l>
 					</sp>
@@ -3442,7 +3442,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὤμοι· νόθον με παρθένευμ’ ἔτικτε σόν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>οὐχ ὑπὸ λαμπάδων οὐδὲ χορευμάτων</l>
 						<l n="1475">ὑμέναιος ἐμός,</l>
@@ -3452,7 +3452,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>αἰαῖ· πέφυκα δυσγενής. μῆτερ, πόθεν;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἴστω Γοργοφόνα — </l>
 					</sp>
@@ -3460,7 +3460,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l part="Y">τί τοῦτ’ ἔλεξας;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἃ σκοπέλοις ἐπ’ ἐμοῖς</l>
 						<l n="1480">τὸν ἐλαιοφυῆ πάγον</l>
@@ -3470,7 +3470,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l part="Y">λέγεις μοι δόλια κοὐ σαφῆ τάδε.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>παρ’ ἀηδόνιον πέτραν</l>
 						<l>Φοίβῳ — </l>
@@ -3479,7 +3479,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l part="Y">τί Φοῖβον αὐδᾷς;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>κρυπτόμενον λέχος ηὐνάσθην . . .</l>
 					</sp>
@@ -3487,7 +3487,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l n="1485">λέγ’· ὡς ἐρεῖς τι κεδνὸν εὐτυχές τέ μοι.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>δεκάτῳ δέ σε μηνὸς ἐν</l>
 						<l>κύκλῳ κρύφιον ὠδῖν’ ἔτεκον Φοίβῳ.</l>
@@ -3496,7 +3496,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὦ φίλτατ’ εἰποῦσ’, εἰ λέγεις ἐτήτυμα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>παρθένια δ’ ἐμᾶς &lt;λάθρα&gt; ματέρος</l>
 						<l n="1490">σπάργαν’ ἀμφίβολά σοι τάδ’ ἐνῆψα, κερ‐</l>
@@ -3511,7 +3511,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l>ὦ δεινὰ τλᾶσα μῆτερ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l part="Y">ἐν φόβῳ, τέκνον,</l>
 						<l>καταδεθεῖσα σὰν</l>
@@ -3522,7 +3522,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l part="Y">ἐξ ἐμοῦ τ’ [οὐχ ὅσῑ] ἔθνῃσκες.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l n="1502">ἰώ· δειναὶ μὲν τότε τύχαι,</l>
 						<l>δεινὰ δὲ καὶ τάδ’· ἑλισσόμεσθ’ ἐκεῖθεν</l>
@@ -3534,7 +3534,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1510">μηδεὶς δοκείτω μηδὲν ἀνθρώπων ποτὲ</l>
 						<l>ἄελπτον εἶναι πρὸς τὰ τυγχάνοντα νῦν.</l>
@@ -3559,7 +3559,7 @@ bring up to P3
 						<l>καὶ τοὐμὸν αἰσχρὸν ἀποφυγεῖν πειρωμένη,</l>
 						<l>Φοίβῳ τεκεῖν με φῄς, τεκοῦσ’ οὐκ ἐκ θεοῦ;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>μὰ τὴν παρασπίζουσαν ἅρμασίν ποτε</l>
 						<l>Νίκην Ἀθηνᾶν Ζηνὶ γηγενεῖς ἔπι,</l>
@@ -3571,7 +3571,7 @@ bring up to P3
 						<l>πῶς οὖν τὸν αὑτοῦ παῖδ’ ἔδωκ’ ἄλλῳ πατρὶ</l>
 						<l>Ξούθου τέ φησι παῖδά μ’ ἐκπεφυκέναι;</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>πεφυκέναι μὲν οὐχί, δωρεῖται δέ σε</l>
 						<l n="1535">αὑτοῦ γεγῶτα· καὶ γὰρ ἂν φίλος φίλῳ</l>
@@ -3582,7 +3582,7 @@ bring up to P3
 						<l>ὁ θεὸς ἀληθὴς ἢ μάτην μαντεύεται,</l>
 						<l>ἐμοῦ ταράσσει, μῆτερ, εἰκότως φρένα.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἄκουε δή νυν ἅμ’ ἐσῆλθεν, ὦ τέκνον·</l>
 						<l n="1540">εὐεργετῶν σε Λοξίας ἐς εὐγενῆ</l>
@@ -3677,7 +3677,7 @@ bring up to P3
 						<l>σοὺς λόγους ἐδεξάμεσθα· πείθομαι δ’ εἶναι πατρὸς</l>
 						<l>Λοξίου καὶ τῆσδε. — καὶ πρὶν τοῦτο δ’ οὐκ ἄπιστον ἦν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>τἀμὰ νῦν ἄκουσον· αἰνῶ Φοῖβον οὐκ αἰνοῦσα πρίν,</l>
 						<l n="1610">οὕνεχ’ οὗ ποτ’ ἠμέλησε παιδὸς ἀποδίδωσί μοι.</l>
@@ -3690,7 +3690,7 @@ bring up to P3
 						<l>ᾔνεσ’ οὕνεκ’ εὐλογεῖς θεὸν μεταβαλοῦσ’· ἀεὶ γὰρ οὖν</l>
 						<l n="1615">χρόνια μὲν τὰ τῶν θεῶν πως, ἐς τέλος δ’ οὐκ ἀσθενῆ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ὦ τέκνον, στείχωμεν οἴκους.</l>
 					</sp>
@@ -3698,7 +3698,7 @@ bring up to P3
 						<speaker>Ἀθήνα</speaker>
 						<l part="Y">στείχεθ’, ἕψομαι δ’ ἐγώ.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἀξία γ’ ἡμῶν ὁδουρός.</l>
 					</sp>
@@ -3706,7 +3706,7 @@ bring up to P3
 						<speaker>Ἀθήνα</speaker>
 						<l part="Y">καὶ φιλοῦσά γε πτόλιν.</l>
 					</sp>
-					<sp who="#kreoysa">
+					<sp who="#kreousa">
 						<speaker>Κρέουσα</speaker>
 						<l>ἐς θρόνους δ’ ἵζου παλαιούς.</l>
 					</sp>
@@ -3714,7 +3714,7 @@ bring up to P3
 						<speaker>Ἴων</speaker>
 						<l part="Y">ἄξιον τὸ κτῆμά μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Διὸς Λητοῦς τ’ Ἄπολλον, χαῖρ’· ὅτῳ δ’ ἐλαύνεται</l>
 						<l n="1620">συμφοραῖς οἶκος, σέβοντα δαίμονας θαρσεῖν χρεών·</l>

--- a/tei/euripides-iphigenia-in-aulis.xml
+++ b/tei/euripides-iphigenia-in-aulis.xml
@@ -51,13 +51,13 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="axilleys" sex="MALE">
+					<person xml:id="achilleus" sex="MALE">
 						<persName>Ἀχιλλεύς</persName>
 					</person>
 					<person xml:id="menelaos" sex="MALE">
 						<persName>Μενέλαος</persName>
 					</person>
-					<person xml:id="aggelosa" sex="MALE">
+					<person xml:id="angelos_a" sex="MALE">
 						<persName>Αγγελος Α</persName>
 					</person>
 					<person xml:id="agamemnon" sex="MALE">
@@ -72,13 +72,13 @@
 					<person xml:id="klytaimestra" sex="FEMALE">
 						<persName>Κλυταιμήστρα</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="FEMALE">
+					<personGrp xml:id="choros" sex="FEMALE">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="ifigeneia" sex="FEMALE">
+					<person xml:id="iphigeneia" sex="FEMALE">
 						<persName>Ἰφιγένεια</persName>
 					</person>
-					<person xml:id="aggelos" sex="MALE">
+					<person xml:id="angelos" sex="MALE">
 						<persName>Ἄγγελος</persName>
 					</person>
 				</listPerson>
@@ -415,7 +415,7 @@ convert to P3
 			<milestone ed="p" n="164" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔμολον ἀμφὶ παρακτίαν</l>
 						<l n="165">ψάμαθον Αὐλίδος ἐναλίας,</l>
@@ -442,7 +442,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="185">πολύθυτον δὲ δῑ ἄλσος Ἀρ‐</l>
 						<l>τέμιδος ἤλυθον ὀρομένα,</l>
@@ -469,7 +469,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="mesode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν ἰσάνεμόν τε ποδοῖν</l>
 						<l>λαιψηροδρόμον Ἀχιλῆα,</l>
@@ -497,7 +497,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ναῶν δ’ εἰς ἀριθμὸν ἤλυθον</l>
 						<l>καὶ θέαν ἀθέσφατον,</l>
@@ -514,7 +514,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἀργείων δὲ ταῖσδ’ ἰσήρετμοι</l>
 						<l>νᾶες ἕστασαν πέλας·</l>
@@ -531,7 +531,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Βοιωτῶν δ’ ὅπλισμα πόντιον</l>
 						<l>πεντήκοντα νῆας εἰδόμαν</l>
@@ -549,7 +549,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="265">Μυκήνας δὲ τᾶς Κυκλωπίας</l>
 						<l>παῖς Ἀτρέως ἔπεμπε ναυβάτας</l>
@@ -567,7 +567,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Αἰνιάνων δὲ δωδεκάστολοι</l>
 						<l>νᾶες ἦσαν, ὧν ἄναξ</l>
@@ -584,7 +584,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="4" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="288">Αἴας δ’ ὁ Σαλαμῖνος ἔντροφος</l>
 						<l n="290">δεξιὸν κέρας † πρὸς τὸ λαιὸν ξυνᾶγε †,</l>
@@ -777,7 +777,7 @@ convert to P3
 						<l n="375">πόλεος ὡς ἄρχων ἀνὴρ πᾶς, ξύνεσιν ἢν ἔχων τύχῃ.</l>
 					</sp>
 					<milestone ed="p" n="376" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεινὸν κασιγνήτοισι γίγνεσθαι λόγους</l>
 						<l>μάχας θ’, ὅταν ποτ’ ἐμπέσωσιν εἰς ἔριν.</l>
@@ -814,7 +814,7 @@ convert to P3
 				</div2>
 				<div2 type="dialogue">
 					<milestone ed="p" n="402" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἵδ’ αὖ διάφοροι τῶν πάρος λελεγμένων</l>
 						<l>μύθων, καλῶς δ’ ἔχουσι, φείδεσθαι τέκνων.</l>
@@ -857,7 +857,7 @@ convert to P3
 						<l>ἐγὼ δ’ ἐπ’ ἄλλας εἶμι μηχανάς τινας</l>
 						<l>φίλους τ’ ἐπ’ ἄλλους — </l>
 					</sp>
-					<sp who="#aggelosa">
+					<sp who="#angelos_a">
 						<speaker>Αγγελος Α</speaker>
 						<l part="Y">ὦ Πανελλήνων ἄναξ,</l>
 						<l n="415">Ἀγάμεμνον, ἥκω παῖδά σοι τὴν σὴν ἄγων,</l>
@@ -919,7 +919,7 @@ convert to P3
 						<l>αἰαῖ, τὸν Ἑλένης ὥς μ’ ἀπώλεσεν γάμον</l>
 						<l>γήμας ὁ Πριάμου Πάρις, ὃς εἴργασται τάδε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κἀγὼ κατῴκτιρ’, ὡς γυναῖκα δεῖ ξένην</l>
 						<l n="470">ὑπὲρ τυράννων συμφορᾶς καταστένειν.</l>
@@ -967,7 +967,7 @@ convert to P3
 						<l>στέργων μετέπεσον. ἀνδρὸς οὐ κακοῦ τροπαὶ</l>
 						<l>τοιαίδε, χρῆσθαι τοῖσι βελτίστοις ἀεί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>γενναῖ’ ἔλεξας Ταντάλῳ τε τῷ Διὸς</l>
 						<l n="505">πρέποντα· προγόνους οὐ καταισχύνεις σέθεν.</l>
@@ -1066,7 +1066,7 @@ convert to P3
 			<milestone ed="p" n="543" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μάκαρες οἳ μετρίας θεοῦ</l>
 						<l>μετά τε σωφροσύνας μετέ‐</l>
@@ -1087,7 +1087,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>διάφοροι δὲ φύσεις βροτῶν,</l>
 						<l>διάφοροι δὲ τρόποι· τὸ δ’ ὀρ‐</l>
@@ -1108,7 +1108,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔμολες, ὦ Πάρις, ᾗτε σύ γε</l>
 						<l>βουκόλος ἀργενναῖς ἐτράφης</l>
@@ -1146,7 +1146,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στῶμεν, Χαλκίδος ἔκγονα θρέμματα,</l>
 						<l>τὴν βασίλειαν δεξώμεθ’ ὄχων</l>
@@ -1186,7 +1186,7 @@ convert to P3
 						<l>ξέναισι ταῖσδε πλησία σταθεῖσα δός,</l>
 						<l n="630">καὶ — δεῦρο δὴ — πατέρα πρόσειπε σὸν φίλον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ μῆτερ, ὑποδραμοῦσά σ’· ὀργισθῇς δὲ μή·</l>
 						<l>πρὸς στέρνα πατρὸς στέρνα τἀμὰ περιβαλῶ.</l>
@@ -1196,7 +1196,7 @@ convert to P3
 						<l>ὦ σέβας ἐμοὶ μέγιστον, Ἀγαμέμνων ἄναξ,</l>
 						<l>ἥκομεν, ἐφετμαῖς οὐκ ἀπιστοῦσαι σέθεν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="635">[ἐγὼ δὲ βούλομαι τὰ σὰ στέρν’, ὦ πάτερ,</l>
 						<l>ὑποδραμοῦσα προσβαλεῖν διὰ χρόνου·]</l>
@@ -1208,7 +1208,7 @@ convert to P3
 						<l>μάλιστα παίδων τῷδ’ ὅσους ἐγὼ ’τεκον.</l>
 					</sp>
 					<milestone ed="p" n="640" unit="card"/>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="640">ὦ πάτερ, ἐσεῖδόν σ’ ἀσμένη πολλῷ χρόνῳ.</l>
 					</sp>
@@ -1216,7 +1216,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>καὶ γὰρ πατὴρ σέ· τόδ’ ἴσον ὑπὲρ ἀμφοῖν λέγεις.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>χαῖρ’· εὖ δέ μ’ ἀγαγὼν πρὸς σ’ ἐποίησας, πάτερ.</l>
 					</sp>
@@ -1224,7 +1224,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>οὐκ οἶδ’ ὅπως φῶ τοῦτο καὶ μὴ φῶ, τέκνον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἔα·</l>
 						<l>ὡς οὐ βλέπεις ἕκηλον ἄσμενός μ’ ἰδών.</l>
@@ -1233,7 +1233,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="645">πόλλ’ ἀνδρὶ βασιλεῖ καὶ στρατηλάτῃ μέλει.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>παρ’ ἐμοὶ γενοῦ νῦν, μὴ ’πὶ φροντίδας τρέπου.</l>
 					</sp>
@@ -1241,7 +1241,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ἀλλ’ εἰμὶ παρὰ σοὶ νῦν ἅπας κοὐκ ἄλλοθι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μέθες νυν ὀφρὺν ὄμμα τ’ ἔκτεινον φίλον.</l>
 					</sp>
@@ -1249,7 +1249,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ἰδού, γέγηθά σ’ ὡς γέγηθ’ ὁρῶν, τέκνον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="650">κἄπειτα λείβεις δάκρῡ ἀπ’ ὀμμάτων σέθεν;</l>
 					</sp>
@@ -1257,7 +1257,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>μακρὰ γὰρ ἡμῖν ἡ ’πιοῦσ’ ἀπουσία.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>† οὐκ οἶδ’ ὅ τι φῄς, οὐκ οἶδα, φίλτατ’ ἐμοὶ πάτερ. †</l>
 					</sp>
@@ -1265,7 +1265,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>συνετὰ λέγουσα μᾶλλον εἰς οἶκτόν μ’ ἄγεις.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἀσύνετά νυν ἐροῦμεν, εἰ σέ γ’ εὐφρανῶ.</l>
 					</sp>
@@ -1273,7 +1273,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="655">παπαῖ. τὸ σιγᾶν οὐ σθένω· σὲ δ’ ᾔνεσα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μέν’, ὦ πάτερ, κατ’ οἶκον ἐπὶ τέκνοις σέθεν.</l>
 					</sp>
@@ -1281,7 +1281,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>θέλω γε· τὸ θέλειν δ’ οὐκ ἔχων ἀλγύνομαι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὄλοιντο λόγχαι καὶ τὰ Μενέλεω κακά.</l>
 					</sp>
@@ -1289,7 +1289,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ἄλλους ὀλεῖ πρόσθ’ ἃ ἐμὲ διολέσαντ’ ἔχει.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="660">ὡς πολὺν ἀπῆσθα χρόνον ἐν Αὐλίδος μυχοῖς.</l>
 					</sp>
@@ -1297,7 +1297,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>καὶ νῦν γέ μ’ ἴσχει δή τι μὴ στέλλειν στρατόν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ποῦ τοὺς Φρύγας λέγουσιν ᾠκίσθαι, πάτερ;</l>
 					</sp>
@@ -1305,7 +1305,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>οὗ μήποτ’ οἰκεῖν ὤφελ’ ὁ Πριάμου Πάρις.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μακρὰν ἀπαίρεις, ὦ πάτερ, λιπὼν ἐμέ.</l>
 					</sp>
@@ -1313,7 +1313,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="665">† εἰς ταὐτόν, ὦ θύγατερ, ἥκεις σῷ πατρί. †</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>φεῦ·</l>
 						<l>εἴθ’ ἦν καλόν μοι σοί τ’ ἄγειν σύμπλουν ἐμέ.</l>
@@ -1322,7 +1322,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ἔτ’ ἔστι καὶ σοὶ πλοῦς, ἵν’ ἀμμνήσῃ πατρός.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>σὺν μητρὶ πλεύσασ’ ἢ μόνη πορεύσομαι;</l>
 					</sp>
@@ -1330,7 +1330,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>μόνη, μονωθεῖσ’ ἀπὸ πατρὸς καὶ μητέρος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="670">οὔ πού μ’ ἐς ἄλλα δώματ’ οἰκίζεις, πάτερ;</l>
 					</sp>
@@ -1338,7 +1338,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>ἐατέ’· οὐ χρὴ τοιάδ’ εἰδέναι κόρας.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>σπεῦδ’ ἐκ Φρυγῶν μοι, θέμενος εὖ τἀκεῖ, πάτερ.</l>
 					</sp>
@@ -1346,7 +1346,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l>θῦσαί με θυσίαν πρῶτα δεῖ τιν’ ἐνθάδε.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἀλλὰ ξὺν ἱεροῖς χρὴ τό γ’ εὐσεβὲς σκοπεῖν.</l>
 					</sp>
@@ -1354,7 +1354,7 @@ convert to P3
 						<speaker>Ἀγαμέμνων</speaker>
 						<l n="675">εἴσῃ σύ· χερνίβων γὰρ ἑστήξῃ πέλας.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>στήσομεν ἄρ’ ἀμφὶ βωμόν, ὦ πάτερ, χορούς;</l>
 					</sp>
@@ -1582,7 +1582,7 @@ convert to P3
 			<milestone ed="p" n="751" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἥξει δὴ Σιμόεντα καὶ</l>
 						<l>δίνας ἀργυροειδεῖς</l>
@@ -1599,7 +1599,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στάσονται δ’ ἐπὶ περγάμων</l>
 						<l>Τροίας ἀμφί τε τείχη</l>
@@ -1616,7 +1616,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Πέργαμον δὲ Φρυγῶν πόλιν</l>
 						<l>λαΐνους περὶ πύργους</l>
@@ -1651,7 +1651,7 @@ convert to P3
 			</div1>
 			<milestone ed="p" n="801" unit="card"/>
 			<div1 type="episode">
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>ποῦ τῶν Ἀχαιῶν ἐνθάδ’ ὁ στρατηλάτης;</l>
 					<l>τίς ἂν φράσειε προσπόλων τὸν Πηλέως</l>
@@ -1677,7 +1677,7 @@ convert to P3
 					<l>ὦ παῖ θεᾶς Νηρῇδος, ἔνδοθεν λόγων</l>
 					<l n="820">τῶν σῶν ἀκούσασ’ ἐξέβην πρὸ δωμάτων.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>ὦ πότνῑ αἰδώς, τήνδε τίνα λεύσσω ποτὲ</l>
 					<l>γυναῖκα, μορφὴν εὐπρεπῆ κεκτημένην;</l>
@@ -1687,7 +1687,7 @@ convert to P3
 					<l>οὐ θαῦμά σ’ ἡμᾶς ἀγνοεῖν, οἷς μὴ πάρος</l>
 					<l>προσῆκες· αἰνῶ δ’ ὅτι σέβεις τὸ σωφρονεῖν.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l n="825">τίς δ’ εἶ; τί δ’ ἦλθες Δαναϊδῶν ἐς σύλλογον,</l>
 					<l>γυνὴ πρὸς ἄνδρας ἀσπίσιν πεφραγμένους;</l>
@@ -1697,7 +1697,7 @@ convert to P3
 					<l>Λήδας μέν εἰμι παῖς, Κλυταιμήστρα δέ μοι</l>
 					<l>ὄνομα, πόσις δέ μοὐστὶν Ἀγαμέμνων ἄναξ.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>καλῶς ἔλεξας ἐν βραχεῖ τὰ καίρια.</l>
 					<l n="830">αἰσχρὸν δέ μοι γυναιξὶ συμβάλλειν λόγους.</l>
@@ -1708,7 +1708,7 @@ convert to P3
 					<l>μεῖνον — τί φεύγεις;  — δεξιάν τ’ ἐμῇ χερὶ</l>
 					<l>σύναψον, ἀρχὴν μακαρίαν νυμφευμάτων.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>τί φῄς; ἐγώ σοι δεξιάν; αἰδοίμεθ’ ἂν</l>
 					<l>Ἀγαμέμνον’, εἰ ψαύοιμεν ὧν μή μοι θέμις.</l>
@@ -1718,7 +1718,7 @@ convert to P3
 					<l n="835">θέμις μάλιστα, τὴν ἐμὴν ἐπεὶ γαμεῖς</l>
 					<l>παῖδ’, ὦ θεᾶς παῖ ποντίας Νηρηίδος.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>ποίους γάμους φῄς; ἀφασία μ’ ἔχει, γύναι·</l>
 					<l>εἰ μή τι παρανοοῦσα καινουργεῖς λόγον;</l>
@@ -1728,7 +1728,7 @@ convert to P3
 					<l>πᾶσιν τόδ’ ἐμπέφυκεν, αἰδεῖσθαι φίλους</l>
 					<l n="840">καινοὺς ὁρῶσι καὶ γάμου μεμνημένοις.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>οὐπώποτ’ ἐμνήστευσα παῖδα σήν, γύναι,</l>
 					<l>οὐδ’ ἐξ Ἀτρειδῶν ἦλθέ μοι λόγος γάμων.</l>
@@ -1738,7 +1738,7 @@ convert to P3
 					<l>τί δῆτ’ ἂν εἴη; σὺ πάλιν αὖ λόγους ἐμοὺς</l>
 					<l>θαύμαζ’· ἐμοὶ γὰρ θαύματ’ ἐστὶ τὰ παρὰ σοῦ.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l n="845">εἴκαζε· κοινόν ἐστιν εἰκάζειν τάδε·</l>
 					<l>ἄμφω γὰρ οὐ ψευδόμεθα τοῖς λόγοις ἴσως.</l>
@@ -1748,7 +1748,7 @@ convert to P3
 					<l>ἀλλ’ ἦ πέπονθα δεινά; μνηστεύω γάμους</l>
 					<l>οὐκ ὄντας, ὡς εἴξασιν· αἰδοῦμαι τάδε.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>ἴσως ἐκερτόμησε κἀμὲ καὶ σέ τις.</l>
 					<l n="850">ἀλλ’ ἀμελίᾳ δὸς αὐτὰ καὶ φαύλως φέρε.</l>
@@ -1758,7 +1758,7 @@ convert to P3
 					<l>χαῖρ’· οὐ γὰρ ὀρθοῖς ὄμμασίν σ’ ἔτ’ εἰσορῶ,</l>
 					<l>ψευδὴς γενομένη καὶ παθοῦσ’ ἀνάξια.</l>
 				</sp>
-				<sp who="#axilleys">
+				<sp who="#achilleus">
 					<speaker>Ἀχιλλεύς</speaker>
 					<l>καὶ σοὶ τόδ’ ἐστὶν ἐξ ἐμοῦ· πόσιν δὲ σὸν</l>
 					<l>στείχω ματεύσων τῶνδε δωμάτων ἔσω.</l>
@@ -1770,7 +1770,7 @@ convert to P3
 						<l n="855">ὦ ξέν’, Αἰακοῦ γένεθλον, μεῖνον· ὦ, σέ τοι λέγω,</l>
 						<l>τὸν θεᾶς γεγῶτα παῖδα, καὶ σέ, τὴν Λήδας κόρην.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>τίς ὁ καλῶν πύλας παροίξας; ὡς τεταρβηκὼς καλεῖ.</l>
 					</sp>
@@ -1778,7 +1778,7 @@ convert to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>δοῦλος, οὐχ ἁβρύνομαι τῷδ’· ἡ τύχη γὰρ οὐκ ἐᾷ.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>τίνος; ἐμὸς μὲν οὐχί· χωρὶς τἀμὰ καὶ Ἀγαμέμνονος.</l>
 					</sp>
@@ -1786,7 +1786,7 @@ convert to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l n="860">τῆσδε τῆς πάροιθεν οἴκων, Τυνδάρεω δόντος πατρός.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἕσταμεν· φράζ’, εἴ τι χρῄζεις, ὧν μ’ ἐπέσχες οὕνεκα.</l>
 					</sp>
@@ -1794,7 +1794,7 @@ convert to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ἦ μόνω παρόντε δῆτα ταῖσδ’ ἐφέστατον πύλαις;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ὡς μόνοιν λέγοις ἄν, ἔξω δ’ ἐλθὲ βασιλείων δόμων.</l>
 					</sp>
@@ -1802,7 +1802,7 @@ convert to P3
 						<speaker>Πρεσβύτης</speaker>
 						<l>ὦ Τύχη πρόνοιά θ’ ἡμή, σῴσαθ’ οὓς ἐγὼ θέλω.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l n="865">ὁ λόγος ἐς μέλλοντ’ † ἂν ὤση † χρόνον· ἔχει δ’ ὄγκον τινά.</l>
 					</sp>
@@ -1930,7 +1930,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ὦ τέκνον Νηρῇδος, ὦ παῖ Πηλέως, κλύεις τάδε;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἔκλυον οὖσαν ἀθλίαν σε, τὸ δ’ ἐμὸν οὐ φαύλως φέρω.</l>
 					</sp>
@@ -1938,7 +1938,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>παῖδά μου κατακτενοῦσι σοῖς δολώσαντες γάμοις.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>μέμφομαι κἀγὼ πόσει σῷ, κοὐχ ἁπλῶς οὕτω φέρω.</l>
 					</sp>
@@ -1966,12 +1966,12 @@ convert to P3
 				</div2>
 				<div2 type="dialogue">
 					<milestone ed="p" n="917" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεινὸν τὸ τίκτειν καὶ φέρει φίλτρον μέγα</l>
 						<l>πᾶσίν τε κοινὸν ὥσθ’ ὑπερκάμνειν τέκνων.</l>
 					</sp>
-					<sp n="Ἀχιλλεύς" who="#axilleys">
+					<sp n="Ἀχιλλεύς" who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ὑψηλόφρων μοι θυμὸς αἴρεται πρόσω·</l>
 						<l n="920">ἐπίσταμαι δὲ τοῖς κακοῖσί τ’ ἀσχαλᾶν</l>
@@ -2031,7 +2031,7 @@ convert to P3
 						<l>ἀλλ’ ἡσύχαζε· θεὸς ἐγὼ πέφηνά σοι</l>
 						<l>μέγιστος, οὐκ ὤν· ἀλλ’ ὅμως γενήσομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="975">ἔλεξας, ὦ παῖ Πηλέως, σοῦ τ’ ἄξια</l>
 						<l>καὶ τῆς ἐναλίας δαίμονος, σεμνῆς θεοῦ.</l>
@@ -2062,7 +2062,7 @@ convert to P3
 						<l>μενέτω κατ’ οἴκους· σεμνὰ γὰρ σεμνύνεται.</l>
 						<l>ὅμως δ’ ὅσον γε δυνατὸν αἰδεῖσθαι χρεών.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>σὺ μήτε σὴν παῖδ’ ἔξαγ’ ὄψιν εἰς ἐμήν,</l>
 						<l>μήτ’ εἰς ὄνειδος ἀμαθὲς ἔλθωμεν, γύναι·</l>
@@ -2079,7 +2079,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ὄναιο συνεχῶς δυστυχοῦντας ὠφελῶν.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἄκουε δή νυν, ἵνα τὸ πρᾶγμ’ ἔχῃ καλῶς.</l>
 					</sp>
@@ -2087,7 +2087,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l n="1010">τί τοῦτ’ ἔλεξας; ὡς ἀκουστέον γέ σου.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>† πειθώμεθ’ αὖτις † πατέρα βέλτιον φρονεῖν.</l>
 					</sp>
@@ -2095,7 +2095,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>κακός τίς ἐστι καὶ λίαν ταρβεῖ στρατόν.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἀλλ’ οἱ λόγοι γε καταπαλαίουσιν λόγους.</l>
 					</sp>
@@ -2103,7 +2103,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ψυχρὰ μὲν ἐλπίς· ὅ τι δὲ χρή με δρᾶν φράσον.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l n="1015">ἱκέτεῡ ἐκεῖνον πρῶτα μὴ κτείνειν τέκνα·</l>
 						<l>ἢν δ’ ἀντιβαίνῃ, πρὸς ἐμέ σοι πορευτέον.</l>
@@ -2122,7 +2122,7 @@ convert to P3
 						<l>ποῦ σ’ αὖθις ὀψόμεσθα, ποῦ; χρή μ’ ἀθλίαν</l>
 						<l>ἐλθοῦσαν εὑρεῖν σὴν χέρ’ ἐπίκουρον κακῶν;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἡμεῖς σε φύλακες οὗ χρεὼν φυλάξομεν,</l>
 						<l>μή τίς σ’ ἴδῃ στείχουσαν ἐπτοημένην</l>
@@ -2141,7 +2141,7 @@ convert to P3
 			<milestone ed="p" n="1036" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίν’ ἄρ’ Ὑμέναιος διὰ λωτοῦ Λίβυος</l>
 						<l>μετά τε φιλοχόρου κιθάρας</l>
@@ -2168,7 +2168,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀνὰ δ’ ἐλάταισι στεφανώδει τε χλόᾳ</l>
 						<l>θίασος ἔμολεν ἱπποβάτας</l>
@@ -2195,7 +2195,7 @@ convert to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1080">σὲ δ’ ἐπὶ κάρα στέψουσι καλλικόμαν</l>
 						<l>πλόκαμον Ἀργεῖοι, βαλιὰν</l>
@@ -2408,13 +2408,13 @@ convert to P3
 					<l>εἰ δ’ εὖ λέλεκται, † νῶι μὴ δή γε κτάνῃς †</l>
 					<l>τὴν σήν τε κἀμὴν παῖδα, καὶ σώφρων ἔσῃ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πιθοῦ. τὸ γάρ τοι τέκνα συνσῴζειν καλόν,</l>
 					<l n="1210">Ἀγάμεμνον· οὐδεὶς πρὸς τάδ’ ἀντερεῖ βροτῶν.</l>
 				</sp>
 				<milestone ed="p" n="1211" unit="card"/>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>εἰ μὲν τὸν Ὀρφέως εἶχον, ὦ πάτερ, λόγον,</l>
 					<l>πείθειν ἐπᾴδουσ’, ὥσθ’ ὁμαρτεῖν μοι πέτρας,</l>
@@ -2459,7 +2459,7 @@ convert to P3
 					<l>τὰ νέρθε δ’ οὐδέν· μαίνεται δ’ ὃς εὔχεται</l>
 					<l>θανεῖν. κακῶς ζῆν κρεῖσσον ἢ καλῶς θανεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ τλῆμον Ἑλένη, διὰ σὲ καὶ τοὺς σοὺς γάμους</l>
 					<l>ἀγὼν Ἀτρείδαις καὶ τέκνοις ἥκει μέγας.</l>
@@ -2501,7 +2501,7 @@ convert to P3
 						<l>οἲ ’γὼ θανάτου &lt;τοῦ&gt; σοῦ μελέα.</l>
 						<l>φεύγει σε πατὴρ Ἅιδῃ παραδούς.</l>
 					</sp>
-					<sp n="Ἰφιγένεια" who="#ifigeneia">
+					<sp n="Ἰφιγένεια" who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οἲ ’γώ, μᾶτερ· ταὐτὸν τόδε γὰρ</l>
 						<l n="1280">μέλος εἰς ἄμφω πέπτωκε τύχης,</l>
@@ -2562,14 +2562,14 @@ convert to P3
 			</div1>
 			<milestone ed="p" n="1336" unit="card"/>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐγὼ μὲν οἰκτίρω σε συμφορᾶς κακῆς</l>
 					<l>τυχοῦσαν, οἵας μήποτ’ ὤφελες τυχεῖν.</l>
 				</sp>
 				<milestone ed="p" n="1338" unit="card"/>
 				<div2 type="trochees">
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ τεκοῦσα μῆτερ, ἀνδρῶν ὄχλον εἰσορῶ πέλας.</l>
 					</sp>
@@ -2577,7 +2577,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>τόν τε τῆς θεᾶς παῖδα, τέκνον, ᾧ &lt;σὺ&gt; δεῦρ’ ἐλήλυθας.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1340">διαχαλᾶτέ μοι μέλαθρα, δμῶες, ὡς κρύψω δέμας.</l>
 					</sp>
@@ -2585,7 +2585,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>τί δὲ τέκνον, φεύγεις;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">Ἀχιλλέα τόνδ’ ἰδεῖν αἰσχύνομαι.</l>
 					</sp>
@@ -2593,7 +2593,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ὡς τί δή;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">τὸ δυστυχές μοι τῶν γάμων αἰδῶ φέρει.</l>
 					</sp>
@@ -2602,7 +2602,7 @@ convert to P3
 						<l>οὐκ ἐν ἁβρότητι κεῖσαι πρὸς τὰ νῦν πεπτωκότα.</l>
 						<l>ἀλλὰ μίμν’· οὐ σεμνότητος ἔργον, ἢν ὀνώμεθα.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l n="1345">ὦ γύναι τάλαινα, Λήδας θύγατερ . . .</l>
 					</sp>
@@ -2610,7 +2610,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">οὐ ψευδῆ θροεῖς.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>δείν’ ἐν Ἀργείοις βοᾶται . . .</l>
 					</sp>
@@ -2618,7 +2618,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">τίνα βοήν; σήμαινέ μοι.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἀμφὶ σῆς παιδός . . .</l>
 					</sp>
@@ -2626,7 +2626,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">πονηρὸν εἶπας οἰωνὸν λόγον.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ὡς χρεὼν σφάξαι νιν.</l>
 					</sp>
@@ -2634,7 +2634,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">οὐδεὶς &lt;τοῖσδ’&gt; ἐναντίον λέγει;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἐς θόρυβον ἐγώ τι καὐτὸς ἤλυθον . . .</l>
 					</sp>
@@ -2642,7 +2642,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">τίν’, ὦ ξένε;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l n="1350">σῶμα λευσθῆναι πέτροισι.</l>
 					</sp>
@@ -2650,7 +2650,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">μῶν κόρην σῴζων ἐμήν;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>αὐτὸ τοῦτο.</l>
 					</sp>
@@ -2658,7 +2658,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">τίς δ’ ἂν ἔτλη [τοῦ] σώματος τοῦ σοῦ θιγεῖν;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>πάντες Ἕλληνες.</l>
 					</sp>
@@ -2666,7 +2666,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">στρατὸς δὲ Μυρμιδὼν οὔ σοι παρῆν;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>πρῶτος ἦν ἐκεῖνος ἐχθρός.</l>
 					</sp>
@@ -2674,7 +2674,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">δῑ ἄρ’ ὀλώλαμεν, τέκνον.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>οἵ με τὸν γάμων ἀπεκάλουν ἥσσονα.</l>
 					</sp>
@@ -2682,7 +2682,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ἀπεκρίνω δὲ τί;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l n="1355">τὴν ἐμὴν μέλλουσαν εὐνὴν μὴ κτανεῖν . . .</l>
 					</sp>
@@ -2690,7 +2690,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">δίκαια γάρ.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἣν ἐφήμισεν πατήρ μοι.</l>
 					</sp>
@@ -2698,7 +2698,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">καὶ Ἀργόθεν γ’ ἐπέμψατο.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἀλλ’ ἐνικώμην κεκραγμοῦ.</l>
 					</sp>
@@ -2706,7 +2706,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">τὸ πολὺ γὰρ δεινὸν κακόν.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἀλλ’ ὅμως ἀρήξομέν σοι.</l>
 					</sp>
@@ -2714,7 +2714,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">καὶ μαχῇ πολλοῖσιν εἷς;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>εἰσορᾷς τεύχη φέροντας τούσδε;</l>
 					</sp>
@@ -2722,7 +2722,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ὄναιο τῶν φρενῶν.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l n="1360">ἀλλ’ ὀνησόμεσθα.</l>
 					</sp>
@@ -2730,7 +2730,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">παῖς ἄρ’ οὐκέτι σφαγήσεται;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>οὔκ, ἐμοῦ γ’ ἑκόντος.</l>
 					</sp>
@@ -2738,7 +2738,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ἥξει δ’ ὅστις ἅψεται κόρης;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>μυρίοι γ’, ἄξει δ’ Ὀδυσσεύς.</l>
 					</sp>
@@ -2746,7 +2746,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ἆρ’ ὁ Σισύφου γόνος;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>αὐτὸς οὗτος.</l>
 					</sp>
@@ -2754,7 +2754,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ἴδια πράσσων, ἢ στρατοῦ ταχθεὶς ὕπο;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>αἱρεθεὶς ἑκών.</l>
 					</sp>
@@ -2762,7 +2762,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">πονηράν γ’ αἵρεσιν, μιαιφονεῖν.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l n="1365">ἀλλ’ ἐγὼ σχήσω νιν.</l>
 					</sp>
@@ -2770,7 +2770,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ἄξει δ’ οὐχ ἑκοῦσαν ἁρπάσας;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>δηλαδὴ ξανθῆς ἐθείρας.</l>
 					</sp>
@@ -2778,7 +2778,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ἐμὲ δὲ δρᾶν τί χρὴ τότε;</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἀντέχου θυγατρός.</l>
 					</sp>
@@ -2786,11 +2786,11 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l part="Y">ὡς τοῦδ’ εἵνεκ’ οὐ σφαγήσεται.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ἀλλὰ μὴν ἐς τοῦτό γ’ ἥξει.</l>
 					</sp>
-					<sp n="Ἰφιγένεια" who="#ifigeneia">
+					<sp n="Ἰφιγένεια" who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">μῆτερ, εἰσακούσατε</l>
 						<l>τῶν ἐμῶν λόγων· μάτην γάρ σ’ εἰσορῶ θυμουμένην</l>
@@ -2831,12 +2831,12 @@ convert to P3
 					<milestone ed="p" n="1402" unit="card"/>
 				</div2>
 				<div2 type="dialogue">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ μὲν σόν, ὦ νεᾶνι, γενναίως ἔχει·</l>
 						<l>τὸ τῆς τύχης δὲ καὶ τὸ τῆς θεοῦ νοσεῖ.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>Ἀγαμέμνονος παῖ, μακάριόν μέ τις θεῶν</l>
 						<l n="1405">ἔμελλε θήσειν, εἰ τύχοιμι σῶν γάμων.</l>
@@ -2851,7 +2851,7 @@ convert to P3
 						<l>εἰ μή σε σώσω Δαναΐδαισι διὰ μάχης</l>
 						<l n="1415">ἐλθών. ἄθρησον· ὁ θάνατος δεινὸν κακόν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>λέγω τάδ’ οὐδὲν οὐδέν’ εὐλαβουμένη.</l>
 						<l>ἡ Τυνδαρὶς παῖς διὰ τὸ σῶμ’ ἀρκεῖ μάχας</l>
@@ -2859,7 +2859,7 @@ convert to P3
 						<l>μὴ θνῇσκε δῑ ἐμὲ μηδ’ ἀποκτείνῃς τινά,</l>
 						<l n="1420">ἔα δὲ σῷσαί μ’ Ἑλλάδ’, ἢν δυνώμεθα.</l>
 					</sp>
-					<sp who="#axilleys">
+					<sp who="#achilleus">
 						<speaker>Ἀχιλλεύς</speaker>
 						<l>ὦ λῆμ’ ἄριστον, οὐκ ἔχω πρὸς τοῦτ’ ἔτι</l>
 						<l>λέγειν, ἐπεί σοι τάδε δοκεῖ· γενναῖα γὰρ</l>
@@ -2875,7 +2875,7 @@ convert to P3
 						<l>καραδοκήσω σὴν ἐκεῖ παρουσίαν.</l>
 					</sp>
 					<milestone ed="p" n="1433" unit="card"/>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μῆτερ, τί σιγῇ δακρύοις τέγγεις κόρας;</l>
 					</sp>
@@ -2883,7 +2883,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ἔχω τάλαινα πρόφασιν ὥστ’ ἀλγεῖν φρένα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1435">παῦσαι· ’μὲ μὴ κάκιζε· τάδε δέ μοι πιθοῦ.</l>
 					</sp>
@@ -2891,7 +2891,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>λέγ’· ὡς παρ’ ἡμῶν οὐδὲν ἀδικήσῃ, τέκνον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μήτ’ οὖν γε τὸν σὸν πλόκαμον ἐκτέμῃς τριχός,</l>
 						<l>μήτ’ ἀμφὶ σῶμα μέλανας ἀμπίσχῃ πέπλους.</l>
@@ -2900,7 +2900,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>τί δὴ τόδ’ εἶπας, τέκνον; ἀπολέσασά σε;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1440">οὐ σύ γε· σέσῳσμαι, κατ’ ἐμὲ δ’ εὐκλεὴς ἔσῃ.</l>
 					</sp>
@@ -2908,7 +2908,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>πῶς εἶπας; οὐ πενθεῖν με σὴν ψυχὴν χρεών;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἥκιστ’, ἐπεί μοι τύμβος οὐ χωσθήσεται.</l>
 					</sp>
@@ -2916,7 +2916,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>τί δαί; τὸ θνῄσκειν, οὐ τάφος, νομίζεται.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>βωμὸς θεᾶς μοι μνῆμα τῆς Διὸς κόρης.</l>
 					</sp>
@@ -2924,7 +2924,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l n="1445">ἀλλ’, ὦ τέκνον, σοὶ πείσομαι· λέγεις γὰρ εὖ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὡς εὐτυχοῦσά γ’ Ἑλλάδος τ’ εὐεργέτις.</l>
 					</sp>
@@ -2932,7 +2932,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>τί δὴ κασιγνήταισιν ἀγγελῶ σέθεν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μηδ’ ἀμφὶ κείναις μέλανας ἐξάψῃ πέπλους.</l>
 					</sp>
@@ -2940,7 +2940,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>εἴπω δὲ παρὰ σοῦ φίλον ἔπος τι παρθένοις;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1450">χαίρειν γε. Ὀρέστην τ’ ἔκτρεφ’ ἄνδρα τόνδε μοι.</l>
 					</sp>
@@ -2948,7 +2948,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>προσέλκυσαί νιν ὕστατον θεωμένη.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ φίλτατ’, ἐπεκούρησας ὅσον εἶχες φίλοις.</l>
 					</sp>
@@ -2956,7 +2956,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ἔσθ’ ὅ τι κατ’ Ἄργος δρῶσά σοι χάριν φέρω;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πατέρα τὸν ἀμὸν μὴ στύγει, πόσιν γε σόν.</l>
 					</sp>
@@ -2964,7 +2964,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l n="1455">δεινοὺς ἀγῶνας διὰ σὲ δεῖ κεῖνον δραμεῖν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἄκων μ’ ὑπὲρ γῆς Ἑλλάδος διώλεσεν.</l>
 					</sp>
@@ -2972,7 +2972,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>δόλῳ δ’, ἀγεννῶς Ἀτρέως τ’ οὐκ ἀξίως.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τίς μ’ εἶσιν ἄξων πρὶν σπαράσσεσθαι κόμης;</l>
 					</sp>
@@ -2980,7 +2980,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ἐγώ, μετά γε σοῦ. . .</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">μὴ σύ γ’· οὐ καλῶς λέγεις.</l>
 					</sp>
@@ -2988,7 +2988,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l n="1460">πέπλων ἐχομένη σῶν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">ἐμοί, μῆτερ, πιθοῦ·</l>
 						<l>μέν’· ὡς ἐμοί τε σοί τε κάλλιον τόδε.</l>
@@ -2999,7 +2999,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>ὦ τέκνον, οἴχῃ;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">καὶ πάλιν γ’ οὐ μὴ μόλω.</l>
 					</sp>
@@ -3007,7 +3007,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l n="1465">λιποῦσα μητέρα;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">ὡς ὁρᾷς γ’, οὐκ ἀξίως.</l>
 					</sp>
@@ -3015,7 +3015,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>σχές, μή με προλίπῃς.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">οὐκ ἐῶ στάζειν δάκρυ.</l>
 						<l>ὑμεῖς δ’ ἐπευφημήσατ’, ὦ νεάνιδες,</l>
@@ -3029,7 +3029,7 @@ convert to P3
 					<milestone ed="p" n="1475" unit="card"/>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1475">ἄγετέ με τὰν Ἰλίου</l>
 						<l>καὶ Φρυγῶν ἑλέπτολιν.</l>
@@ -3057,21 +3057,21 @@ convert to P3
 					<milestone ed="p" n="1500" unit="card"/>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1500">καλεῖς πόλισμα Περσέως,</l>
 						<l>Κυκλωπίων πόνον χερῶν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἐθρέψαθ’ Ἑλλάδι με φάος·</l>
 						<l>θανοῦσα δ’ οὐκ ἀναίνομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κλέος γὰρ οὔ σε μὴ λίπῃ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1505">ἰὼ ἰώ.</l>
 						<l>λαμπαδοῦχος ἁμέρα</l>
@@ -3079,7 +3079,7 @@ convert to P3
 						<l>αἰῶνα καὶ μοῖραν οἰκήσομεν.</l>
 						<l>χαῖρέ μοι, φίλον φάος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1510">ἰὼ ἰώ.</l>
 						<l>ἴδεσθε τὰν Ἰλίου</l>
@@ -3108,7 +3108,7 @@ convert to P3
 					<milestone ed="p" n="1532" unit="card"/>
 				</div2>
 				<div2 type="dialogue">
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ὦ Τυνδαρεία παῖ, Κλυταιμήστρα, δόμων</l>
 						<l>ἔξω πέρασον, ὡς κλύῃς ἐμῶν λόγων.</l>
@@ -3120,7 +3120,7 @@ convert to P3
 						<l>μή μοί τιν’ ἄλλην ξυμφορὰν ἥκεις φέρων</l>
 						<l>πρὸς τῇ παρούσῃ;</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l part="Y">σῆς μὲν οὖν παιδὸς πέρι</l>
 						<l>θαυμαστά σοι καὶ δεινὰ σημῆναι θέλω.</l>
@@ -3129,7 +3129,7 @@ convert to P3
 						<speaker>Κλυταιμήστρα</speaker>
 						<l>μὴ μέλλε τοίνυν, ἀλλὰ φράζ’ ὅσον τάχος.</l>
 					</sp>
-					<sp n="Ἀγγελος" who="#aggelos">
+					<sp n="Ἀγγελος" who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l n="1540">ἀλλ’, ὦ φίλη δέσποινα, πᾶν πεύσῃ σαφῶς.</l>
 						<l>λέξω δ’ ἀπ’ ἀρχῆς, ἤν τι μὴ σφαλεῖσά μου</l>
@@ -3207,7 +3207,7 @@ convert to P3
 						<l>σώζουσί θ’ οὓς φιλοῦσιν. ἦμαρ γὰρ τόδε</l>
 						<l>θανοῦσαν εἶδε καὶ βλέπουσαν παῖδα σήν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς ἥδομαί τοι ταῦτ’ ἀκούσασ’ ἀγγέλου·</l>
 						<l>ζῶν δ’ ἐν θεοῖσι σὸν μένειν φράζει τέκος.</l>
@@ -3222,7 +3222,7 @@ convert to P3
 						<l>παραμυθεῖσθαι τούσδε μάτην μύθους,</l>
 						<l>ὥς σου πένθους λυγροῦ παυσαίμαν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν Ἀγαμέμνων ἄναξ στείχει,</l>
 						<l n="1620">τούσδ’ αὐτοὺς ἔχων σοι φράζειν μύθους.</l>
@@ -3238,7 +3238,7 @@ convert to P3
 						<l>Τροίηθεν ἔσται. καὶ γένοιτό σοι καλῶς.</l>
 						<milestone ed="p" n="1627" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χαίρων, Ἀτρείδη, γῆν ἱκοῦ Φρυγίαν,</l>
 						<l>χαίρων δ’ ἐπάνηκε,</l>

--- a/tei/euripides-iphigenia-in-tauris.xml
+++ b/tei/euripides-iphigenia-in-tauris.xml
@@ -54,7 +54,7 @@
 					<person xml:id="orestes">
 						<persName>Ὀρέστης</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
 					<person xml:id="pylades">
@@ -63,16 +63,16 @@
 					<person xml:id="athena">
 						<persName>Ἀθήνα</persName>
 					</person>
-					<person xml:id="boykolos">
+					<person xml:id="boukolos">
 						<persName>Βουκόλος</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="thoas">
 						<persName>Θόας</persName>
 					</person>
-					<person xml:id="ifigeneia">
+					<person xml:id="iphigeneia">
 						<persName>Ἰφιγένεια</persName>
 					</person>
 				</listPerson>
@@ -155,7 +155,7 @@ bring up to P3
 		<body>
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp n="Ἰφιγένεια" who="#ifigeneia">
+				<sp n="Ἰφιγένεια" who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>Πέλοψ ὁ Ταντάλειος ἐς Πῖσαν μολὼν</l>
 					<l>θοαῖσιν ἵπποις Οἰνομάου γαμεῖ κόρην,</l>
@@ -326,7 +326,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐφαμεῖτ’, ὦ</l>
 						<l>πόντου δισσὰς συγχωρούσας</l>
@@ -349,7 +349,7 @@ bring up to P3
 						<l>μυριοτευχοῦς Ἀτρείδα; [τῶν κλεινῶν;]</l>
 						<milestone ed="p" n="143" unit="card"/>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἰὼ δμωαί,</l>
 						<l>δυσθρηνήτοις ὡς θρήνοις</l>
@@ -385,7 +385,7 @@ bring up to P3
 						<l>κεῖμαι σφαχθεῖσ’ ἁ τλάμων.</l>
 						<milestone ed="p" n="178" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀντιψάλμους ᾠδὰς ὕμνων τ’</l>
 						<l n="180">Ἀσιητᾶν σοι βάρβαρον ἀχὰν</l>
@@ -411,7 +411,7 @@ bring up to P3
 						<l>ἐπὶ σοὶ δαίμων.</l>
 						<milestone ed="p" n="203" unit="card"/>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἐξ ἀρχᾶς μοι δυσδαίμων</l>
 						<l>δαίμων τᾶς ματρὸς ζώνας</l>
@@ -450,21 +450,21 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ μὴν ὅδ’ ἀκτὰς ἐκλιπὼν θαλασσίους</l>
 					<l>βουφορβὸς ἥκει σημανῶν τί σοι νέον.</l>
 				</sp>
-				<sp who="#boykolos">
+				<sp who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l>Ἀγαμέμνονός τε καὶ Κλυταιμήστρας τέκνον,</l>
 					<l>ἄκουε καινῶν ἐξ ἐμοῦ κηρυγμάτων.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l n="240">τί δ’ ἔστι τοῦ παρόντος ἐκπλῆσσον λόγου;</l>
 				</sp>
-				<sp who="#boykolos">
+				<sp who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l>ἥκουσιν ἐς γῆν, κυανέαν Συμπληγάδα</l>
 					<l>πλάτῃ φυγόντες, δίπτυχοι νεανίαι,</l>
@@ -472,47 +472,47 @@ bring up to P3
 					<l>Ἀρτέμιδι. χέρνιβας δὲ καὶ κατάργματα</l>
 					<l n="245">οὐκ ἂν φθάνοις ἂν εὐτρεπῆ ποιουμένη.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ποδαποί; τίνος γῆς σχῆμ’ ἔχουσιν οἱ ξένοι;</l>
 				</sp>
-				<sp who="#boykolos">
+				<sp who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l>Ἕλληνες· ἓν τοῦτ’ οἶδα κοὐ περαιτέρω.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>οὐδ’ ὄνομ’ ἀκούσας οἶσθα τῶν ξένων φράσαι;</l>
 				</sp>
-				<sp who="#boykolos">
+				<sp who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l>Πυλάδης ἐκλῄζεθ’ ἅτερος πρὸς θατέρου.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l n="250">τοῦ ξυζύγου δὲ τοῦ ξένου τί τοὔνομ’ ἦν;</l>
 				</sp>
-				<sp who="#boykolos">
+				<sp who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l>οὐδεὶς τόδ’ οἶδεν· οὐ γὰρ εἰσηκούσαμεν.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>πῶς δ’ εἴδετ’ αὐτοὺς κἀντυχόντες εἵλετε;</l>
 				</sp>
-				<sp who="#boykolos">
+				<sp who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l>ἄκραις ἐπὶ ῥηγμῖσιν ἀξένου πόρου — </l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>καὶ τίς θαλάσσης βουκόλοις κοινωνία;</l>
 				</sp>
-				<sp who="#boykolos">
+				<sp who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l n="255">βοῦς ἤλθομεν νίψοντες ἐναλίᾳ δρόσῳ.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἐκεῖσε δὴ ’πάνελθε, πῶς νιν εἵλετε</l>
 					<l>τρόπῳ θ’ ὁποίῳ· τοῦτο γὰρ μαθεῖν θέλω.</l>
@@ -520,7 +520,7 @@ bring up to P3
 					<l>Ἑλληνικαῖσιν ἐξεφοινίχθη ῥοαῖς.</l>
 					<milestone ed="p" n="260" unit="card"/>
 				</sp>
-				<sp n="Βουκόλος" who="#boykolos">
+				<sp n="Βουκόλος" who="#boukolos">
 					<speaker>Βουκόλος</speaker>
 					<l n="260">ἐπεὶ τὸν ἐσρέοντα διὰ Συμπληγάδων</l>
 					<l>βοῦς ὑλοφορβοὺς πόντον εἰσεβάλλομεν,</l>
@@ -614,13 +614,13 @@ bring up to P3
 					<l>τοιούσδε, τὸν σὸν Ἑλλὰς ἀποτείσει φόνον</l>
 					<l>δίκας τίνουσα τῆς ἐν Αὐλίδι σφαγῆς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="340">θαυμάστ’ ἔλεξας τὸν μανένθ’, ὅστις ποτὲ</l>
 					<l>Ἕλληνος ἐκ γῆς πόντον ἦλθεν ἄξενον.</l>
 				</sp>
 				<milestone ed="p" n="342" unit="card"/>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>εἶἑν· σὺ μὲν κόμιζε τοὺς ξένους μολών,</l>
 					<l>τὰ δ’ ἐνθάδ’ ἡμεῖς ὅσια φροντιούμεθα — </l>
@@ -683,7 +683,7 @@ bring up to P3
 			<milestone ed="p" n="392" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κυάνεαι κυάνεαι</l>
 						<l>σύνοδοι θαλάσσας, ἵν’ οἶ‐</l>
@@ -702,7 +702,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ ῥοθίοις εἰλατίνας</l>
 						<l>δικρότοισι κώπας ἔπλευ‐</l>
@@ -721,7 +721,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς πέτρας τὰς συνδρομάδας,</l>
 						<l>πῶς Φινεϊδᾶν ἀΰ‐</l>
@@ -745,7 +745,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἴθ’ εὐχαῖσιν δεσποσύνοις</l>
 						<l>Λήδας Ἑλένα φίλα</l>
@@ -771,7 +771,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ οἵδε χέρας δεσμοῖς δίδυμοι</l>
 						<l>συνερεισθέντες χωροῦσι, νέον</l>
@@ -786,7 +786,7 @@ bring up to P3
 						<l>[Ἕλλησι διδοὺς] ἀναφαίνει.</l>
 						<milestone ed="p" n="467" unit="card"/>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>εἶἑν·</l>
 						<l>τὰ τῆς θεοῦ μὲν πρῶτον ὡς καλῶς ἔχῃ</l>
@@ -825,7 +825,7 @@ bring up to P3
 						<l>θυσίας ἐπιστάμεσθα καὶ γιγνώσκομεν.</l>
 						<milestone ed="p" n="492" unit="card"/>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πότερος ἄρ’ ὑμῶν ἐνθάδ’ ὠνομασμένος</l>
 						<l>Πυλάδης κέκληται; τόδε μαθεῖν πρῶτον θέλω.</l>
@@ -834,7 +834,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὅδ’, εἴ τι δή σοι τοῦτ’ ἐν ἡδονῇ μαθεῖν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="495">ποίας πολίτης πατρίδος Ἕλληνος γεγώς;</l>
 					</sp>
@@ -842,7 +842,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τί δ’ ἂν μαθοῦσα τόδε πλέον λάβοις, γύναι;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πότερον ἀδελφὼ μητρός ἐστον ἐκ μιᾶς;</l>
 					</sp>
@@ -850,7 +850,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>φιλότητί γ’· ἐσμὲν δ’ οὐ κασιγνήτω, γύναι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>σοὶ δ’ ὄνομα ποῖον ἔθεθ’ ὁ γεννήσας πατήρ;</l>
 					</sp>
@@ -858,7 +858,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="500">τὸ μὲν δίκαιον Δυστυχὴς καλοίμεθ’ ἄν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οὐ τοῦτ’ ἐρωτῶ· τοῦτο μὲν δὸς τῇ τύχῃ.</l>
 					</sp>
@@ -866,7 +866,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἀνώνυμοι θανόντες οὐ γελῴμεθ’ ἄν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τί δὲ φθονεῖς τοῦτο; ἦ φρονεῖς οὕτω μέγα;</l>
 					</sp>
@@ -874,7 +874,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τὸ σῶμα θύσεις τοὐμόν, οὐχὶ τοὔνομα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="505">οὐδ’ ἂν πόλιν φράσειας ἥτις ἐστί σοι;</l>
 					</sp>
@@ -882,7 +882,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ζητεῖς γὰρ οὐδὲν κέρδος, ὡς θανουμένῳ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>χάριν δὲ δοῦναι τήνδε κωλύει τί σε;</l>
 					</sp>
@@ -890,7 +890,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τὸ κλεινὸν Ἄργος πατρίδ’ ἐμὴν ἐπεύχομαι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πρὸς θεῶν, ἀληθῶς, ὦ ξέν’, εἶ κεῖθεν γεγώς;</l>
 					</sp>
@@ -898,7 +898,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="510">ἐκ τῶν Μυκηνῶν &lt;γ’&gt;, αἵ ποτ’ ἦσαν ὄλβιαι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>φυγὰς &lt;δ’&gt; ἀπῆρας πατρίδος, ἢ ποίᾳ τύχῃ;</l>
 					</sp>
@@ -906,7 +906,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>φεύγω τρόπον γε δή τιν’ οὐχ ἑκὼν ἑκών.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἆρ’ ἄν τί μοι φράσειας ὧν ἐγὼ θέλω;</l>
 					</sp>
@@ -914,7 +914,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὡς ἐν παρέργῳ τῆς ἐμῆς δυσπραξίας.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="515">καὶ μὴν ποθεινός γ’ ἦλθες ἐξ Ἄργους μολών.</l>
 					</sp>
@@ -922,7 +922,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὔκουν ἐμαυτῷ γ’· εἰ δὲ σοί, σὺ τοῦτ’ ἔρα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>Τροίαν ἴσως οἶσθ’, ἧς ἁπανταχοῦ λόγος.</l>
 					</sp>
@@ -930,7 +930,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὡς μήποτ’ ὤφελόν γε μηδ’ ἰδὼν ὄναρ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>φασίν νιν οὐκέτ’ οὖσαν οἴχεσθαι δορί.</l>
 					</sp>
@@ -938,7 +938,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="520">ἔστιν γὰρ οὕτως οὐδ’ ἄκραντ’ ἠκούσατε.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>Ἑλένη δ’ ἀφῖκται δῶμα Μενέλεω πάλιν;</l>
 					</sp>
@@ -946,7 +946,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἥκει, κακῶς γ’ ἐλθοῦσα τῶν ἐμῶν τινι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>καὶ ποῦ ’στι; κἀμοὶ γάρ τι προυφείλει κακόν.</l>
 					</sp>
@@ -954,7 +954,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>Σπάρτῃ ξυνοικεῖ τῷ πάρος ξυνευνέτῃ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="525">ὦ μῖσος εἰς Ἕλληνας, οὐκ ἐμοὶ μόνῃ.</l>
 					</sp>
@@ -962,7 +962,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἀπέλαυσα κἀγὼ δή τι τῶν κείνης γάμων.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>νόστος δ’ Ἀχαιῶν ἐγένεθ’, ὡς κηρύσσεται;</l>
 					</sp>
@@ -970,7 +970,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὡς πάνθ’ ἅπαξ με συλλαβοῦσ’ ἀνιστορεῖς.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πρὶν γὰρ θανεῖν σε, τοῦδ’ ἐπαυρέσθαι θέλω.</l>
 					</sp>
@@ -978,7 +978,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="530">ἔλεγχ’, ἐπειδὴ τοῦδ’ ἐρᾷς· λέξω δ’ ἐγώ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>Κάλχας τις ἦλθε μάντις ἐκ Τροίας πάλιν;</l>
 					</sp>
@@ -986,7 +986,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὄλωλεν, ὡς ἦν ἐν Μυκηναίοις λόγος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ πότνῑ, ὡς εὖ.  — τί γὰρ ὁ Λαέρτου γόνος;</l>
 					</sp>
@@ -994,7 +994,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὔπω νενόστηκ’ οἶκον, ἔστι δ’, ὡς λόγος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="535">ὄλοιτο, νόστου μήποτ’ ἐς πάτραν τυχών.</l>
 					</sp>
@@ -1002,7 +1002,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>μηδὲν κατεύχου· πάντα τἀκείνου νοσεῖ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>Θέτιδος δ’ ὁ τῆς Νηρῇδος ἔστι παῖς ἔτι;</l>
 					</sp>
@@ -1010,7 +1010,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὐκ ἔστιν· ἄλλως λέκτρ’ ἔγημ’ ἐν Αὐλίδι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>δόλια γάρ, ὡς ἴσασιν οἱ πεπονθότες.</l>
 						<milestone ed="p" n="540" unit="card"/>
@@ -1019,7 +1019,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="540">τίς εἶ ποθ’; ὡς εὖ πυνθάνῃ τἀφ’ Ἑλλάδος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἐκεῖθέν εἰμι· παῖς ἔτ’ οὖσ’ ἀπωλόμην.</l>
 					</sp>
@@ -1027,7 +1027,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὀρθῶς ποθεῖς ἄρ’ εἰδέναι τἀκεῖ, γύναι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τί δ’ ὁ στρατηγός, ὃν λέγουσ’ εὐδαιμονεῖν;</l>
 					</sp>
@@ -1035,7 +1035,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τίς; οὐ γὰρ ὅν γ’ ἐγᾦδα τῶν εὐδαιμόνων.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="545">Ἀτρέως ἐλέγετο δή τις Ἀγαμέμνων ἄναξ.</l>
 					</sp>
@@ -1043,7 +1043,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὐκ οἶδ’· ἄπελθε τοῦ λόγου τούτου, γύναι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μὴ πρὸς θεῶν, ἀλλ’ εἴφ’, ἵν’ εὐφρανθῶ, ξένε.</l>
 					</sp>
@@ -1051,7 +1051,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τέθνηχ’ ὁ τλήμων, πρὸς δ’ ἀπώλεσέν τινα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τέθνηκε; ποίᾳ συμφορᾷ; τάλαιν’ ἐγώ.</l>
 					</sp>
@@ -1059,7 +1059,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="550">τί δ’ ἐστέναξας τοῦτο; μῶν προσῆκέ σοι;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τὸν ὄλβον αὐτοῦ τὸν πάροιθ’ ἀναστένω.</l>
 					</sp>
@@ -1067,7 +1067,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>δεινῶς γὰρ ἐκ γυναικὸς οἴχεται σφαγείς.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ πανδάκρυτος ἡ κτανοῦσα . . . χὡ κτανών.</l>
 					</sp>
@@ -1075,7 +1075,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>παῦσαί νυν ἤδη μηδ’ ἐρωτήσῃς πέρα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="555">τοσόνδε γ’, εἰ ζῇ τοῦ ταλαιπώρου δάμαρ.</l>
 					</sp>
@@ -1083,7 +1083,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὐκ ἔστι· παῖς νιν ὃν ἔτεχ’, οὗτος ὤλεσεν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ συνταραχθεὶς οἶκος. ὡς τί δὴ θέλων;</l>
 					</sp>
@@ -1091,7 +1091,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>πατρὸς θανόντος τήνδε τιμωρούμενος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>φεῦ·</l>
 						<l>ὡς εὖ κακὸν δίκαιον εἰσεπράξατο.</l>
@@ -1100,7 +1100,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="560">ἀλλ’ οὐ τὰ πρὸς θεῶν εὐτυχεῖ δίκαιος ὤν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>λείπει δ’ ἐν οἴκοις ἄλλον Ἀγαμέμνων γόνον;</l>
 					</sp>
@@ -1108,7 +1108,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>λέλοιπεν Ἠλέκτραν γε παρθένον μίαν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τί δέ; σφαγείσης θυγατρὸς ἔστι τις λόγος;</l>
 					</sp>
@@ -1116,7 +1116,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὐδείς γε, πλὴν θανοῦσαν οὐχ ὁρᾶν φάος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="565">τάλαιν’ ἐκείνη χὡ κτανὼν αὐτὴν πατήρ.</l>
 					</sp>
@@ -1124,7 +1124,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>κακῆς γυναικὸς χάριν ἄχαριν ἀπώλετο.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὁ τοῦ θανόντος δ’ ἔστι παῖς Ἄργει πατρός;</l>
 					</sp>
@@ -1132,7 +1132,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἔστ’, ἄθλιός γε, κοὐδαμοῦ καὶ πανταχοῦ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ψευδεῖς ὄνειροι, χαίρετ’· οὐδὲν ἦτ’ ἄρα.</l>
 					</sp>
@@ -1145,13 +1145,13 @@ bring up to P3
 						<l>ὃς οὐκ ἄφρων ὢν μάντεων πεισθεὶς λόγοις</l>
 						<l n="575">ὄλωλεν — ὡς ὄλωλε τοῖσιν εἰδόσιν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φεῦ φεῦ· τί δ’ ἡμεῖς οἵ τ’ ἐμοὶ γεννήτορες;</l>
 						<l>ἆρ’ εἰσίν; ἆρ’ οὐκ εἰσί; τίς φράσειεν ἄν;</l>
 						<milestone ed="p" n="578" unit="card"/>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἀκούσατ’· ἐς γὰρ δή τιν’ ἥκομεν λόγον,</l>
 						<l>ὑμῖν τ’ ὄνησιν, ὦ ξένοι, σπουδῆς ἅμα</l>
@@ -1188,7 +1188,7 @@ bring up to P3
 						<l>αὐτὸς σέσῳσται. τυγχάνει δ’ ὅδ’ ὢν φίλος,</l>
 						<l>ὃν οὐδὲν ἧσσον ἢ ’μὲ φῶς ὁρᾶν θέλω.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ λῆμ’ ἄριστον, ὡς ἀπ’ εὐγενοῦς τινος</l>
 						<l n="610">ῥίζης πέφυκας τοῖς φίλοις τ’ ὀρθῶς φίλος.</l>
@@ -1204,7 +1204,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>θύσει δὲ τίς με καὶ τὰ δεινὰ τλήσεται;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἐγώ· θεᾶς γὰρ τῆσδε προστροπὴν ἔχω.</l>
 					</sp>
@@ -1212,7 +1212,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἄζηλά γ’, ὦ νεᾶνι, κοὐκ εὐδαίμονα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="620">ἀλλ’ εἰς ἀνάγκην κείμεθ’, ἣν φυλακτέον.</l>
 					</sp>
@@ -1220,7 +1220,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>αὐτὴ ξίφει θύουσα θῆλυς ἄρσενας;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οὔκ, ἀλλὰ χαίτην ἀμφὶ σὴν χερνίψομαι.</l>
 					</sp>
@@ -1228,7 +1228,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὁ δὲ σφαγεὺς τίς; εἰ τάδ’ ἱστορεῖν με χρή.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἔσω δόμων τῶνδ’ εἰσὶν οἷς μέλει τάδε.</l>
 					</sp>
@@ -1236,7 +1236,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="625">τάφος δὲ ποῖος δέξεταί μ’, ὅταν θάνω;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πῦρ ἱερὸν ἔνδον χάσμα τ’ εὐρωπὸν πέτρας.</l>
 					</sp>
@@ -1245,7 +1245,7 @@ bring up to P3
 						<l>φεῦ·</l>
 						<l>πῶς ἄν μ’ ἀδελφῆς χεὶρ περιστείλειεν ἄν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μάταιον εὐχήν, ὦ τάλας, ὅστις ποτ’ εἶ,</l>
 						<l>ηὔξω· μακρὰν γὰρ βαρβάρου ναίει χθονός.</l>
@@ -1269,7 +1269,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κατολοφύρομαι σὲ τὸν χερνίβων</l>
 						<l n="645">ῥανίσι μελόμενον αἱμακταῖς.</l>
@@ -1280,7 +1280,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὲ δὲ τύχας μάκαρος, ὦ</l>
 						<l>νεανία, σεβόμεθ’, ἐς</l>
@@ -1292,7 +1292,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ σχέτλιοι πομπαί.</l>
 						<l>φεῦ φεῦ, διόλλυσαι.</l>
@@ -1400,7 +1400,7 @@ bring up to P3
 						<l>γυνὴ γὰρ ἥδε δωμάτων ἔξω περᾷ.</l>
 						<milestone ed="p" n="725" unit="card"/>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="725">ἀπέλθεθ’ ὑμεῖς καὶ παρευτρεπίζετε</l>
 						<l>τἄνδον μολόντες τοῖς ἐφεστῶσι σφαγῇ.</l>
@@ -1419,7 +1419,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τί δῆτα βούλῃ; τίνος ἀμηχανεῖς πέρι;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="735">ὅρκον δότω μοι τάσδε πορθμεύσειν γραφὰς</l>
 						<l>πρὸς Ἄργος, οἷσι βούλομαι πέμψαι φίλων.</l>
@@ -1428,7 +1428,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἦ κἀντιδώσεις τῷδε τοὺς αὐτοὺς λόγους;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τί χρῆμα δράσειν ἢ τί μὴ δράσειν; λέγε.</l>
 					</sp>
@@ -1436,7 +1436,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἐκ γῆς ἀφήσειν μὴ θανόντα βαρβάρου.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="740">δίκαιον εἶπας· πῶς γὰρ ἀγγείλειεν ἄν;</l>
 					</sp>
@@ -1444,7 +1444,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἦ καὶ τύραννος ταῦτα συγχωρήσεται;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ναί.</l>
 						<l>πείσω σφε, καὐτὴ ναὸς εἰσβήσω σκάφος.</l>
@@ -1453,7 +1453,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὄμνυ· σὺ δ’ ἔξαρχ’ ὅρκον ὅστις εὐσεβής.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>δώσω, λέγειν χρή, τήνδε τοῖσι σοῖς φίλοις.</l>
 					</sp>
@@ -1461,7 +1461,7 @@ bring up to P3
 						<speaker>Πυλάδης</speaker>
 						<l n="745">τοῖς σοῖς φίλοισι γράμματ’ ἀποδώσω τάδε.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>κἀγὼ σὲ σώσω κυανέας ἔξω πέτρας.</l>
 					</sp>
@@ -1469,7 +1469,7 @@ bring up to P3
 						<speaker>Πυλάδης</speaker>
 						<l>τίν’ οὖν ἐπόμνυς τοισίδ’ ὅρκιον θεῶν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>Ἄρτεμιν, ἐν ἧσπερ δώμασιν τιμὰς ἔχω.</l>
 					</sp>
@@ -1477,7 +1477,7 @@ bring up to P3
 						<speaker>Πυλάδης</speaker>
 						<l>ἐγὼ δ’ ἄνακτά γ’ οὐρανοῦ, σεμνὸν Δία.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="750">εἰ δ’ ἐκλιπὼν τὸν ὅρκον ἀδικοίης ἐμέ;</l>
 					</sp>
@@ -1485,7 +1485,7 @@ bring up to P3
 						<speaker>Πυλάδης</speaker>
 						<l>ἄνοστος εἴην· τί δὲ σύ, μὴ σῴσασά με;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μήποτε κατ’ Ἄργος ζῶσ’ ἴχνος θείην ποδός.</l>
 					</sp>
@@ -1493,7 +1493,7 @@ bring up to P3
 						<speaker>Πυλάδης</speaker>
 						<l>ἄκουε δή νυν ὃν παρήλθομεν λόγον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἀλλ’ αὖθις ἔσται καινός, ἢν καλῶς ἔχῃ.</l>
 					</sp>
@@ -1504,7 +1504,7 @@ bring up to P3
 						<l>ἀφανὴς γένηται, σῶμα δ’ ἐκσῴσω μόνον,</l>
 						<l>τὸν ὅρκον εἶναι τόνδε μηκέτ’ ἔμπεδον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἀλλ’ οἶσθ’ ὃ δράσω; πολλὰ γὰρ πολλῶν κυρεῖ·</l>
 						<l n="760">τἀνόντα κἀγγεγραμμέν’ ἐν δέλτου πτυχαῖς</l>
@@ -1521,7 +1521,7 @@ bring up to P3
 						<l>πρὸς Ἄργος ὅ τι τε χρὴ κλύοντα σοῦ λέγειν.</l>
 						<milestone ed="p" n="769" unit="card"/>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἄγγελλ’ Ὀρέστῃ, παιδὶ τῷ Ἀγαμέμνονος·</l>
 						<l n="770">Ἡ ’ν Αὐλίδι σφαγεῖσ’ ἐπιστέλλει τάδε</l>
@@ -1531,7 +1531,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ποῦ δ’ ἔστ’ ἐκείνη; κατθανοῦσ’ ἥκει πάλιν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἥδ’ ἣν ὁρᾷς σύ· μὴ λόγοις ἔκπλησσέ με.</l>
 						<l>Κόμισαί μ’ ἐς Ἄργος, ὦ σύναιμε, πρὶν θανεῖν,</l>
@@ -1542,7 +1542,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>Πυλάδη, τί λέξω; ποῦ ποτ’ ὄνθ’ ηὑρήμεθα;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἢ σοῖς ἀραία δώμασιν γενήσομαι.</l>
 					</sp>
@@ -1550,7 +1550,7 @@ bring up to P3
 						<speaker>Πυλάδης</speaker>
 						<l>Ὀρέστα — ;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">ἵν’ αὖθις ὄνομα δὶς κλύων μάθῃς.</l>
 					</sp>
@@ -1558,7 +1558,7 @@ bring up to P3
 						<speaker>Πυλάδης</speaker>
 						<l n="780">ὦ θεοί.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l part="Y">τί τοὺς θεοὺς ἀνακαλεῖς ἐν τοῖς ἐμοῖς;</l>
 					</sp>
@@ -1567,7 +1567,7 @@ bring up to P3
 						<l>οὐδέν· πέραινε δ’· ἐξέβην γὰρ ἄλλοσε.</l>
 						<l>τάχ’ οὐκ ἐρωτῶν σ’ εἰς ἄπιστ’ ἀφίξομαι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>λέγ’ οὕνεκ’ ἔλαφον ἀντιδοῦσά μου θεὰ</l>
 						<l>Ἄρτεμις ἔσῳσέ μ’, ἣν ἔθυσ’ ἐμὸς πατήρ,</l>
@@ -1598,7 +1598,7 @@ bring up to P3
 						<l>ἐς τέρψιν εἶμι, πυθόμενος θαυμάστ’ ἐμοί.</l>
 						<milestone ed="p" n="798" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ξέν’, οὐ δικαίως τῆς θεοῦ τὴν πρόσπολον</l>
 						<l>χραίνεις ἀθίκτοις περιβαλὼν πέπλοις χέρα.</l>
@@ -1609,7 +1609,7 @@ bring up to P3
 						<l>Ἀγαμέμνονος γεγῶσα, μή μ’ ἀποστρέφου,</l>
 						<l>ἔχουσ’ ἀδελφόν, οὐ δοκοῦσ’ ἕξειν ποτέ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἐγώ σ’ ἀδελφὸν τὸν ἐμόν; οὐ παύσῃ λέγων;</l>
 						<l>τὸ δ’ Ἄργος αὐτοῦ μεστὸν ἥ τε Ναυπλία.</l>
@@ -1618,7 +1618,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="805">οὐκ ἔστ’ ἐκεῖ σός, ὦ τάλαινα, σύγγονος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἀλλ’ ἡ Λάκαινα Τυνδαρίς σ’ ἐγείνατο;</l>
 					</sp>
@@ -1626,7 +1626,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>Πέλοπός γε παιδὶ παιδός, οὗ ’κπέφυκ’ ἐγώ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τί φῄς; ἔχεις τι τῶνδέ μοι τεκμήριον;</l>
 					</sp>
@@ -1634,7 +1634,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἔχω· πατρῴων ἐκ δόμων τι πυνθάνου.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="810">οὐκοῦν λέγειν μὲν χρὴ σέ, μανθάνειν δ’ ἐμέ.</l>
 					</sp>
@@ -1643,7 +1643,7 @@ bring up to P3
 						<l>λέγοιμ’ ἄν, ἀκοῇ πρῶτον Ἠλέκτρας τάδε·</l>
 						<l>Ἀτρέως Θυέστου τ’ οἶσθα γενομένην ἔριν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἤκουσα· χρυσῆς ἀρνὸς ἦν νείκη πέρι.</l>
 					</sp>
@@ -1651,7 +1651,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ταῦτ’ οὖν ὑφήνασ’ οἶσθ’ ἐν εὐπήνοις ὑφαῖς;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="815">ὦ φίλτατ’, ἐγγὺς τῶν ἐμῶν κάμπτεις φρενῶν.</l>
 					</sp>
@@ -1659,7 +1659,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>εἰκώ τ’ ἐν ἱστοῖς ἡλίου μετάστασιν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὕφηνα καὶ τόδ’ εἶδος εὐμίτοις πλοκαῖς.</l>
 					</sp>
@@ -1667,7 +1667,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>καὶ λούτρ’ ἐς Αὖλιν μητρὸς ἀνεδέξω πάρα;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οἶδ’· οὐ γὰρ ὁ γάμος ἐσθλὸς ὤν μ’ ἀφείλετο.</l>
 					</sp>
@@ -1675,7 +1675,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="820">τί γάρ; κόμας σὰς μητρὶ δοῦσα σῇ φέρειν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μνημεῖά γ’ ἀντὶ σώματος τοὐμοῦ τάφῳ.</l>
 					</sp>
@@ -1688,7 +1688,7 @@ bring up to P3
 						<l>ἐν παρθενῶσι τοῖσι σοῖς κεκρυμμένην.</l>
 					</sp>
 					<milestone ed="p" n="827" unit="card"/>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ φίλτατ’, οὐδὲν ἄλλο, φίλτατος γὰρ εἶ,</l>
 						<l>ἔχω σ’, Ὀρέστα, τηλύγετον [χθονὸς] ἀπὸ πατρίδος</l>
@@ -1704,7 +1704,7 @@ bring up to P3
 						<l>κατὰ δὲ δάκρυ, κατὰ δὲ γόος ἅμα χαρᾷ</l>
 						<l>τὸ σὸν νοτίζει βλέφαρον, ὡσαύτως δ’ ἐμόν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τόδ’ ἔτι βρέφος</l>
 						<l n="835">ἔλιπον ἀγκάλαισι νεαρὸν τροφοῦ</l>
@@ -1717,7 +1717,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τὸ λοιπὸν εὐτυχοῖμεν ἀλλήλων μέτα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἄτοπον ἁδονὰν ἔλαβον, ὦ φίλαι·</l>
 						<l>δέδοικα δ’ ἐκ χερῶν με μὴ πρὸς αἰθέρα</l>
@@ -1733,7 +1733,7 @@ bring up to P3
 						<l n="850">γένει μὲν εὐτυχοῦμεν, ἐς δὲ συμφοράς,</l>
 						<l>ὦ σύγγον’, ἡμῶν δυστυχὴς ἔφυ βίος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἐγᾦδ’ ἁ μέλεος, οἶδ’, ὅτε φάσγανον</l>
 						<l n="854">δέρᾳ θῆκέ μοι μελεόφρων πατήρ.</l>
@@ -1742,7 +1742,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="855">οἴμοι. δοκῶ γὰρ οὐ παρών σ’ ὁρᾶν ἐκεῖ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἀνυμέναιος, &lt;ὦ&gt; σύγγον’, Ἀχιλλέως</l>
 						<l>ἐς κλισίαν λέκτρων</l>
@@ -1754,7 +1754,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ᾤμωξα κἀγὼ τόλμαν ἣν ἔτλη πατήρ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="864">ἀπάτορ’ ἀπάτορα πότμον ἔλαχον.</l>
 						<l n="865">ἄλλα δ’ ἐξ ἄλλων κυρεῖ</l>
@@ -1765,7 +1765,7 @@ bring up to P3
 						<l n="866">εἰ σόν γ’ ἀδελφόν, ὦ τάλαιν’, ἀπώλεσας.</l>
 					</sp>
 					<milestone ed="p" n="868" unit="card"/>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="868">ὦ μελέα δεινᾶς τόλμας. δείν’ ἔτλαν</l>
 						<l n="870">δείν’ ἔτλαν, ὤμοι σύγγονε. παρὰ δ’ ὀλίγον</l>
@@ -1795,7 +1795,7 @@ bring up to P3
 				</div2>
 				<div2 type="iambic">
 					<milestone ed="p" n="900" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="900">ἐν τοῖσι θαυμαστοῖσι καὶ μύθων πέρα</l>
 						<l>τάδ’ εἶδον αὐτὴ κοὐ κλύουσ’ ἀπαγγελῶ.</l>
@@ -1816,7 +1816,7 @@ bring up to P3
 						<l n="910">τοῦδε ξὺν ἡμῖν· ἢν δέ τις πρόθυμος ᾖ,</l>
 						<l>σθένειν τὸ θεῖον μᾶλλον εἰκότως ἔχει.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μηδέν μ’ ἐπίσχῃ γ’· οὐδ’ ἀποστήσει λόγου,</l>
 						<l>πρῶτον πυθέσθαι τίνα ποτ’ Ἠλέκτρα πότμον</l>
@@ -1826,7 +1826,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="915">τῷδε ξυνοικεῖ βίον ἔχουσ’ εὐδαίμονα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οὗτος δὲ ποδαπὸς καὶ τίνος πέφυκε παῖς;</l>
 					</sp>
@@ -1834,7 +1834,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>Στρόφιος ὁ Φωκεὺς τοῦδε κλῄζεται πατήρ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὁ δ’ ἐστί γ’ Ἀτρέως θυγατρός, ὁμογενὴς ἐμός;</l>
 					</sp>
@@ -1842,7 +1842,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἀνεψιός γε, μόνος ἐμοὶ σαφὴς φίλος.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="920">οὐκ ἦν τόθ’ οὗτος ὅτε πατὴρ ἔκτεινέ με.</l>
 					</sp>
@@ -1850,7 +1850,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὐκ ἦν· χρόνον γὰρ Στρόφιος ἦν ἄπαις τινά.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>χαῖρ’ ὦ πόσις μοι τῆς ἐμῆς ὁμοσπόρου.</l>
 					</sp>
@@ -1858,7 +1858,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>κἀμός γε σωτήρ, οὐχὶ συγγενὴς μόνον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τὰ δεινὰ δ’ ἔργα πῶς ἔτλης μητρὸς πέρι;</l>
 					</sp>
@@ -1866,7 +1866,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="925">σιγῶμεν αὐτά· πατρὶ τιμωρῶν ἐμῷ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἡ δ’ αἰτία τίς ἀνθ’ ὅτου κτείνει πόσιν;</l>
 					</sp>
@@ -1874,7 +1874,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἔα τὰ μητρός· οὐδὲ σοὶ κλύειν καλόν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>σιγῶ· τὸ δ’ Ἄργος πρὸς σὲ νῦν ἀποβλέπει;</l>
 					</sp>
@@ -1882,7 +1882,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>Μενέλαος ἄρχει· φυγάδες ἐσμὲν ἐκ πάτρας.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="930">οὔ που νοσοῦντας θεῖος ὕβρισεν δόμους;</l>
 					</sp>
@@ -1890,7 +1890,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὔκ, ἀλλ’ Ἐρινύων δεῖμά μ’ ἐκβάλλει χθονός.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ταῦτ’ ἆρ’ ἐπ’ ἀκταῖς κἀνθάδ’ ἠγγέλης μανείς;</l>
 					</sp>
@@ -1898,7 +1898,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὤφθημεν οὐ νῦν πρῶτον ὄντες ἄθλιοι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἔγνωκα· μητρός σ’ οὕνεκ’ ἠλάστρουν θεαί.</l>
 					</sp>
@@ -1906,7 +1906,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="935">ὥσθ’ αἱματηρὰ στόμῑ ἐπεμβαλεῖν ἐμοί.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τί γάρ ποτ’ ἐς γῆν τήνδ’ ἐπόρθμευσας πόδα;</l>
 					</sp>
@@ -1914,7 +1914,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>Φοίβου κελευσθεὶς θεσφάτοις ἀφικόμην.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τί χρῆμα δράσειν; ῥητὸν ἢ σιγώμενον;</l>
 						<milestone ed="p" n="939" unit="card"/>
@@ -1974,12 +1974,12 @@ bring up to P3
 						<l>οὐράνιον εἰ μὴ ληψόμεσθα θεᾶς βρέτας.</l>
 					</sp>
 					<milestone ed="p" n="987" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεινή τις ὀργὴ δαιμόνων ἐπέζεσε</l>
 						<l>τὸ Ταντάλειον σπέρμα διὰ πόνων τ’ ἄγει.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τὸ μὲν πρόθυμον, πρίν σε δεῦρ’ ἐλθεῖν, ἔχω</l>
 						<l n="990">Ἄργει γενέσθαι καὶ σέ, σύγγον’, εἰσιδεῖν.</l>
@@ -2019,7 +2019,7 @@ bring up to P3
 						<l>συνθεὶς τάδ’ εἰς ἓν νόστον ἐλπίζω λαβεῖν.</l>
 					</sp>
 					<milestone ed="p" n="1017" unit="card"/>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πῶς οὖν γένοιτ’ ἂν ὥστε μήθ’ ἡμᾶς θανεῖν,</l>
 						<l>λαβεῖν θ’ ἃ βουλόμεσθα; τῇδε γὰρ νοσεῖ</l>
@@ -2029,7 +2029,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="1020">ἆρ’ ἂν τύραννον διολέσαι δυναίμεθ’ ἄν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>δεινὸν τόδ’ εἶπας, ξενοφονεῖν ἐπήλυδας.</l>
 					</sp>
@@ -2037,7 +2037,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἀλλ’, εἰ σὲ σώσει κἀμέ, κινδυνευτέον.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οὐκ ἂν δυναίμην· τὸ δὲ πρόθυμον ᾔνεσα.</l>
 					</sp>
@@ -2045,7 +2045,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τί δ’, εἴ με ναῷ τῷδε κρύψειας λάθρα;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1025">ὡς δὴ σκότον λαβόντες ἐκσωθεῖμεν ἄν;</l>
 					</sp>
@@ -2053,7 +2053,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>κλεπτῶν γὰρ ἡ νύξ, τῆς δ’ ἀληθείας τὸ φῶς.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>εἴσ’ ἔνδον ἱεροὶ φύλακες, οὓς οὐ λήσομεν.</l>
 					</sp>
@@ -2061,7 +2061,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οἴμοι, διεφθάρμεσθα· πῶς σωθεῖμεν ἄν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἔχειν δοκῶ μοι καινὸν ἐξεύρημά τι.</l>
 					</sp>
@@ -2069,7 +2069,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="1030">ποῖόν τι; δόξης μετάδος, ὡς κἀγὼ μάθω.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ταῖς σαῖς ἀνίαις χρήσομαι σοφίσμασι.</l>
 					</sp>
@@ -2077,7 +2077,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>δειναὶ γὰρ αἱ γυναῖκες εὑρίσκειν τέχνας.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>φονέα σε φήσω μητρὸς ἐξ Ἄργους μολεῖν.</l>
 					</sp>
@@ -2085,7 +2085,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>χρῆσαι κακοῖσι τοῖς ἐμοῖς, εἰ κερδανεῖς.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1035">ὡς οὐ θέμις γε λέξομεν θύειν θεᾷ,</l>
 					</sp>
@@ -2093,7 +2093,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τίν’ αἰτίαν ἔχουσ’; ὑποπτεύω τι γάρ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οὐ καθαρὸν ὄντα· τὸ δ’ ὅσιον δώσω φόβῳ.</l>
 					</sp>
@@ -2101,7 +2101,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>τί δῆτα μᾶλλον θεᾶς ἄγαλμ’ ἁλίσκεται;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πόντου σε πηγαῖς ἁγνίσαι βουλήσομαι,</l>
 					</sp>
@@ -2109,7 +2109,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="1040">ἔτ’ ἐν δόμοισι βρέτας, ἐφ’ ᾧ πεπλεύκαμεν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>κἀκεῖνο νίψαι, σοῦ θιγόντος ὥς, ἐρῶ.</l>
 					</sp>
@@ -2117,7 +2117,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ποῖ δῆτα; πόντου νοτερὸν εἶπας ἔκβολον;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οὗ ναῦς χαλινοῖς λινοδέτοις ὁρμεῖ σέθεν.</l>
 					</sp>
@@ -2125,7 +2125,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>σὺ δ’ ἤ τις ἄλλος ἐν χεροῖν οἴσει βρέτας;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1045">ἐγώ· θιγεῖν γὰρ ὅσιόν ἐστ’ ἐμοὶ μόνῃ.</l>
 					</sp>
@@ -2133,7 +2133,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>Πυλάδης δ’ ὅδ’ ἡμῖν ποῦ τετάξεται πόνου;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ταὐτὸν χεροῖν σοὶ λέξεται μίασμ’ ἔχων.</l>
 					</sp>
@@ -2141,7 +2141,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>λάθρα δ’ ἄνακτος ἢ εἰδότος δράσεις τάδε;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πείσασα μύθοις· οὐ γὰρ ἂν λάθοιμί γε.</l>
 					</sp>
@@ -2149,7 +2149,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="1050">καὶ μὴν νεώς γε πίτυλος εὐήρης πάρα.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>σοὶ δὴ μέλειν χρὴ τἄλλ’ ὅπως ἕξει καλῶς.</l>
 					</sp>
@@ -2161,7 +2161,7 @@ bring up to P3
 						<l n="1055">τὰ δ’ ἄλλ’ ἴσως — . ἅπαντα συμβαίη καλῶς.</l>
 					</sp>
 					<milestone ed="p" n="1056" unit="card"/>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὦ φίλταται γυναῖκες, εἰς ὑμᾶς βλέπω,</l>
 						<l>καὶ τἄμ’ ἐν ὑμῖν ἐστιν ἢ καλῶς ἔχειν</l>
@@ -2183,13 +2183,13 @@ bring up to P3
 						<l>φθέγξασθε — ταῦτα; μὴ γὰρ αἰνουσῶν λόγους</l>
 						<l>ὄλωλα κἀγὼ καὶ κασίγνητος τάλας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1075">θάρσει, φίλη δέσποινα, καὶ σῴζου μόνον·</l>
 						<l>ὡς ἔκ γ’ ἐμοῦ σοι πάντα σιγηθήσεται — </l>
 						<l>ἴστω μέγας Ζεύς — ὧν ἐπισκήπτεις πέρι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ὄναισθε μύθων καὶ γένοισθ’ εὐδαίμονες.</l>
 						<l>
@@ -2214,7 +2214,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὄρνις, ἃ παρὰ πετρίνας</l>
 						<l n="1090">πόντου δειράδας, ἀλκυών,</l>
@@ -2237,7 +2237,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πολλαὶ δακρύων λιβάδες,</l>
 						<l>αἳ παρηίδας εἰς ἐμὰς</l>
@@ -2260,7 +2260,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ σὲ μέν, πότνῑ, Ἀργεία</l>
 						<l>πεντηκόντορος οἶκον ἄξει·</l>
@@ -2280,7 +2280,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λαμπροὺς ἱπποδρόμους βαίην,</l>
 						<l>ἔνθ’ εὐάλιον ἔρχεται πῦρ·</l>
@@ -2307,7 +2307,7 @@ bring up to P3
 					<l>Ἑλληνίς; ἤδη τῶν ξένων κατήρξατο;</l>
 					<l n="1155">ἀδύτοις ἐν ἁγνοῖς σῶμα λάμπονται πυρί;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἥδ’ ἐστίν, ἥ σοι πάντ’, ἄναξ, ἐρεῖ σαφῶς.</l>
 				</sp>
@@ -2317,7 +2317,7 @@ bring up to P3
 					<l>τί τόδε μεταίρεις ἐξ ἀκινήτων βάθρων,</l>
 					<l>Ἀγαμέμνονος παῖ, θεᾶς ἄγαλμ’ ἐν ὠλέναις;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἄναξ, ἔχ’ αὐτοῦ πόδα σὸν ἐν παραστάσιν.</l>
 				</sp>
@@ -2325,7 +2325,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l n="1160">τί δ’ ἔστιν, Ἰφιγένεια, καινὸν ἐν δόμοις;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἀπέπτυσ’· Ὁσίᾳ γὰρ δίδωμ’ ἔπος τόδε.</l>
 				</sp>
@@ -2333,7 +2333,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>τί φροιμιάζῃ νεοχμόν; ἐξαύδα σαφῶς.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>οὐ καθαρά μοι τὰ θύματ’ ἠγρεύσασθ’, ἄναξ.</l>
 				</sp>
@@ -2341,7 +2341,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>τί τοὐκδιδάξαν τοῦτό σ’; ἢ δόξαν λέγεις;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l n="1165">βρέτας τὸ τῆς θεοῦ πάλιν ἕδρας ἀπεστράφη.</l>
 				</sp>
@@ -2349,7 +2349,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>αὐτόματον, ἤ νιν σεισμὸς ἔστρεψε χθονός;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>αὐτόματον· ὄψιν δ’ ὀμμάτων ξυνήρμοσεν.</l>
 				</sp>
@@ -2357,7 +2357,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>ἡ δ’ αἰτία τίς; ἦ τὸ τῶν ξένων μύσος;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἥδ’, οὐδὲν ἄλλο· δεινὰ γὰρ δεδράκατον.</l>
 				</sp>
@@ -2365,7 +2365,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l n="1170">ἀλλ’ ἦ τιν’ ἔκανον βαρβάρων ἀκτῆς ἔπι;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>οἰκεῖον ἦλθον τὸν φόνον κεκτημένοι.</l>
 				</sp>
@@ -2373,7 +2373,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>τίν’; εἰς ἔρον γὰρ τοῦ μαθεῖν πεπτώκαμεν.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>μητέρα κατειργάσαντο κοινωνῷ ξίφει.</l>
 				</sp>
@@ -2381,7 +2381,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>Ἄπολλον, οὐδ’ ἐν βαρβάροις ἔτλη τις ἄν.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l n="1175">πάσης διωγμοῖς ἠλάθησαν Ἑλλάδος.</l>
 				</sp>
@@ -2389,7 +2389,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>ἦ τῶνδ’ ἕκατι δῆτ’ ἄγαλμ’ ἔξω φέρεις;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>σεμνόν γ’ ὑπ’ αἰθέρ’, ὡς μεταστήσω φόνου.</l>
 				</sp>
@@ -2397,7 +2397,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>μίασμα δ’ ἔγνως τοῖν ξένοιν ποίῳ τρόπῳ;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἤλεγχον, ὡς θεᾶς βρέτας ἀπεστράφη πάλιν.</l>
 				</sp>
@@ -2405,7 +2405,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l n="1180">σοφήν σ’ ἔθρεψεν Ἑλλάς, ὡς ᾔσθου καλῶς.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>καὶ μὴν καθεῖσαν δέλεαρ ἡδύ μοι φρενῶν.</l>
 				</sp>
@@ -2413,7 +2413,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>τῶν Ἀργόθεν τι φίλτρον ἀγγέλλοντέ σοι;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>τὸν μόνον Ὀρέστην ἐμὸν ἀδελφὸν εὐτυχεῖν.</l>
 				</sp>
@@ -2421,7 +2421,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>ὡς δή σφε σῴσαις ἡδοναῖς ἀγγελμάτων.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l n="1185">καὶ πατέρα γε ζῆν καὶ καλῶς πράσσειν ἐμόν.</l>
 				</sp>
@@ -2429,7 +2429,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>σὺ δ’ ἐς τὸ τῆς θεοῦ γ’ ἐξένευσας εἰκότως.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>πᾶσάν γε μισοῦσ’ Ἑλλάδ’, ἥ μ’ ἀπώλεσεν.</l>
 				</sp>
@@ -2437,7 +2437,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>τί δῆτα δρῶμεν, φράζε, τοῖν ξένοιν πέρι;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>τὸν νόμον ἀνάγκη τὸν προκείμενον σέβειν.</l>
 				</sp>
@@ -2445,7 +2445,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l n="1190">οὔκουν ἐν ἔργῳ χέρνιβες ξίφος τε σόν;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἁγνοῖς καθαρμοῖς πρῶτά νιν νίψαι θέλω.</l>
 				</sp>
@@ -2453,7 +2453,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>πηγαῖσιν ὑδάτων ἢ θαλασσίᾳ δρόσῳ;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>θάλασσα κλύζει πάντα τἀνθρώπων κακά.</l>
 				</sp>
@@ -2461,7 +2461,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>ὁσιώτερον γοῦν τῇ θεῷ πέσοιεν ἄν.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l n="1195">καὶ τἀμά γ’ οὕτω μᾶλλον ἂν καλῶς ἔχοι.</l>
 				</sp>
@@ -2469,7 +2469,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>οὔκουν πρὸς αὐτὸν ναὸν ἐκπίπτει κλύδων;</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἐρημίας δεῖ· καὶ γὰρ ἄλλα δράσομεν.</l>
 				</sp>
@@ -2477,7 +2477,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>ἄγ’ ἔνθα χρῄζεις· οὐ φιλῶ τἄρρηθ’ ὁρᾶν.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>ἁγνιστέον μοι καὶ τὸ τῆς θεοῦ βρέτας.</l>
 				</sp>
@@ -2485,7 +2485,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l n="1200">εἴπερ γε κηλὶς ἔβαλέ νιν μητροκτόνος.</l>
 				</sp>
-				<sp who="#ifigeneia">
+				<sp who="#iphigeneia">
 					<speaker>Ἰφιγένεια</speaker>
 					<l>οὐ γάρ ποτ’ ἄν νιν ἠράμην βάθρων ἄπο.</l>
 				</sp>
@@ -2495,7 +2495,7 @@ bring up to P3
 					<milestone ed="p" n="1203" unit="card"/>
 				</sp>
 				<div2 type="trochees">
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>οἶσθά νυν ἅ μοι γενέσθω;</l>
 					</sp>
@@ -2503,7 +2503,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">σὸν τὸ σημαίνειν τόδε.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>δεσμὰ τοῖς ξένοισι πρόσθες.</l>
 					</sp>
@@ -2511,7 +2511,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">ποῖ δέ σ’ ἐκφύγοιεν ἄν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1205">πιστὸν Ἑλλὰς οἶδεν οὐδέν.</l>
 					</sp>
@@ -2519,7 +2519,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">ἴτ’ ἐπὶ δεσμά, πρόσπολοι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>κἀκκομιζόντων δὲ δεῦρο τοὺς ξένους — </l>
 					</sp>
@@ -2527,7 +2527,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">ἔσται τάδε.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>κρᾶτα κρύψαντες πέπλοισιν.</l>
 					</sp>
@@ -2535,7 +2535,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">ἡλίου πρόσθεν φλογός.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>σῶν τέ μοι σύμπεμπ’ ὀπαδῶν.</l>
 					</sp>
@@ -2543,7 +2543,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">οἵδ’ ὁμαρτήσουσί σοι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>καὶ πόλει πέμψον τιν’ ὅστις σημανεῖ — </l>
 					</sp>
@@ -2551,7 +2551,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">ποίας τύχας;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1210">ἐν δόμοις μίμνειν ἅπαντας.</l>
 					</sp>
@@ -2559,7 +2559,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">μὴ συναντῷεν φόνῳ;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μυσαρὰ γὰρ τὰ τοιάδ’ ἐστί.</l>
 					</sp>
@@ -2567,7 +2567,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">στεῖχε καὶ σήμαινε σύ — </l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>μηδέν’ εἰς ὄψιν πελάζειν.</l>
 					</sp>
@@ -2575,7 +2575,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">εὖ γε κηδεύεις πόλιν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>καὶ φίλων γ’ οὓς δεῖ μάλιστα.</l>
 					</sp>
@@ -2583,7 +2583,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">τοῦτ’ ἔλεξας εἰς ἐμέ.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<!-- lacuna here? -->
 						<l>. . .</l>
@@ -2592,7 +2592,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">ὡς εἰκότως σε πᾶσα θαυμάζει πόλις.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1215">σὺ δὲ μένων αὐτοῦ πρὸ ναῶν τῇ θεῷ — </l>
 					</sp>
@@ -2600,7 +2600,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">τί χρῆμα δρῶ;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἅγνισον πυρσῷ μέλαθρον.</l>
 					</sp>
@@ -2608,7 +2608,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">καθαρὸν ὡς μόλῃς πάλιν.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἡνίκ’ ἂν δ’ ἔξω περῶσιν οἱ ξένοι — </l>
 					</sp>
@@ -2616,7 +2616,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">τί χρή με δρᾶν;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>πέπλον ὀμμάτων προθέσθαι.</l>
 					</sp>
@@ -2624,7 +2624,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">μὴ παλαμναῖον λάβω.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>ἢν δ’ ἄγαν δοκῶ χρονίζειν — </l>
 					</sp>
@@ -2632,7 +2632,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">τοῦδ’ ὅρος τίς ἐστί μοι;</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l n="1220">θαυμάσῃς μηδέν.</l>
 					</sp>
@@ -2640,7 +2640,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">τὰ τῆς θεοῦ πρᾶσσ’ — ἐπεὶ σχολή — καλῶς.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>εἰ γὰρ ὡς θέλω καθαρμὸς ὅδε πέσοι.</l>
 					</sp>
@@ -2648,7 +2648,7 @@ bring up to P3
 						<speaker>Θόας</speaker>
 						<l part="Y">συνεύχομαι.</l>
 					</sp>
-					<sp who="#ifigeneia">
+					<sp who="#iphigeneia">
 						<speaker>Ἰφιγένεια</speaker>
 						<l>τούσδ’ ἄρ’ ἐκβαίνοντας ἤδη δωμάτων ὁρῶ ξένους</l>
 						<l>καὶ θεᾶς κόσμους νεογνούς τ’ ἄρνας, ὡς φόνῳ φόνον</l>
@@ -2671,7 +2671,7 @@ bring up to P3
 			<milestone ed="p" n="1234" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὔπαις ὁ Λατοῦς γόνος,</l>
 						<l n="1235">τόν ποτε Δηλιὰς ἐν καρποφόροις γυάλοις</l>
@@ -2700,7 +2700,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Θέμιν δ’ ἐπεὶ γᾶς ἰὼν</l>
 						<l n="1260">παῖδ’ ἀπενάσσατο &lt;Πυθῶνος&gt; ἀπὸ ζαθέων</l>
@@ -2730,49 +2730,49 @@ bring up to P3
 			</div1>
 			<milestone ed="p" n="1284" unit="card"/>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὦ ναοφύλακες βώμιοί τ’ ἐπιστάται,</l>
 					<l n="1285">Θόας ἄναξ γῆς τῆσδε ποῦ κυρεῖ βεβώς;</l>
 					<l>καλεῖτ’ ἀναπτύξαντες εὐγόμφους πύλας</l>
 					<l>ἔξω μελάθρων τῶνδε κοίρανον χθονός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ ἔστιν, εἰ χρὴ μὴ κελευσθεῖσαν λέγειν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>βεβᾶσι φροῦδοι δίπτυχοι νεανίαι</l>
 					<l n="1290">Ἀγαμεμνονείας παιδὸς ἐκ βουλευμάτων</l>
 					<l>φεύγοντες ἐκ γῆς τῆσδε καὶ σεμνὸν βρέτας</l>
 					<l>λαβόντες ἐν κόλποισιν Ἑλλάδος νεώς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄπιστον εἶπας μῦθον· ὃν δ’ ἰδεῖν θέλεις</l>
 					<l>ἄνακτα χώρας, φροῦδος ἐκ ναοῦ συθείς.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1295">ποῖ; δεῖ γὰρ αὐτὸν εἰδέναι τὰ δρώμενα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ ἴσμεν· ἀλλὰ στεῖχε καὶ δίωκέ νιν</l>
 					<l>ὅπου κυρήσας τούσδ’ ἀπαγγελεῖς λόγους.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὁρᾶτ’, ἄπιστον ὡς γυναικεῖον γένος·</l>
 					<l>μέτεστι χὑμῖν τῶν πεπραγμένων μέρος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1300">μαίνῃ· τί δ’ ἡμῖν τῶν ξένων δρασμοῦ μέτα;</l>
 					<l>οὐκ εἶ κρατούντων πρὸς πύλας ὅσον τάχος;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὔ, πρίν γ’ ἂν εἴπῃ τοὔπος ἑρμηνεὺς ὅδε,</l>
 					<l>εἴτ’ ἔνδον εἴτ’ οὐκ ἔνδον ἀρχηγὸς χθονός.</l>
@@ -2788,7 +2788,7 @@ bring up to P3
 					<l>τίς ἀμφὶ δῶμα θεᾶς τόδ’ ἵστησιν βοήν,</l>
 					<l>πύλας ἀράξας καὶ ψόφον πέμψας ἔσω;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>φεῦ·</l>
 					<l>πῶς ἔλεγον αἵδε, καί μ’ ἀπήλαυνον δόμων,</l>
@@ -2798,7 +2798,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>τί προσδοκῶσαι κέρδος ἢ θηρώμεναι;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>αὖθις τὰ τῶνδε σημανῶ· τὰ δ’ ἐν ποσὶ</l>
 					<l>παρόντ’ ἄκουσον. ἡ νεᾶνις ἣ ’νθάδε</l>
@@ -2810,7 +2810,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>πῶς φῄς; τί πνεῦμα συμφορᾶς κεκτημένη;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>σῴζουσ’ Ὀρέστην· τοῦτο γὰρ σὺ θαυμάσῃ.</l>
 				</sp>
@@ -2818,7 +2818,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>τὸν ποῖον; ἆρ’ ὃν Τυνδαρὶς τίκτει κόρη;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1320">ὃν τοῖσδε βωμοῖς θεὰ καθωσιώσατο.</l>
 				</sp>
@@ -2826,7 +2826,7 @@ bring up to P3
 					<speaker>Θόας</speaker>
 					<l>ὦ θαῦμα — πῶς σε μεῖζον ὀνομάσας τύχω;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>μὴ ’νταῦθα τρέψῃς σὴν φρέν’, ἀλλ’ ἄκουέ μου·</l>
 					<l>σαφῶς δ’ ἀθρήσας καὶ κλύων ἐκφρόντισον</l>
@@ -2838,7 +2838,7 @@ bring up to P3
 					<l>φεύγουσιν, ὥστε διαφυγεῖν τοὐμὸν δόρυ.</l>
 					<milestone ed="p" n="1327" unit="card"/>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐπεὶ πρὸς ἀκτὰς ἤλθομεν θαλασσίας,</l>
 					<l>οὗ ναῦς Ὀρέστου κρύφιος ἦν ὡρμισμένη,</l>
@@ -2945,7 +2945,7 @@ bring up to P3
 					<l>λαβεῖν, ἀδελφήν θ’, ἣ φόνον τὸν Αὐλίδι</l>
 					<l>ἀμνημόνευτον θεᾷ προδοῦσ’ ἁλίσκεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1420">ὦ τλῆμον Ἰφιγένεια, συγγόνου μέτα</l>
 					<l>θανῇ πάλιν μολοῦσα δεσποτῶν χέρας.</l>
@@ -3050,7 +3050,7 @@ bring up to P3
 					<milestone ed="p" n="1490" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1490">ἴτ’ ἐπ’ εὐτυχίᾳ τῆς σῳζομένης</l>
 						<l>μοίρας εὐδαίμονες ὄντες.</l>

--- a/tei/euripides-orestes.xml
+++ b/tei/euripides-orestes.xml
@@ -54,19 +54,19 @@
 					<person xml:id="orestes">
 						<persName>Ὀρέστης</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
 					<person xml:id="pylades">
 						<persName>Πυλάδης</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός </name>
 					</personGrp>
 					<person xml:id="ermione">
 						<persName>Ερμιόνη</persName>
 					</person>
-					<person xml:id="elene">
+					<person xml:id="helene">
 						<persName>Ἑλένη</persName>
 					</person>
 					<person xml:id="elektra">
@@ -75,16 +75,16 @@
 					<person xml:id="menelaos">
 						<persName>Μενέλαος</persName>
 					</person>
-					<person xml:id="emixoros">
-						<persName>Ἡμίχορος</persName>
-					</person>
+					<personGrp xml:id="hemichoros">
+						<name>Ἡμίχορος</name>
+					</personGrp>
 					<person xml:id="apollon">
 						<persName>Ἀπόλλων</persName>
 					</person>
 					<person xml:id="tyndareos">
 						<persName>Τυνδάρεως</persName>
 					</person>
-					<person xml:id="fryks">
+					<person xml:id="phryx">
 						<persName>Φρύξ</persName>
 					</person>
 				</listPerson>
@@ -256,7 +256,7 @@ bring up to P3
 					<l n="70">σωθῶμεν. ἄπορον χρῆμα δυστυχῶν δόμος.</l>
 				</sp>
 				<milestone ed="p" n="71" unit="card"/>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ὦ παῖ Κλυταιμήστρας τε καὶ Ἀγαμέμνονος,</l>
 					<l>παρθένε μακρὸν δὴ μῆκος Ἠλέκτρα χρόνου,</l>
@@ -279,7 +279,7 @@ bring up to P3
 					<l>σὺ δ’ εἶ μακαρία μακάριός θ’ ὁ σὸς πόσις.</l>
 					<l>[ἥκετον ἐφ’ ἡμᾶς ἀθλίως πεπραγότας]</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>πόσον χρόνον δ’ ἐν δεμνίοις πέπτωχ’ ὅδε;</l>
 				</sp>
@@ -287,7 +287,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἐξ οὗπερ αἷμα γενέθλιον κατήνυσεν.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="90">ὢ μέλεος· ἡ τεκοῦσά θ’, ὡς διώλετο.</l>
 				</sp>
@@ -295,7 +295,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>οὕτως ἔχει τάδ’, ὥστ’ ἀπείρηκεν κακοῖς.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>πρὸς θεῶν, πίθοῑ ἂν δῆτά μοί τι, παρθένε;</l>
 				</sp>
@@ -303,7 +303,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ὡς ἄσχολός γε συγγόνου προσεδρίᾳ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>βούλῃ τάφον μοι πρὸς κασιγνήτης μολεῖν;</l>
 				</sp>
@@ -311,7 +311,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="95">μητρὸς κελεύεις τῆς ἐμῆς; τίνος χάριν;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>κόμης ἀπαρχὰς καὶ χοὰς φέρουσ’ ἐμάς.</l>
 				</sp>
@@ -319,7 +319,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>σοὶ δ’ οὐχὶ θεμιτὸν πρὸς φίλων στείχειν τάφον;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>δεῖξαι γὰρ Ἀργείοισι σῶμ’ αἰσχύνομαι.</l>
 				</sp>
@@ -327,7 +327,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ὀψέ γε φρονεῖς εὖ, τότε λιποῦσ’ αἰσχρῶς δόμους.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="100">ὀρθῶς ἔλεξας, οὐ φίλως δ’ ἐμοὶ λέγεις.</l>
 				</sp>
@@ -335,7 +335,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>αἰδὼς δὲ δὴ τίς σ’ ἐς Μυκηναίους ἔχει;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>δέδοικα πατέρας τῶν ὑπ’ Ἰλίῳ νεκρῶν.</l>
 				</sp>
@@ -343,7 +343,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>δεινὸν γάρ· Ἄργει τ’ ἀναβοᾷ διὰ στόμα.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>σύ νυν χάριν μοι τὸν φόβον λύσασα δός.</l>
 				</sp>
@@ -351,7 +351,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="105">οὐκ ἂν δυναίμην μητρὸς ἐσβλέψαι τάφον.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>αἰσχρόν γε μέντοι προσπόλους φέρειν τάδε.</l>
 				</sp>
@@ -359,7 +359,7 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τί δ’ οὐχὶ θυγατρὸς Ἑρμιόνης πέμπεις δέμας;</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἐς ὄχλον ἕρπειν παρθένοισιν οὐ καλόν.</l>
 				</sp>
@@ -368,7 +368,7 @@ bring up to P3
 					<l>καὶ μὴν τίνοι γ’ ἂν τῇ τεθνηκυίᾳ τροφάς.</l>
 					<milestone ed="p" n="110" unit="card"/>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="110">ὀρθῶς ἔλεξας, πείθομαί τέ σοι, κόρη.</l>
 					<l>[καὶ πέμψομέν γε θυγατέρ’· εὖ γάρ τοι λέγεις.]</l>
@@ -411,7 +411,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="140">σῖγα σῖγα, λεπτὸν ἴχνος ἀρβύλης</l>
 						<l>τίθετε, μὴ κτυπεῖτ’.</l>
@@ -420,7 +420,7 @@ bring up to P3
 						<speaker>Ἠλέκτρα</speaker>
 						<l>ἀποπρὸ βᾶτ’ ἐκεῖσ’, ἀποπρό μοι κοίτας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰδού, πείθομαι.</l>
 					</sp>
@@ -429,7 +429,7 @@ bring up to P3
 						<l n="145">ἆ ἆ σύριγγος ὅπως πνοὰ</l>
 						<l>λεπτοῦ δόνακος, ὦ φίλα, φώνει μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴδ’, ἀτρεμαῖον ὡς ὑπόροφον φέρω</l>
 						<l>βοάν.</l>
@@ -444,7 +444,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς ἔχει; λόγου μετάδος, ὦ φίλα·</l>
 						<l>τίνα τύχαν εἴπω; τίνα δὲ συμφοράν;</l>
@@ -453,7 +453,7 @@ bring up to P3
 						<speaker>Ἠλέκτρα</speaker>
 						<l n="155">ἔτι μὲν ἐμπνέει, βραχὺ δ’ ἀναστένει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί φῄς; ὦ τάλας.</l>
 					</sp>
@@ -462,7 +462,7 @@ bring up to P3
 						<l n="158">ὀλεῖς, εἰ βλέφαρα κινήσεις</l>
 						<l>ὕπνου γλυκυτάταν φερομένῳ χάριν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="160">μέλεος ἐχθίστων θεόθεν ἐργμάτων,</l>
 						<l>τάλας.</l>
@@ -477,7 +477,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρᾷς; ἐν πέπλοισι κινεῖ δέμας.</l>
 					</sp>
@@ -486,7 +486,7 @@ bring up to P3
 						<l>σὺ γάρ νιν, ὦ τάλαινα,</l>
 						<l>θωΰξασ’ ἔβαλες ἐξ ὕπνου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὕδειν μὲν οὖν ἔδοξα.</l>
 					</sp>
@@ -496,7 +496,7 @@ bring up to P3
 						<l>πάλιν ἀνὰ πόδα σὸν εἱλίξεις</l>
 						<l>μεθεμένα κτύπου;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὑπνώσσει.</l>
 					</sp>
@@ -516,7 +516,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θρόει τίς κακῶν τελευτὰ μένει.</l>
 					</sp>
@@ -525,7 +525,7 @@ bring up to P3
 						<l>θανεῖν &lt;θανεῖν&gt;, τί δ’ ἄλλο;</l>
 						<l>οὐδὲ γὰρ πόθον ἔχει βορᾶς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="190">πρόδηλος ἆρ’ ὁ πότμος.</l>
 					</sp>
@@ -535,7 +535,7 @@ bring up to P3
 						<l>μέλεον ἀπόφονον αἷμα δοὺς</l>
 						<l>πατροφόνου ματρός.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δίκᾳ μέν.</l>
 					</sp>
@@ -556,7 +556,7 @@ bring up to P3
 			</div1>
 			<milestone ed="p" n="208" unit="card"/>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅρα παροῦσα, παρθέν’ Ἠλέκτρα, πέλας,</l>
 					<l>μὴ κατθανών σε σύγγονος λέληθ’ ὅδε·</l>
@@ -765,7 +765,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ,</l>
 						<l>δρομάδες ὦ πτεροφόροι</l>
@@ -787,7 +787,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ Ζεῦ,</l>
 						<l>τίς ἔλεος, τίς ὅδ’ ἀγὼν</l>
@@ -811,7 +811,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν βασιλεὺς ὅδε δὴ στείχει,</l>
 						<l>Μενέλαος ἄναξ, πολλῇ ἁβροσύνῃ</l>
@@ -1128,7 +1128,7 @@ bring up to P3
 						<l>ὄνομα γάρ, ἔργον δ’ οὐκ ἔχουσιν οἱ φίλοι</l>
 						<l n="455">οἱ μὴ ’πὶ ταῖσι συμφοραῖς ὄντες φίλοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν γέροντι δεῦρ’ ἁμιλλᾶται ποδὶ</l>
 						<l>ὁ Σπαρτιάτης Τυνδάρεως, μελάμπεπλος</l>
@@ -1269,7 +1269,7 @@ bring up to P3
 						<l n="540">ἐγὼ δὲ τἄλλα μακάριος πέφυκ’ ἀνήρ,</l>
 						<l>πλὴν ἐς θυγατέρας· τοῦτο δ’ οὐκ εὐδαιμονῶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ζηλωτὸς ὅστις εὐτύχησεν ἐς τέκνα</l>
 						<l>καὶ μὴ ’πισήμους συμφορὰς ἐκτήσατο.</l>
@@ -1349,7 +1349,7 @@ bring up to P3
 						<l>μακάριος αἰών· οἷς δὲ μὴ πίπτουσιν εὖ,</l>
 						<l>τά τ’ ἔνδον εἰσὶ τά τε θύραζε δυστυχεῖς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="605">αἰεὶ γυναῖκες ἐμποδὼν ταῖς συμφοραῖς</l>
 						<l>ἔφυσαν ἀνδρῶν πρὸς τὸ δυστυχέστερον.</l>
@@ -1458,7 +1458,7 @@ bring up to P3
 						<l>εἴρηκα κἀπῄτηκα τὴν σωτηρίαν,</l>
 						<l>θηρῶν ὃ πάντες κοὐκ ἐγὼ ζητῶ μόνος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="680">κἀγώ σ’ ἱκνοῦμαι καὶ γυνή περ οὖσ’ ὅμως</l>
 						<l>τοῖς δεομένοισιν ὠφελεῖν· οἷός τε δ’ εἶ.</l>
@@ -1911,7 +1911,7 @@ bring up to P3
 			<milestone ed="p" n="807" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ μέγας ὄλβος ἅ τ’ ἀρετὰ</l>
 						<l>μέγα φρονοῦσ’ ἀν’ Ἑλλάδα καὶ</l>
@@ -1929,7 +1929,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ καλὸν οὐ καλόν, τοκέων</l>
 						<l n="820">πυριγενεῖ τεμεῖν παλάμᾳ</l>
@@ -1947,7 +1947,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς νόσος ἢ τίνα δάκρυα καὶ</l>
 						<l>τίς ἔλεος μείζων κατὰ γᾶν</l>
@@ -1972,7 +1972,7 @@ bring up to P3
 					<l>γυναῖκες, ἦ που τῶνδ’ ἀφώρμηται δόμων</l>
 					<l n="845">τλήμων Ὀρέστης θεομανεῖ λύσσῃ δαμείς;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἥκιστα· πρὸς δ’ Ἀργεῖον οἴχεται λεών,</l>
 					<l>ψυχῆς ἀγῶνα τὸν προκείμενον πέρι</l>
@@ -1982,12 +1982,12 @@ bring up to P3
 					<speaker>Ἠλέκτρα</speaker>
 					<l>οἴμοι· τί χρῆμ’ ἔδρασε; τίς δ’ ἔπεισέ νιν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="850">Πυλάδης· ἔοικε δ’ οὐ μακρὰν ὅδ’ ἄγγελος</l>
 					<l>λέξειν τὰ κεῖθεν σοῦ κασιγνήτου πέρι.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὦ τλῆμον, ὦ δύστηνε τοῦ στρατηλάτου</l>
 					<l>Ἀγαμέμνονος παῖ, πότνῑ Ἠλέκτρα, λόγους</l>
@@ -1998,7 +1998,7 @@ bring up to P3
 					<l n="855">αἰαῖ, διοιχόμεσθα· δῆλος εἶ λόγῳ.</l>
 					<l>κακῶν γὰρ ἥκεις, ὡς ἔοικεν, ἄγγελος.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ψήφῳ Πελασγῶν σὸν κασίγνητον θανεῖν</l>
 					<l>καὶ σέ, ὦ τάλαιν’, ἔδοξε τῇδ’ ἐν ἡμέρᾳ.</l>
@@ -2014,7 +2014,7 @@ bring up to P3
 					<l n="865">κοινὰς ἀδελφῷ συμφορὰς κεκτημένην;</l>
 					<milestone ed="p" n="866" unit="card"/>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐτύγχανον μὲν ἀγρόθεν πυλῶν ἔσω</l>
 					<l>βαίνων, πυθέσθαι δεόμενος τά τ’ ἀμφὶ σοῦ</l>
@@ -2125,7 +2125,7 @@ bring up to P3
 					<l n="955">οὐδέν σ’ ἐπωφέλησεν, οὐδ’ ὁ Πύθιος</l>
 					<l>τρίποδα καθίζων Φοῖβος, ἀλλ’ ἀπώλεσεν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>[Χορός ]</speaker>
 					<l>ὦ δυστάλαινα παρθέν’, ὡς ξυνηρεφὲς</l>
 					<l>πρόσωπον εἰς γῆν σὸν βαλοῦσ’ ἄφθογγος εἶ,</l>
@@ -2213,7 +2213,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ὅδε σὸς σύγγονος ἕρπει</l>
 						<l>ψήφῳ θανάτου κατακυρωθείς,</l>
@@ -2535,7 +2535,7 @@ bring up to P3
 						<l>ἑνὸς γὰρ οὐ σφαλέντες ἕξομεν κλέος,</l>
 						<l>καλῶς θανόντες ἢ καλῶς σεσῳσμένοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάσαις γυναιξὶν ἀξία στυγεῖν ἔφυ</l>
 						<l>ἡ Τυνδαρὶς παῖς, ἣ κατῄσχυνεν γένος.</l>
@@ -2740,7 +2740,7 @@ bring up to P3
 						<l>Μυκηνίδες ὦ φίλαι,</l>
 						<l>τὰ πρῶτα κατὰ Πελασγὸν ἕδος Ἀργείων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1249">τίνα θροεῖς αὐδάν, πότνια; παραμένει</l>
 						<l n="1250">γὰρ ἔτι σοι τόδ’ ἐν Δαναϊδῶν πόλει.</l>
@@ -2750,7 +2750,7 @@ bring up to P3
 						<l>στῆθ’ αἳ μὲν ὑμῶν τόνδ’ ἁμαξήρη τρίβον,</l>
 						<l>αἳ δ’ ἐνθάδ’ ἄλλον οἶμον ἐς φρουρὰν δόμων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί δέ με τόδε χρέος ἀπύεις;</l>
 						<l>ἔνεπέ μοι, φίλα.</l>
@@ -2761,12 +2761,12 @@ bring up to P3
 						<l>σταθεὶς ἐπὶ φοίνιον αἷμα</l>
 						<l>πήματα πήμασιν ἐξεύρῃ.</l>
 					</sp>
-					<sp who="#emixoros">
+					<sp who="#hemichoros">
 						<speaker>Ἡμίχορος</speaker>
 						<l>χωρεῖτ’, ἐπειγώμεσθ’· ἐγὼ μὲν οὖν τρίβον</l>
 						<l>τόνδ’ ἐκφυλάξω, τὸν πρὸς ἡλίου βολάς.</l>
 					</sp>
-					<sp who="#emixoros">
+					<sp who="#hemichoros">
 						<speaker>Ἡμίχορος</speaker>
 						<l n="1260">καὶ μὴν ἐγὼ τόνδ’, ὃς πρὸς ἑσπέραν φέρει.</l>
 					</sp>
@@ -2774,7 +2774,7 @@ bring up to P3
 						<speaker>Ἠλέκτρα</speaker>
 						<l>δόχμιά νυν κόρας διάφερ’ ὀμμάτων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐκεῖθεν ἐνθάδ’, εἶτα παλινσκοπιὰν</l>
 						<l n="1265">ἔχομεν, ὡς θροεῖς.</l>
@@ -2787,7 +2787,7 @@ bring up to P3
 						<l>ἑλίσσετέ νυν βλέφαρα,</l>
 						<l>κόραισι δίδοτε πάντα διὰ βοστρύχων.</l>
 					</sp>
-					<sp who="#emixoros">
+					<sp who="#hemichoros">
 						<speaker>Ἡμίχορος</speaker>
 						<l n="1269">ὅδε τις ἐν τρίβῳ [προσέρχεται]. τίς ὅδ’ ἄρ’ ἀμ‐</l>
 						<l n="1270">φὶ μέλαθρον πολεῖ σὸν ἀγρότας ἀνήρ;</l>
@@ -2797,7 +2797,7 @@ bring up to P3
 						<l>ἀπωλόμεσθ’ ἄρ’, ὦ φίλαι· κεκρυμμένους</l>
 						<l>θῆρας ξιφήρεις αὐτίκ’ ἐχθροῖσιν φανεῖ.</l>
 					</sp>
-					<sp who="#emixoros">
+					<sp who="#hemichoros">
 						<speaker>Ἡμίχορος</speaker>
 						<l>ἄφοβος ἔχε· κενός, ὦ φίλα,</l>
 						<l>στίβος ὃν οὐ δοκεῖς.</l>
@@ -2808,12 +2808,12 @@ bring up to P3
 						<l>δὸς ἀγγελίαν ἀγαθάν τιν’,</l>
 						<l>εἰ τάδ’ ἔρημα τὰ πρόσθ’ αὐλᾶς.</l>
 					</sp>
-					<sp who="#emixoros">
+					<sp who="#hemichoros">
 						<speaker>Ἡμίχορος</speaker>
 						<l>καλῶς τά γ’ ἐνθένδ’. ἀλλὰ τἀπὶ σοῦ σκόπει·</l>
 						<l>ὡς οὔτις ἡμῖν Δαναϊδῶν πελάζεται.</l>
 					</sp>
-					<sp who="#emixoros">
+					<sp who="#hemichoros">
 						<speaker>Ἡμίχορος</speaker>
 						<l n="1280">ἐς ταὐτὸν ἥκεις· καὶ γὰρ οὐδὲ τῇδ’ ὄχλος.</l>
 					</sp>
@@ -2821,7 +2821,7 @@ bring up to P3
 						<speaker>Ἠλέκτρα</speaker>
 						<l>φέρε νυν ἐν πύλαισιν ἀκοὰν βάλω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1284">τί μέλλεθ’ οἱ κατ’ οἶκον ἐν ἡσυχίᾳ</l>
 						<l n="1285">σφάγια φοινίσσειν;</l>
@@ -2840,15 +2840,15 @@ bring up to P3
 						<l>σκέψασθέ νυν ἄμεινον· οὐχ ἕδρας ἀγών·</l>
 						<l>ἀλλ’ αἳ μὲν ἐνθάδ’, αἳ δ’ ἐκεῖσ’ ἑλίσσετε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1295">ἀμείβω κέλευθον σκοποῦσα πάντῃ.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>ἰὼ Πελασγὸν Ἄργος, ὄλλυμαι κακῶς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — ἠκούσαθ’; ἅνδρες χεῖρ’ ἔχουσιν ἐν φόνῳ.</l>
 						<l> — Ἑλένης τὸ κώκυμ’ ἐστίν, ὡς ἀπεικάσαι.</l>
@@ -2858,7 +2858,7 @@ bring up to P3
 						<l>ὦ Διός, ὦ Διὸς ἀέναον κράτος,</l>
 						<l n="1300">ἔλθ’ ἐπίκουρος ἐμοῖς φίλοισι πάντως.</l>
 					</sp>
-					<sp who="#elene">
+					<sp who="#helene">
 						<speaker>Ἑλένη</speaker>
 						<l>Μενέλαε, θνῄσκω· σὺ δὲ παρών μ’ οὐκ ὠφελεῖς.</l>
 						<milestone ed="p" n="1302" unit="card"/>
@@ -2878,7 +2878,7 @@ bring up to P3
 					<milestone ed="p" n="1311" unit="card"/>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σιγᾶτε σιγᾶτ’· ᾐσθόμην κτύπου τινὸς</l>
 						<l>κέλευθον ἐσπεσόντος ἀμφὶ δώματα.</l>
@@ -2984,7 +2984,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — ἰὼ ἰὼ φίλαι,</l>
 						<l>κτύπον ἐγείρετε, κτύπον καὶ βοὰν</l>
@@ -3005,14 +3005,14 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>[ἀλλὰ κτυπεῖ γὰρ κλῇθρα βασιλείων δόμων,</l>
 					<l>σιγήσατ’· ἔξω γάρ τις ἐκβαίνει Φρυγῶν,</l>
 					<l>οὗ πευσόμεσθα τἀν δόμοις ὅπως ἔχει.]</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>Ἀργέϊον ξίφος ἐκ θανάτου πέφευγα</l>
 						<l n="1370">βαρβάροις ἐν εὐμάρι‐</l>
@@ -3026,11 +3026,11 @@ bring up to P3
 						<l>ταυρόκρανος ἀγκάλαις</l>
 						<l>ἑλίσσων κυκλοῖ χθόνα;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1380">τί δ’ ἔστιν, Ἑλένης πρόσπολ’. Ἰδαῖον κάρα;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>Ἴλιον Ἴλιον, ὤμοι μοι,</l>
 						<l>Φρύγιον ἄστυ καὶ καλλίβωλον Ἴ‐</l>
@@ -3047,12 +3047,12 @@ bring up to P3
 						<l>ἱπποσύνᾳ, Διὸς εὐνέτα.</l>
 						<milestone ed="p" n="1393" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σαφῶς λέγ’ ἡμῖν αὔθ’ ἕκαστα τἀν δόμοις.</l>
 						<l>[τὰ γὰρ πρὶν οὐκ εὔγνωστα συμβαλοῦσ’ ἔχω.]</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l n="1395">αἴλινον αἴλινον ἀρχὰν θανάτου</l>
 						<l>βάρβαροι λέγουσιν, αἰαῖ,</l>
@@ -3088,11 +3088,11 @@ bring up to P3
 						<l>μητροφόντας δράκων.</l>
 						<milestone ed="p" n="1425" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1425">σὺ δ’ ἦσθα ποῦ τότ’; ἢ πάλαι φεύγεις φόβῳ,</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>Φρυγίοις ἔτυχον Φρυγίοισι νόμοις</l>
 						<l>παρὰ βόστρυχον αὔραν αὔραν</l>
@@ -3123,11 +3123,11 @@ bring up to P3
 						<l n="1450">έδραισι, τοὺς δ’ ἐκεῖσ’ ἐκεῖθεν [ἄλλον ἄλ‐</l>
 						<l>λοσε] διαρμόσας ἀποπρὸ δεσποίνας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί τοὐπὶ τῷδε συμφορᾶς ἐγίγνετο;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>Ἰδαία μᾶτερ</l>
 						<l>μᾶτερ ὀβρίμα ὀβρίμα,</l>
@@ -3158,11 +3158,11 @@ bring up to P3
 						<l n="1472b">λεν εἴσω μέλαν ξίφος.</l>
 						<milestone ed="p" n="1473" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποῦ δ’ ἦτ’ ἀμύνειν οἱ κατὰ στέγας Φρύγες;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>ἰαχᾷ</l>
 						<l>δόμων θύρετρα καὶ σταθμοὺς</l>
@@ -3204,7 +3204,7 @@ bring up to P3
 						<l>Μενέλεως ἀνασχόμενος ἀνόνητον ἀ‐</l>
 						<l>πὸ Τροίας ἔλαβε τὸν Ἑλένας γάμον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ἀμείβει καινὸν ἐκ καινῶν τόδε·</l>
 						<l>ξιφηφόρον γὰρ εἰσορῶ πρὸ δωμάτων</l>
@@ -3217,7 +3217,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ποῦ ’στιν οὗτος ὃς πέφευγεν ἐκ δόμων τοὐμὸν ξίφος;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>προσκυνῶ σ’, ἄναξ, νόμοισι βαρβάροισι προσπίτνων.</l>
 					</sp>
@@ -3225,7 +3225,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>οὐκ ἐν Ἰλίῳ τάδ’ ἐστίν, ἀλλ’ ἐν Ἀργείᾳ χθονί.</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>πανταχοῦ ζῆν ἡδὺ μᾶλλον ἢ θανεῖν τοῖς σώφροσιν.</l>
 					</sp>
@@ -3233,7 +3233,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="1510">οὔτι που κραυγὴν ἔθηκας Μενέλεῳ βοηδρομεῖν;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>σοὶ μὲν οὖν ἔγωγ’ ἀμύνειν· ἀξιώτερος γὰρ εἶ.</l>
 					</sp>
@@ -3241,7 +3241,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἐνδίκως ἡ Τυνδάρειος ἆρα παῖς διώλετο;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>ἐνδικώτατ’, εἴ γε λαιμοὺς εἶχε τριπτύχους θανεῖν.</l>
 					</sp>
@@ -3249,7 +3249,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>δειλίᾳ γλώσσῃ χαρίζῃ, τἄνδον οὐχ οὕτω φρονῶν.</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l n="1515">οὐ γάρ, ἥτις Ἑλλάδ’ αὐτοῖς Φρυξὶ διελυμήνατο;</l>
 					</sp>
@@ -3257,7 +3257,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὄμοσον — εἰ δὲ μή, κτενῶ σε — μὴ λέγειν ἐμὴν χάριν.</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>τὴν ἐμὴν ψυχὴν κατώμοσ’, ἣν ἂν εὐορκοῖμ’ ἐγώ.</l>
 					</sp>
@@ -3265,7 +3265,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ὧδε κἀν Τροίᾳ σίδηρος πᾶσι Φρυξὶν ἦν φόβος;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>ἄπεχε φάσγανον· πέλας γὰρ δεινὸν ἀνταυγεῖ φόνον.</l>
 					</sp>
@@ -3273,7 +3273,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l n="1520">μὴ πέτρος γένῃ δέδοικας ὥστε Γοργόν’ εἰσιδών;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>μὴ μὲν οὖν νεκρός· τὸ Γοργοῦς δ’ οὐ κάτοιδ’ ἐγὼ κάρα.</l>
 					</sp>
@@ -3281,7 +3281,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>δοῦλος ὢν φοβῇ τὸν Ἅιδην, ὅς σ’ ἀπαλλάξει κακῶν;</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l>πᾶς ἀνήρ, κἂν δοῦλος ᾖ τις, ἥδεται τὸ φῶς ὁρῶν.</l>
 					</sp>
@@ -3289,7 +3289,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>εὖ λέγεις· σῴζει σε σύνεσις. ἀλλὰ βαῖν’ ἔσω δόμων.</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l n="1525">οὐκ ἄρα κτενεῖς με;</l>
 					</sp>
@@ -3297,7 +3297,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l part="Y">ἀφεῖσαι.</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l part="Y">καλὸν ἔπος λέγεις τόδε.</l>
 					</sp>
@@ -3305,7 +3305,7 @@ bring up to P3
 						<speaker>Ὀρέστης</speaker>
 						<l>ἀλλὰ μεταβουλευσόμεσθα.</l>
 					</sp>
-					<sp who="#fryks">
+					<sp who="#phryx">
 						<speaker>Φρύξ</speaker>
 						<l part="Y">τοῦτο δ’ οὐ καλῶς λέγεις.</l>
 					</sp>
@@ -3327,7 +3327,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — ἰὼ ἰὼ τύχα,</l>
 						<l>ἕτερον εἰς ἀγῶν’, ἕτερον αὖ δόμος</l>
@@ -3349,7 +3349,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ μὴν καὶ τόνδε λεύσσω Μενέλεων δόμων πέλας</l>
 						<l n="1550">ὀξύπουν, ᾐσθημένον που τὴν τύχην ἣ νῦν πάρα.</l>
@@ -3745,7 +3745,7 @@ bring up to P3
 						<l>σὺν Τυνδαρίδαις, τοῖς Διὸς υἱοῖς,</l>
 						<l n="1690">ναύταις μεδέουσα θαλάσσης.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ μέγα σεμνὴ Νίκη, τὸν ἐμὸν</l>
 						<l>βίοτον κατέχοις</l>

--- a/tei/euripides-phoenissae.xml
+++ b/tei/euripides-phoenissae.xml
@@ -51,7 +51,7 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
 					<person xml:id="teiresias">
@@ -63,16 +63,16 @@
 					<person xml:id="iokaste">
 						<persName>Ἰοκάστη</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="oidipoys">
+					<person xml:id="oidipous">
 						<persName>Οἰδίπους</persName>
 					</person>
 					<person xml:id="antigone">
 						<persName>Ἄντιγόνη</persName>
 					</person>
-					<person xml:id="menoikeys">
+					<person xml:id="menoikeus">
 						<persName>Μενοικεύς</persName>
 					</person>
 					<person xml:id="paidagogos">
@@ -504,7 +504,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Τύριον οἶδμα λιποῦσ’ ἔβαν</l>
 						<l>ἀκροθίνια Λοξίᾳ</l>
@@ -522,7 +522,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πόλεος ἐκπροκριθεῖσ’ ἐμᾶς</l>
 						<l n="215">καλλιστεύματα Λοξίᾳ</l>
@@ -540,7 +540,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="mesode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ λάμπουσα πέτρα πυρὸς</l>
 						<l>δικόρυφον σέλας ὑπὲρ ἄκρων</l>
@@ -559,7 +559,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν δέ μοι πρὸ τειχέων</l>
 						<l n="240">θούριος μολὼν Ἄρης</l>
@@ -576,7 +576,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="250">ἀμφὶ δὲ πτόλιν νέφος</l>
 						<l>ἀσπίδων πυκνὸν φλέγει</l>
@@ -616,7 +616,7 @@ bring up to P3
 					<l>ξέναι γυναῖκες, εἴπατ’, ἐκ ποίας πάτρας</l>
 					<l>Ἑλληνικοῖσι δώμασιν πελάζετε;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="280">Φοίνισσα μὲν γῆ πατρὶς ἡ θρέψασά με,</l>
 					<l>Ἀγήνορος δὲ παῖδες ἐκ παίδων δορὸς</l>
@@ -633,13 +633,13 @@ bring up to P3
 					<l>ἔτικτε δ’ Ἰοκάστη με, παῖς Μενοικέως·</l>
 					<l n="290">καλεῖ δὲ Πολυνείκη με Θηβαῖος λεώς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ συγγένεια τῶν Ἀγήνορος τέκνων,</l>
 					<l>ἐμῶν τυράννων, ὧν ἀπεστάλην ὕπο — </l>
 					<milestone ed="p" n="293" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>γονυπετεῖς ἕδρας προσπίτνω σ’, ἄναξ,</l>
 					<l>τὸν οἴκοθεν νόμον σέβουσ’ — </l>
@@ -713,7 +713,7 @@ bring up to P3
 						<l>πρὸς ἐμὲ γὰρ κακῶν ἔμολε τῶνδ’ ἄχη.</l>
 					</sp>
 					<milestone ed="p" n="355" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="355">δεινὸν γυναιξὶν αἱ δῑ ὠδίνων γοναί,</l>
 						<l>καὶ φιλότεκνόν πως πᾶν γυναικεῖον γένος.</l>
@@ -938,7 +938,7 @@ bring up to P3
 						<l>ἁγὼ μεθήκω δεῦρο μυρίαν ἄγων</l>
 						<l>λόγχην· πένης γὰρ οὐδὲν εὐγενὴς ἀνήρ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν Ἐτεοκλῆς ἐς διαλλαγὰς ὅδε</l>
 						<l>χωρεῖ· σὸν ἔργον, μῆτερ Ἰοκάστη, λέγειν</l>
@@ -1008,7 +1008,7 @@ bring up to P3
 						<l n="495">λόγων ἀθροίσας εἶπον, ἀλλὰ καὶ σοφοῖς</l>
 						<l>καὶ τοῖσι φαύλοις ἔνδιχ’, ὡς ἐμοὶ δοκεῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐμοὶ μέν, εἰ καὶ μὴ καθ’ Ἑλλήνων χθόνα</l>
 						<l>τεθράμμεθ’, ἀλλ’ οὖν ξυνετά μοι δοκεῖς λέγειν.</l>
@@ -1044,7 +1044,7 @@ bring up to P3
 						<l>εἴπερ γὰρ ἀδικεῖν χρή, τυραννίδος πέρι</l>
 						<l n="525">κάλλιστον ἀδικεῖν, τἄλλα δ’ εὐσεβεῖν χρεών.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ εὖ λέγειν χρὴ μὴ ’πὶ τοῖς ἔργοις καλοῖς·</l>
 						<l>οὐ γὰρ καλὸν τοῦτ’, ἀλλὰ τῇ δίκῃ πικρόν.</l>
@@ -1123,7 +1123,7 @@ bring up to P3
 						</l>
 						<l n="585">ἐς ταὔθ’ ὅταν μόλητον, ἔχθιστον κακόν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ θεοί, γένοισθε τῶνδ’ ἀπότροποι κακῶν</l>
 						<l>καὶ ξύμβασίν τιν’ Οἰδίπου τέκνοις δότε.</l>
@@ -1374,7 +1374,7 @@ bring up to P3
 			<milestone ed="p" n="638" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Κάδμος ἔμολε τάνδε γᾶν</l>
 						<l>Τύριος, ᾧ τετρασκελὴς</l>
@@ -1399,7 +1399,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔνθα φόνιος ἦν δράκων</l>
 						<l>Ἄρεος ὠμόφρων φύλαξ</l>
@@ -1424,7 +1424,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ σέ, τὸν προμάτορος</l>
 						<l>Ἰοῦς ποτ’ ἔκγονον</l>
@@ -1682,7 +1682,7 @@ bring up to P3
 			<milestone ed="p" n="784" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πολύμοχθος Ἄρης, τί ποθ’ αἵματι</l>
 						<l n="785">καὶ θανάτῳ κατέχῃ Βρομίου παράμουσος ἑορταῖς;</l>
@@ -1707,7 +1707,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ ζαθέων πετάλων πολυθηρότα‐</l>
 						<l>τον νάπος, Ἀρτέμιδος χιονοτρόφον ὄμμα Κιθαιρών,</l>
@@ -1734,7 +1734,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔτεκες, ὦ Γαῖ’, ἔτεκές ποτε,</l>
 						<l>βάρβαρον ὡς ἀκοὰν ἐδάην ἐδάην ποτ’ ἐν οἴκοις,</l>
@@ -2010,7 +2010,7 @@ bring up to P3
 					<l>χρῆν θεσπιῳδεῖν, ὃς δέδοικεν οὐδένα.</l>
 					<milestone ed="p" n="960" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="960">Κρέον, τί σιγᾷς γῆρυν ἄφθογγον σχάσας;</l>
 					<l>κἀμοὶ γὰρ οὐδὲν ἧσσον ἔκπληξις πάρα.</l>
@@ -2036,7 +2036,7 @@ bring up to P3
 					<l n="975">κἂν μὲν φθάσωμεν, ἔστι σοι σωτηρία·</l>
 					<l>ἢν δ’ ὑστερήσῃς, οἰχόμεσθα, κατθανῇ.</l>
 				</sp>
-				<sp who="#menoikeys">
+				<sp who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l>ποῖ δῆτα φεύγω; τίνα πόλιν; τίνα ξένων;</l>
 				</sp>
@@ -2044,7 +2044,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l>ὅπου χθονὸς τῆσδ’ ἐκποδὼν μάλιστ’ ἔσῃ.</l>
 				</sp>
-				<sp who="#menoikeys">
+				<sp who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l>οὐκοῦν σὲ φράζειν εἰκός, ἐκπονεῖν δ’ ἐμέ.</l>
 				</sp>
@@ -2052,7 +2052,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l n="980">Δελφοὺς περάσας — </l>
 				</sp>
-				<sp who="#menoikeys">
+				<sp who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l part="Y">ποῖ με χρή, πάτερ, μολεῖν;</l>
 				</sp>
@@ -2060,7 +2060,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l>Αἰτωλίδ’ ἐς γῆν.</l>
 				</sp>
-				<sp who="#menoikeys">
+				<sp who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l part="Y">ἐκ δὲ τῆσδε ποῖ περῶ;</l>
 				</sp>
@@ -2068,7 +2068,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l>Θεσπρωτὸν οὖδας.</l>
 				</sp>
-				<sp who="#menoikeys">
+				<sp who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l part="Y">σεμνὰ Δωδώνης βάθρα;</l>
 				</sp>
@@ -2076,7 +2076,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l>ἔγνως.</l>
 				</sp>
-				<sp who="#menoikeys">
+				<sp who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l part="Y">τί δὴ τόδ’ ἔρυμά μοι γενήσεται;</l>
 				</sp>
@@ -2084,7 +2084,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l>πόμπιμος ὁ δαίμων.</l>
 				</sp>
-				<sp who="#menoikeys">
+				<sp who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l part="Y">χρημάτων δὲ τίς πόρος;</l>
 				</sp>
@@ -2092,7 +2092,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l n="985">ἐγὼ πορεύσω χρυσόν.</l>
 				</sp>
-				<sp n="Μενοικεύς" who="#menoikeys">
+				<sp n="Μενοικεύς" who="#menoikeus">
 					<speaker>Μενοικεύς</speaker>
 					<l part="Y">εὖ λέγεις, πάτερ.</l>
 					<l>χώρει νυν· ὡς σὴν πρὸς κασιγνήτην μολών,</l>
@@ -2140,7 +2140,7 @@ bring up to P3
 			<milestone ed="p" n="1019" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔβας ἔβας,</l>
 						<l>ὦ πτεροῦσσα, γᾶς λόχευμα</l>
@@ -2173,7 +2173,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χρόνῳ δ’ ἔβα</l>
 						<l>Πυθίαις ἀποστολαῖσιν</l>
@@ -2207,7 +2207,7 @@ bring up to P3
 			</div1>
 			<milestone ed="p" n="1067" unit="card"/>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὠή, τίς ἐν πύλαισι δωμάτων κυρεῖ;</l>
 					<l>ἀνοίγετ’· ἐκπορεύετ’ Ἰοκάστην δόμων.</l>
@@ -2223,7 +2223,7 @@ bring up to P3
 					<l n="1075">[τί μοί ποθ’ ἥκεις καινὸν ἀγγελῶν ἔπος;]</l>
 					<l>τέθνηκεν ἢ ζῇ παῖς ἐμός; σήμαινέ μοι.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ζῇ, μὴ τρέσῃς τόδ’, ὥς &lt;σ’&gt; ἀπαλλάξω φόβου.</l>
 				</sp>
@@ -2231,7 +2231,7 @@ bring up to P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>τί δ’; ἑπτάπυργοι πῶς ἔχουσι περιβολαί;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἑστᾶσ’ ἄθραυστοι, κοὐκ ἀνήρπασται πόλις.</l>
 				</sp>
@@ -2239,7 +2239,7 @@ bring up to P3
 					<speaker>Ἰοκάστη</speaker>
 					<l n="1080">ἦλθον δὲ πρὸς κίνδυνον Ἀργείου δορός;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἀκμήν γ’ ἐπ’ αὐτήν· ἀλλ’ ὁ Καδμείων Ἄρης</l>
 					<l>κρείσσων κατέστη τοῦ Μυκηναίου δορός.</l>
@@ -2249,7 +2249,7 @@ bring up to P3
 					<l>ἓν εἰπὲ πρὸς θεῶν, εἴ τι Πολυνείκους πέρι</l>
 					<l>οἶσθ’· ὡς μέλει μοι καὶ τόδ’, εἰ λεύσσει φάος.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1085">ζῇ σοι ξυνωρὶς ἐς τόδ’ ἡμέρας τέκνων.</l>
 				</sp>
@@ -2260,7 +2260,7 @@ bring up to P3
 					<l>λέξον, γέροντα τυφλὸν ὡς κατὰ στέγας</l>
 					<l>ἐλθοῦσα τέρψω, τῆσδε γῆς σεσῳσμένης.</l>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1090">ἐπεὶ Κρέοντος παῖς ὁ γῆς ὑπερθανὼν</l>
 					<l>πύργων ἐπ’ ἄκρων στὰς μελάνδετον ξίφος</l>
@@ -2405,7 +2405,7 @@ bring up to P3
 					<l>ἔσται τὸ λοιπὸν ἥδε γῆ, θεοῖς μέλει·</l>
 					<l>καὶ νῦν γὰρ αὐτὴν δαιμόνων ἔσῳσέ τις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1200">καλὸν τὸ νικᾶν· εἰ δ’ ἀμείνον’ οἱ θεοὶ</l>
 					<l>γνώμην ἔχουσιν — εὐτυχὴς εἴην ἐγώ.</l>
@@ -2421,7 +2421,7 @@ bring up to P3
 					<l>ἰδίᾳ δὲ λυπρῶς. ἀλλ’ ἄνελθέ μοι πάλιν,</l>
 					<l>τί τἀπὶ τούτοις παῖδ’ ἐμὼ δρασείετον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἔα τὰ λοιπά· δεῦρ’ ἀεὶ γὰρ εὐτυχεῖς.</l>
 				</sp>
@@ -2429,7 +2429,7 @@ bring up to P3
 					<speaker>Ἰοκάστη</speaker>
 					<l n="1210">τοῦτ’ εἰς ὕποπτον εἶπας· οὐκ ἐατέον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>μεῖζον τί χρῄζεις παῖδας ἢ σεσῳσμένους;</l>
 				</sp>
@@ -2437,7 +2437,7 @@ bring up to P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>καὶ τἀπίλοιπά γ’ εἰ καλῶς πράσσω κλύειν.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>μέθες μ’· ἔρημος παῖς ὑπασπιστοῦ σέθεν.</l>
 				</sp>
@@ -2445,7 +2445,7 @@ bring up to P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>κακόν τι κεύθεις καὶ στέγεις ὑπὸ σκότῳ.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1215">κοὐκ ἄν γε λέξαιμ’ ἐπ’ ἀγαθοῖσι σοῖς κακά.</l>
 				</sp>
@@ -2453,7 +2453,7 @@ bring up to P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>ἢν μή γε φεύγων ἐκφύγῃς πρὸς αἰθέρα.</l>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>αἰαῖ· τί μ’ οὐκ εἴασας ἐξ εὐαγγέλου</l>
 					<l>φήμης ἀπελθεῖν, ἀλλὰ μηνῦσαι κακά;</l>
@@ -2590,7 +2590,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ αἰαῖ, τρομερὰν φρίκᾳ</l>
 						<l n="1285">τρομερὰν φρέν’ ἔχω· διὰ σάρκα δ’ ἐμὰν</l>
@@ -2607,7 +2607,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φεῦ δᾶ φεῦ δᾶ, δίδυμοι θῆρες,</l>
 						<l>φόνιαι ψυχαὶ δορὶ παλλόμεναι</l>
@@ -2647,7 +2647,7 @@ bring up to P3
 					<l n="1320">τοῖς γὰρ θανοῦσι χρὴ τὸν οὐ τεθνηκότα</l>
 					<l>τιμὰς διδόντα χθόνιον εὐσεβεῖν θεόν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>βέβηκ’ ἀδελφὴ σή, Κρέων, ἔξω δόμων</l>
 					<l>κόρη τε μητρὸς Ἀντιγόνη κοινῷ ποδί.</l>
@@ -2656,7 +2656,7 @@ bring up to P3
 					<speaker>Κρέων</speaker>
 					<l>ποῖ; κἀπὶ ποίαν συμφοράν; σήμαινέ μοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1325">ἤκουσε τέκνα μονομάχῳ μέλλειν δορὶ</l>
 					<l>ἐς ἀσπίδ’ ἥξειν βασιλικῶν δόμων ὕπερ.</l>
@@ -2666,7 +2666,7 @@ bring up to P3
 					<l>πῶς φῄς; νέκυν τοι παιδὸς ἀγαπάζων ἐμοῦ</l>
 					<l>οὐκ ἐς τόδ’ ἦλθον ὥστε καὶ τάδ’ εἰδέναι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ οἴχεται μὲν σὴ κασιγνήτη πάλαι·</l>
 					<l n="1330">δοκῶ δ’ ἀγῶνα τὸν περὶ ψυχῆς, Κρέον,</l>
@@ -2680,7 +2680,7 @@ bring up to P3
 					<milestone ed="p" n="1335" unit="card"/>
 				</sp>
 				<div2 type="trochees">
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l n="1335">ὦ τάλας ἐγώ, τίν’ εἴπω μῦθον ἢ τίνας γόους;</l>
 					</sp>
@@ -2688,7 +2688,7 @@ bring up to P3
 						<speaker>Κρέων</speaker>
 						<l>οἰχόμεσθ’· οὐκ εὐπροσώποις φροιμίοις ἄρχῃ λόγου.</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ὦ τάλας, δισσῶς ἀυτῶ· μεγάλα γὰρ φέρω κακά.</l>
 					</sp>
@@ -2696,7 +2696,7 @@ bring up to P3
 						<speaker>Κρέων</speaker>
 						<l>πρὸς πεπραγμένοισιν ἄλλοις πήμασιν. λέγεις δὲ τί;</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>οὐκέτ’ εἰσὶ σῆς ἀδελφῆς παῖδες ἐν φάει, Κρέον.</l>
 						<milestone ed="p" n="1340" unit="card"/>
@@ -2709,7 +2709,7 @@ bring up to P3
 						<l>ὦ δώματ’ εἰσηκούσατ’ Οἰδίπου τάδε</l>
 						<l>παίδων ὁμοίαις συμφοραῖς ὀλωλότων;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὥστ’ ἂν δακρῦσαί γ’, εἰ φρονοῦντ’ ἐτύγχανεν.</l>
 					</sp>
@@ -2719,7 +2719,7 @@ bring up to P3
 						<l n="1345">οἴμοι ξυμφορᾶς βαρυποτμωτάτας,</l>
 						<l>[οἴμοι κακῶν δύστηνος· ὦ τάλας ἐγώ.]</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>εἰ καὶ τὰ πρὸς τούτοισί γ’ εἰδείης κακά.</l>
 					</sp>
@@ -2727,13 +2727,13 @@ bring up to P3
 						<speaker>Κρέων</speaker>
 						<l>καὶ πῶς γένοιτ’ ἂν τῶνδε δυσποτμώτερα;</l>
 					</sp>
-					<sp who="#aggelos">
+					<sp who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>τέθνηκ’ ἀδελφὴ σὴ δυοῖν παίδοιν μέτα.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1350">ἀνάγετ’ ἀνάγετε κωκυ‐</l>
 						<l>τόν, ἐπὶ κάρα τε λευκοπήχεις κτύπους χεροῖν.</l>
@@ -2745,7 +2745,7 @@ bring up to P3
 						<l>πῶς καὶ πέπρακται διπτύχων παίδων φόνος</l>
 						<l n="1355">ἀρᾶς τ’ ἀγώνισμ’ Οἰδίπου; σήμαινέ μοι.</l>
 					</sp>
-					<sp n="Ἄγγελος" who="#aggelos">
+					<sp n="Ἄγγελος" who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>τὰ μὲν πρὸ πύργων εὐτυχήματα χθονὸς</l>
 						<l>οἶσθ’· οὐ μακρὰν γὰρ τειχέων περιπτυχαί.</l>
@@ -2827,13 +2827,13 @@ bring up to P3
 						<l>γαῖαν δ’ ὀδὰξ ἑλόντες ἀλλήλων πέλας</l>
 						<l>πίπτουσιν ἄμφω κοὐ διώρισαν κράτος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1425">φεῦ φεῦ, κακῶν σῶν, Οἰδίπου, σ’ ὅσον στένω·</l>
 						<l>τὰς σὰς δ’ ἀρὰς ἔοικεν ἐκπλῆσαι θεός.</l>
 					</sp>
 					<milestone ed="p" n="1427" unit="card"/>
-					<sp n="Ἄγγελος" who="#aggelos">
+					<sp n="Ἄγγελος" who="#angelos">
 						<speaker>Ἄγγελος</speaker>
 						<l>ἄκουε δή νυν καὶ τὰ πρὸς τούτοις κακά.</l>
 						<l>ἐπεὶ τέκνω πεσόντ’ ἐλειπέτην βίον,</l>
@@ -2899,7 +2899,7 @@ bring up to P3
 					<milestone ed="p" n="1480" unit="card"/>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1480">οὐκ εἰς ἀκοὰς ἔτι δυστυχία</l>
 						<l>δώματος ἥκει· πάρα γὰρ λεύσσειν</l>
@@ -2969,7 +2969,7 @@ bring up to P3
 						<l>πόδ’ ἢ δεμνίοις δύ‐</l>
 						<l>στανος ἰαύων;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>τί μ’, ὦ παρθένε, βακτρεύμασι τυφλοῦ</l>
 						<l n="1540">ποδὸς ἐξάγαγες ἐς φῶς</l>
@@ -2987,7 +2987,7 @@ bring up to P3
 						<l>ἃ πόδα σὸν τυφλόπουν θεραπεύμασιν αἰὲν ἐμόχθει,</l>
 						<l n="1550">&lt;ὦ&gt; πάτερ, ὤμοι.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὤμοι ἐμῶν παθέων· πάρα γὰρ στενάχειν τάδ’, ἀυτεῖν.</l>
 						<l>τρισσαὶ ψυχαί· ποίᾳ μοίρᾳ</l>
@@ -3002,7 +3002,7 @@ bring up to P3
 						<l>καὶ πυρὶ καὶ σχετλίαισι μάχαις ἐπὶ παῖδας ἔβα σούς,</l>
 						<l>ὦ πάτερ, ὤ μοι.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1560">αἰαῖ.</l>
 					</sp>
@@ -3010,7 +3010,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="Y">τί τάδε καταστένεις,</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>τέκνα.</l>
 					</sp>
@@ -3021,7 +3021,7 @@ bring up to P3
 						<l>ἀελίου τάδε σώματα νεκρῶν</l>
 						<l>ὄμματος αὐγαῖς σαῖς ἐπενώμας — </l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1565">τῶν μὲν ἐμῶν τεκέων φανερὸν κακόν·</l>
 						<l>ἁ δὲ τάλαιν’ ἄλοχος τίνι μοι, τέκνον, ὤλετο μοίρᾳ;</l>
@@ -3048,7 +3048,7 @@ bring up to P3
 				</div2>
 				<div2 type="iambic">
 					<milestone ed="p" n="1582" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλῶν κακῶν κατῆρξεν Οἰδίπου δόμοις</l>
 						<l>τόδ’ ἦμαρ· εἴη δ’ εὐτυχέστερος βίος.</l>
@@ -3067,7 +3067,7 @@ bring up to P3
 						<l>οὐδ’ ἐχθρὸς ὢν σός, διὰ δὲ τοὺς ἀλάστορας</l>
 						<l>τοὺς σοὺς δεδοικὼς μή τι γῆ πάθῃ κακόν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1595">ὦ μοῖρ’, ἀπ’ ἀρχῆς ὥς μ’ ἔφυσας ἄθλιον</l>
 						<l>καὶ τλήμον’, εἴ τις ἄλλος ἀνθρώπων ἔφυ·</l>
@@ -3281,7 +3281,7 @@ bring up to P3
 						<speaker>Κρέων</speaker>
 						<l>ἴθ’, οὐ φονεύσεις παῖδ’ ἐμόν, λίπε χθόνα.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὦ θύγατερ, αἰνῶ μέν σε τῆς προθυμίας.</l>
 					</sp>
@@ -3289,7 +3289,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ἀλλ’ εἰ γαμοίμην, σὺ δὲ μόνος φεύγοις, πάτερ;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1685">μέν’ εὐτυχοῦσα, τἄμ’ ἐγὼ στέρξω κακά.</l>
 					</sp>
@@ -3297,7 +3297,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>καὶ τίς σε τυφλὸν ὄντα θεραπεύσει, πάτερ;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>πεσὼν ὅπου μοι μοῖρα κείσομαι πέδῳ.</l>
 					</sp>
@@ -3305,7 +3305,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ὁ δ’ Οἰδίπους ποῦ καὶ τὰ κλείν’ αἰνίγματα;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὄλωλ’· ἓν ἦμάρ μ’ ὤλβισ’, ἓν δ’ ἀπώλεσεν.</l>
 					</sp>
@@ -3313,7 +3313,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l n="1690">οὔκουν μετασχεῖν κἀμὲ δεῖ τῶν σῶν κακῶν;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>αἰσχρὰ φυγὴ θυγατρὶ σὺν τυφλῷ πατρί.</l>
 					</sp>
@@ -3321,7 +3321,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>οὔ, σωφρονούσῃ γ’, ἀλλὰ γενναία, πάτερ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>προσάγαγέ νύν με, μητρὸς ὡς ψαύσω σέθεν.</l>
 					</sp>
@@ -3329,7 +3329,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ἰδού, γεραιᾶς φιλτάτης ψαῦσον χερί.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1695">ὦ μῆτερ, ὦ ξυνάορ’ ἀθλιωτάτη.</l>
 					</sp>
@@ -3337,7 +3337,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>οἰκτρὰ πρόκειται, πάντ’ ἔχουσ’ ὁμοῦ κακά.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>Ἐτεοκλέους δὲ πτῶμα Πολυνείκους τε ποῦ;</l>
 					</sp>
@@ -3345,7 +3345,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>τώδ’ ἐκτάδην σοι κεῖσθον ἀλλήλοιν πέλας.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>πρόσθες τυφλὴν χεῖρ’ ἐπὶ πρόσωπα δυστυχῆ.</l>
 					</sp>
@@ -3353,7 +3353,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l n="1700">ἰδού, θανόντων σῶν τέκνων ἅπτου χερί.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὦ φίλα πεσήματ’ ἄθλῑ ἀθλίου πατρός.</l>
 					</sp>
@@ -3361,7 +3361,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ὦ φίλτατον δῆτ’ ὄνομα Πολυνείκους ἐμοί.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>νῦν χρησμός, ὦ παῖ, Λοξίου περαίνεται.</l>
 					</sp>
@@ -3369,7 +3369,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ὁ ποῖος; ἀλλ’ ἦ πρὸς κακοῖς ἐρεῖς κακά;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1705">ἐν ταῖς Ἀθήναις κατθανεῖν μ’ ἀλώμενον.</l>
 					</sp>
@@ -3377,7 +3377,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ποῦ; τίς σε πύργος Ἀτθίδος προσδέξεται;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἱερὸς Κολωνός, δώμαθ’ ἱππίου θεοῦ.</l>
 						<l>ἀλλ’ εἶα, τυφλῷ τῷδ’ ὑπηρέτει πατρί,</l>
@@ -3392,7 +3392,7 @@ bring up to P3
 						<l>πάτερ γεραιέ, πομπίμαν</l>
 						<l>ἔχων ἔμ’ ὥστε ναυσίπομπον αὔραν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>&lt;ἰδοὺ&gt; ἰδού, πορεύομαι·</l>
 						<l n="1715">τέκνον, σύ μοι ποδαγὸς ἀθλία γενοῦ.</l>
@@ -3402,7 +3402,7 @@ bring up to P3
 						<l>γενόμεθα γενόμεθ’, ἄθλιαί</l>
 						<l>γε δῆτα Θηβαιᾶν μάλιστα παρθένων.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>πόθι γεραιὸν ἴχνος τίθημι;</l>
 						<l>βάκτρα πρόσφερ’, ὦ τέκνον.</l>
@@ -3413,7 +3413,7 @@ bring up to P3
 						<l>τᾷδε τᾷδε πόδα τιθείς,</l>
 						<l>ὥστ’ ὄνειρον ἰσχύν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἰὼ ἰώ, δυστυχεστάτας φυγὰς</l>
 						<l>ἐλαύνων τὸν γέροντά μ’ ἐκ πάτρας.</l>
@@ -3424,7 +3424,7 @@ bring up to P3
 						<l>τί τλάς; τί τλάς; οὐχ ὁρᾷ Δίκα κακούς,</l>
 						<l>οὐδ’ ἀμείβεται βροτῶν ἀσυνεσίας.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὅδ’ εἰμὶ μοῦσαν ὃς ἐπὶ καλ‐</l>
 						<l>λίνικον οὐράνιον ἔβαν</l>
@@ -3452,7 +3452,7 @@ bring up to P3
 						<l n="1745">μέλεος, ὅν, εἴ με καὶ θανεῖν, πάτερ, χρεών,</l>
 						<l>σκότια γᾷ καλύψω.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>πρὸς ἥλικας φάνηθι σάς.</l>
 					</sp>
@@ -3460,7 +3460,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ἅλις ὀδυρμάτων ἐμῶν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>σὺ δ’ ἀμφὶ βωμίους λιτὰς — </l>
 					</sp>
@@ -3468,7 +3468,7 @@ bring up to P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l n="1750">κόρον ἔχουσ’ ἐμῶν κακῶν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἴθ’ ἀλλὰ Βρόμιος ἵνα τε σηκὸς</l>
 						<l>ἄβατος ὄρεσι μαινάδων.</l>
@@ -3483,7 +3483,7 @@ bring up to P3
 					<milestone ed="p" n="1758" unit="card"/>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὦ πάτρας κλεινῆς πολῖται, λεύσσετ’, Οἰδίπους ὅδε,</l>
 						<l>ὃς τὰ κλείν’ αἰνίγματ’ ἔγνω καὶ μέγιστος ἦν ἀνήρ,</l>
@@ -3495,7 +3495,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ μέγα σεμνὴ Νίκη, τὸν ἐμὸν</l>
 						<l n="1765">βίοτον κατέχοις</l>

--- a/tei/euripides-rhesus.xml
+++ b/tei/euripides-rhesus.xml
@@ -51,25 +51,25 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="moysa" sex="FEMALE">
+					<person xml:id="mousa" sex="FEMALE">
 						<persName>Μοῦσα</persName>
 					</person>
-					<person xml:id="odysseys" sex="MALE">
+					<person xml:id="odysseus" sex="MALE">
 						<persName>Ὀδυσσεύς</persName>
 					</person>
 					<person xml:id="aineias" sex="MALE">
 						<persName>Αἰνείας</persName>
 					</person>
-					<person xml:id="enioxos" sex="MALE">
+					<person xml:id="heniochos" sex="MALE">
 						<persName>Ἡνίοχος</persName>
 					</person>
 					<person xml:id="athena" sex="FEMALE">
 						<persName>Ἀθήνα</persName>
 					</person>
-					<person xml:id="aleksandros" sex="MALE">
+					<person xml:id="alexandros" sex="MALE">
 						<persName>Ἀλέξανδρος</persName>
 					</person>
-					<person xml:id="aggelospoimen" sex="MALE">
+					<person xml:id="angelos_poimen" sex="MALE">
 						<persName>Ἄγγελος Ποιμήν</persName>
 					</person>
 					<person xml:id="dolon" sex="MALE">
@@ -78,16 +78,16 @@
 					<person xml:id="diomedes" sex="MALE">
 						<persName>Διομήδης</persName>
 					</person>
-					<person xml:id="ektor" sex="MALE">
+					<person xml:id="hektor" sex="MALE">
 						<persName>Ἕκτωρ</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="MALE">
+					<personGrp xml:id="choros" sex="MALE">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="resos" sex="MALE">
 						<persName>Ῥῆσος</persName>
 					</person>
-					<person xml:id="aggelos" sex="MALE">
+					<person xml:id="angelos" sex="MALE">
 						<persName>Ἄγγελος</persName>
 					</person>
 				</listPerson>
@@ -171,7 +171,7 @@ bring up to P3
 			<div1 type="choral">
 				<milestone ed="p" n="1" unit="card"/>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Βᾶθι πρὸς εὐνὰς τὰς Ἑκτορέους.</l>
 						<l>τίς ὑπασπιστῶν ἄγρυπνος βασιλέως,</l>
@@ -184,35 +184,35 @@ bring up to P3
 						<l>λεῖπε χαμεύνας φυλλοστρώτους,</l>
 						<l n="10">Ἕκτορ· καιρὸς γὰρ ἀκοῦσαι.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>τίς ὅδ’; ἦ φίλιος φθόγγος· τίς ἀνήρ;</l>
 						<l>τί τὸ σῆμα; θρόει·</l>
 						<l>τίνες ἐκ νυκτῶν τὰς ἡμετέρας</l>
 						<l>κοίτας πλάθουσ’; ἐνέπειν χρή.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="15">φύλακες στρατιᾶς.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l part="Y">τί φέρῃ θορύβῳ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θάρσει.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l part="Y">θαρσῶ.</l>
 						<l>μῶν τις λόχος ἐκ νυκτῶν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">[οὐκ ἔστι.]</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>τί σὺ γὰρ</l>
 						<l>φυλακὰς προλιπὼν κινεῖς στρατιάν,</l>
@@ -224,7 +224,7 @@ bring up to P3
 					<milestone ed="p" n="23" unit="card"/>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁπλίζου χέρα· συμμάχων,</l>
 						<l>Ἕκτορ, βᾶθι πρὸς εὐνάς,</l>
@@ -241,7 +241,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>τὰ μὲν ἀγγέλλεις δείματ’ ἀκούειν,</l>
 						<l n="35">τὰ δὲ θαρσύνεις, κοὐδὲν καθαρῶς.</l>
@@ -254,7 +254,7 @@ bring up to P3
 					<milestone ed="p" n="41" unit="card"/>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πύρ’ αἴθει στρατὸς Ἀργόλας,</l>
 						<l>Ἕκτορ, πᾶσαν ἀν’ ὄρφναν,</l>
@@ -272,7 +272,7 @@ bring up to P3
 			</div1>
 			<milestone ed="p" n="52" unit="card"/>
 			<div1 type="episode">
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>ἐς καιρὸν ἥκεις, καίπερ ἀγγέλλων φόβον·</l>
 					<l>ἅνδρες γὰρ ἐκ γῆς τῆσδε νυκτέρῳ πλάτῃ</l>
@@ -299,41 +299,41 @@ bring up to P3
 					<l>οἳ δ’ ἐν βρόχοισι δέσμιοι λελημμένοι</l>
 					<l n="75">Φρυγῶν ἀρούρας ἐκμάθωσι γαπονεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Ἕκτορ, ταχύνεις πρὶν μαθεῖν τὸ δρώμενον·</l>
 					<l>ἅνδρες γὰρ εἰ φεύγουσιν οὐκ ἴσμεν τορῶς.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>τίς γὰρ πύρ’ αἴθειν πρόφασις Ἀργείων στρατόν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ οἶδ’· ὕποπτον δ’ ἐστὶ κάρτ’ ἐμῇ φρενί.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l n="80">πάντ’ ἂν φοβηθεὶς ἴσθι, δειμαίνων τόδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὔπω πρὶν ἧψαν πολέμιοι τοσόνδε φῶς.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>οὐδ’ ὧδέ γ’ αἰσχρῶς ἔπεσον ἐν τροπῇ δορός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σὺ ταῦτ’ ἔπραξας· καὶ τὰ λοιπὰ νῦν σκόπει.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>ἁπλοῦς ἐπ’ ἐχθροῖς μῦθος ὁπλίζειν χέρα.</l>
 				</sp>
 				<milestone ed="p" n="85" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="85">καὶ μὴν ὅδ’ Αἰνέας καὶ μάλα σπουδῇ ποδὸς</l>
 					<l>στείχει, νέον τι πρᾶγμ’ ἔχων φίλοις φράσαι.</l>
@@ -344,7 +344,7 @@ bring up to P3
 					<l>τὰς σὰς πρὸς εὐνὰς φύλακες ἐλθόντες φόβῳ</l>
 					<l>νυκτηγοροῦσι καὶ κεκίνηται· στρατός;</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l n="90">Αἰνέα, πύκαζε τεύχεσιν δέμας σέθεν.</l>
 				</sp>
@@ -353,7 +353,7 @@ bring up to P3
 					<l>τί δ’ ἔστι; μῶν τις πολεμίων ἀγγέλλεται</l>
 					<l>δόλος κρυφαῖος ἑστάναι κατ’ εὐφρόνην;</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>φεύγουσιν ἅνδρες κἀπιβαίνουσιν νεῶν.</l>
 				</sp>
@@ -361,7 +361,7 @@ bring up to P3
 					<speaker>Αἰνείας</speaker>
 					<l>τί τοῦδ’ ἂν εἴποις ἀσφαλὲς τεκμήριον;</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l n="95">αἴθουσι πᾶσαν νύκτα λαμπάδας πυρός·</l>
 					<l>καί μοι δοκοῦσιν οὐ μενεῖν ἐς αὔριον,</l>
@@ -372,7 +372,7 @@ bring up to P3
 					<speaker>Αἰνείας</speaker>
 					<l>σὺ δ’ ὡς τί δράσων πρὸς τάδ’ ὁπλίζῃ χέρας;</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l n="100">φεύγοντας αὐτοὺς κἀπιθρῴσκοντας νεῶν</l>
 					<l>λόγχῃ καθέξω κἀπικείσομαι βαρύς·</l>
@@ -411,7 +411,7 @@ bring up to P3
 				</sp>
 				<milestone ed="p" n="131" unit="card"/>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάδε δοκεῖ, τάδε μεταθέμενος νόει.</l>
 						<l>σφαλερὰ δ’ οὐ φιλῶ στρατηγῶν κράτη.</l>
@@ -423,7 +423,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>νικᾶτ’, ἐπειδὴ πᾶσιν ἁνδάνει τάδε.</l>
 						<l>στείχων δὲ κοίμα συμμάχους· τάχ’ ἂν στρατὸς</l>
@@ -441,7 +441,7 @@ bring up to P3
 						<l>πέμφ’ ὡς τάχιστα· νῦν γὰρ ἀσφαλῶς φρονεῖς.</l>
 						<l>σὺν σοὶ δ’ ἔμ’ ὄψῃ καρτεροῦνθ’, ὅταν δέῃ.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>τίς δῆτα Τρώων οἳ πάρεισιν ἐν λόγῳ</l>
 						<l n="150">θέλει κατόπτης ναῦς ἐπ’ Ἀργείων μολεῖν;</l>
@@ -456,7 +456,7 @@ bring up to P3
 						<l>καὶ πάντ’ Ἀχαιῶν ἐκμαθὼν βουλεύματα</l>
 						<l>ἥξω· ἐπὶ τούτοις τόνδ’ ὑφίσταμαι πόνον.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>ἐπώνυμος μὲν κάρτα καὶ φιλόπτολις</l>
 						<l>Δόλων· πατρὸς δὲ καὶ πρὶν εὐκλεᾶ δόμον</l>
@@ -469,7 +469,7 @@ bring up to P3
 						<l>κέρδος πρὸς ἔργῳ τὴν χάριν τίκτει διπλῆν.</l>
 					</sp>
 					<milestone ed="p" n="164" unit="card"/>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>ναί, καὶ δίκαια ταῦτα κοὐκ ἄλλως λέγω.</l>
 						<l n="165">τάξαι δὲ μισθόν, πλὴν ἐμῆς τυραννίδος.</l>
@@ -478,7 +478,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l>οὐ σῆς ἐρῶμεν πολιόχου τυραννίδος.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>σὺ δ’ ἀλλὰ γήμας Πριαμιδῶν γαμβρὸς γενοῦ.</l>
 					</sp>
@@ -486,7 +486,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l>οὐδ’ ἐξ ἐμαυτοῦ μειζόνων γαμεῖν θέλω.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>χρυσὸς πάρεστιν, εἰ τόδ’ αἰτήσεις γέρας.</l>
 					</sp>
@@ -494,7 +494,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l n="170">ἀλλ’ ἔστ’ ἐν οἴκοις· οὐ βίου σπανίζομεν.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>τί δῆτα χρῄζεις ὧν κέκευθεν Ἴλιος;</l>
 					</sp>
@@ -502,7 +502,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l>ἑλὼν Ἀχαιοὺς δῶρά μοι ξυναίνεσον.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>δώσω· σὺ δ’ αἴτει πλὴν στρατηλάτας νεῶν.</l>
 					</sp>
@@ -510,7 +510,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l>κτεῖν’, οὔ σ’ ἀπαιτῶ Μενέλεω σχέσθαι χέρα.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l n="175">οὐ μὴν τὸν Ἰλέως παῖδά μ’ ἐξαιτῇ λαβεῖν;</l>
 					</sp>
@@ -518,7 +518,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l>κακαὶ γεωργεῖν χεῖρες εὖ τεθραμμέναι.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>τίν’ οὖν Ἀχαιῶν ζῶντ’ ἀποινᾶσθαι θέλεις;</l>
 					</sp>
@@ -526,7 +526,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l>καὶ πρόσθεν εἶπον· ἔστι χρυσὸς ἐν δόμοις.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>καὶ μὴν λαφύρων γ’ αὐτὸς αἱρήσῃ παρών.</l>
 					</sp>
@@ -534,7 +534,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l n="180">θεοῖσιν αὐτὰ πασσάλευε πρὸς δόμοις.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>τί δῆτα μεῖζον τῶνδέ μ’ αἰτήσεις γέρας;</l>
 					</sp>
@@ -543,7 +543,7 @@ bring up to P3
 						<l>ἵππους Ἀχιλλέως· χρὴ δ’ ἐπ’ ἀξίοις πονεῖν</l>
 						<l>ψυχὴν προβάλλοντ’ ἐν κύβοισι δαίμονος.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>καὶ μὴν ἐρῶντί γ’ ἀντερᾷς ἵππων ἐμοί·</l>
 						<l n="185">ἐξ ἀφθίτων γὰρ ἄφθιτοι πεφυκότες</l>
@@ -563,7 +563,7 @@ bring up to P3
 					<milestone ed="p" n="195" unit="card"/>
 				</div2>
 				<div2 type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="195">μέγας ἀγών, μεγάλα δ’ ἐπινοεῖς ἑλεῖν·</l>
 						<l>μακάριός γε μὴν κυρήσας ἔσῃ.</l>
@@ -581,7 +581,7 @@ bring up to P3
 						<l>σκευῇ πρεπόντως σῶμ’ ἐμὸν καθάψομαι,</l>
 						<l>κἀκεῖθεν ἥσω ναῦς ἐπ’ Ἀργείων πόδα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεὶ τίν’ ἄλλην ἀντὶ τῆσδ’ ἕξεις στολήν;</l>
 					</sp>
@@ -589,7 +589,7 @@ bring up to P3
 						<speaker>Δόλων</speaker>
 						<l n="205">πρέπουσαν ἔργῳ κλωπικοῖς τε βήμασι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σοφοῦ παρ’ ἀνδρὸς χρὴ σοφόν τι μανθάνειν·</l>
 						<l>λέξον, τίς ἔσται τοῦδε σώματος σαγή;</l>
@@ -605,7 +605,7 @@ bring up to P3
 						<l>ὅταν δ’ ἔρημον χῶρον ἐμβαίνω ποδί,</l>
 						<l n="215">δίβαμος εἶμι· τῇδε σύγκειται δόλος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ εὖ σ’ ὁ Μαίας παῖς ἐκεῖσε καὶ πάλιν</l>
 						<l>πέμψειεν Ἑρμῆς, ὅς γε φηλητῶν ἄναξ.</l>
@@ -624,7 +624,7 @@ bring up to P3
 			<milestone ed="p" n="224" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Θυμβραῖε καὶ Δάλιε καὶ Λυκίας</l>
 						<l n="225">ναὸν ἐμβατεύων</l>
@@ -638,7 +638,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μόλοι δὲ ναυκλήρια, καὶ στρατιᾶς</l>
 						<l>Ἑλλάδος διόπτας</l>
@@ -652,7 +652,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="243">ἐπεὶ πρό τ’ οἴκων πρό τε γᾶς ἔτλα μόνος</l>
 						<l>ναύσταθμα βὰς κατιδεῖν· ἄγαμαι</l>
@@ -668,7 +668,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίν’ ἄνδρ’ Ἀχαιῶν ὁ πεδοστιβὴς σφαγεὺς</l>
 						<l n="255">οὐτάσει ἐν κλισίαις, τετράπουν</l>
@@ -685,12 +685,12 @@ bring up to P3
 			</div1>
 			<milestone ed="p" n="264" unit="card"/>
 			<div1 type="episode">
-				<sp who="#aggelospoimen">
+				<sp who="#angelos_poimen">
 					<speaker>Ἄγγελος Ποιμήν</speaker>
 					<l>ἄναξ, τοιούτων δεσπόταισιν ἄγγελος</l>
 					<l n="265">εἴην τὸ λοιπὸν οἷά σοι φέρω μαθεῖν.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>ἦ πόλλ’ ἀγρώταις σκαιὰ πρόσκειται φρενί·</l>
 					<l>καὶ γὰρ σὺ ποίμνας δεσπόταις τευχεσφόροις</l>
@@ -698,45 +698,45 @@ bring up to P3
 					<l>οὐκ οἶσθα δῶμα τοὐμὸν ἢ θρόνους πατρός,</l>
 					<l n="270">οἷ χρῆν γεγωνεῖν σ’ εὐτυχοῦντα ποίμνια;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>σκαιοὶ βοτῆρές ἐσμεν· οὐκ ἄλλως λέγω.</l>
 					<l>ἀλλ’ οὐδὲν ἧσσον σοι φέρω κεδνοὺς λόγους.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>παῦσαι λέγων μοι τὰς προσαυλείους τύχας·</l>
 					<l>μάχας πρὸ χειρῶν καὶ δόρη βαστάζομεν.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="275">τοιαῦτα κἀγὼ σημανῶν ἐλήλυθα·</l>
 					<l>ἀνὴρ γὰρ ἀλκῆς μυρίας στρατηλατῶν</l>
 					<l>στείχει φίλος σοὶ σύμμαχός τε τῇδε γῇ.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>ποίας πατρῴας γῆς ἐρημώσας πέδον;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>Θρῄκης· πατρὸς δὲ Στρυμόνος κικλήσκεται.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l n="280">Ῥῆσον τιθέντ’ ἔλεξας ἐν Τροίᾳ πόδα;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἔγνως· λόγου δὲ δὶς τόσου μ’ ἐκούφισας.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>καὶ πῶς πρὸς Ἴδης ὀργάδας πορεύεται,</l>
 					<l>πλαγχθεὶς πλατείας πεδιάδος θ’ ἁμαξιτοῦ;</l>
 				</sp>
 				<milestone ed="p" n="284" unit="card"/>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐκ οἶδ’ ἀκριβῶς· εἰκάσαι γε μὴν πάρα.</l>
 					<l n="285">νυκτὸς γὰρ οὔτι φαῦλον ἐμβαλεῖν στρατόν,</l>
@@ -775,13 +775,13 @@ bring up to P3
 					<l n="315">ὃν οὔτε φεύγων οὔθ’ ὑποσταθεὶς δορὶ</l>
 					<l>ὁ Πηλέως παῖς ἐκφυγεῖν δυνήσεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅταν πολίταις εὐσταθῶσι δαίμονες,</l>
 					<l>ἕρπει κατάντης ξυμφορὰ πρὸς τἀγαθά.</l>
 				</sp>
 				<milestone ed="p" n="319" unit="card"/>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>πολλούς, ἐπειδὴ τοὐμὸν εὐτυχεῖ δόρυ</l>
 					<l n="320">καὶ Ζεὺς πρὸς ἡμῶν ἐστιν, εὑρήσω φίλους.</l>
@@ -792,43 +792,43 @@ bring up to P3
 					<l n="325">ἥκει γὰρ ἐς δαῖτ’, οὐ παρὼν κυνηγέταις</l>
 					<l>αἱροῦσι λείαν οὐδὲ συγκαμὼν δορί.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὀρθῶς ἀτίζεις κἀπίμομφος εἶ φίλοις·</l>
 					<l>δέχου δὲ τοὺς θέλοντας ὠφελεῖν πόλιν.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>ἀρκοῦμεν οἱ σῴζοντες Ἴλιον πάλαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="330">πέποιθας ἤδη πολεμίους ᾑρηκέναι;</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>πέποιθα· δείξει τοὐπιὸν σέλας θεοῦ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅρα τὸ μέλλον· πόλλ’ ἀναστρέφει θεός.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l>μισῶ φίλοισιν ὕστερον βοηδρομεῖν.</l>
 					<l n="336">ὃ δ’ οὖν, ἐπείπερ ἦλθε, σύμμαχος μὲν οὔ,</l>
 					<l>ξένος δὲ πρὸς τράπεζαν ἡκέτω ξένων·</l>
 					<l>χάρις γὰρ αὐτῷ Πριαμιδῶν διώλετο.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="334">ἄναξ, ἀπωθεῖν συμμάχους ἐπίφθονον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="335">φόβος γένοιτ’ ἂν πολεμίοις ὀφθεὶς μόνον.</l>
 				</sp>
-				<sp who="#ektor">
+				<sp who="#hektor">
 					<speaker>Ἕκτωρ</speaker>
 					<l n="339">σύ τ’ εὖ παραινεῖς καὶ σὺ καιρίως σκοπεῖς.</l>
 					<l n="340">ὁ χρυσοτευχὴς δ’ οὕνεκ’ ἀγγέλου λόγων</l>
@@ -838,7 +838,7 @@ bring up to P3
 			<milestone ed="p" n="342" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἀδράστεια μὲν ἁ Διὸς</l>
 						<l>παῖς εἴργοι στομάτων φθόνον·</l>
@@ -853,7 +853,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Στρυμών, ὅς ποτε τᾶς μελῳ‐</l>
 						<l>δοῦ Μούσας δῑ ἀκηράτων</l>
@@ -868,7 +868,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="360">ἆρά ποτ’ αὖθις ἁ παλαιὰ Τροΐα</l>
 						<l>τοὺς προπότας παναμερεύ‐</l>
@@ -885,7 +885,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="370">ἐλθέ, φάνηθι, τὰν ζάχρυσον προβαλοῦ</l>
 						<l>Πηλεΐδα κατ’ ὄμμα πέλ‐</l>
@@ -904,7 +904,7 @@ bring up to P3
 			<milestone ed="p" n="379" unit="card"/>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰώ, μέγας ὦ βασιλεῦ.</l>
 						<l n="380">καλόν, ὦ Θρῄκη,</l>
@@ -927,7 +927,7 @@ bring up to P3
 						<l>πύργοισιν ἐχθρῶν· συγκατασκάψων δ’ ἐγὼ</l>
 						<l>τείχη πάρειμι καὶ νεῶν πρήσων σκάφη.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>παῖ τῆς μελῳδοῦ μητέρος Μουσῶν μιᾶς</l>
 						<l>Θρῃκός τε ποταμοῦ Στρυμόνος, φιλῶ λέγειν</l>
@@ -998,7 +998,7 @@ bring up to P3
 					<milestone ed="p" n="454" unit="card"/>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰώ.</l>
 						<l n="455">φίλα θροεῖς, φίλος Διόθεν εἶ· μόνον</l>
@@ -1026,7 +1026,7 @@ bring up to P3
 						<l>καὶ πᾶσαν ἐλθὼν Ἑλλάδ’ ἐκπέρσαι δορί,</l>
 						<l>ὡς ἂν μάθωσιν ἐν μέρει πάσχειν κακῶς.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>εἰ τοῦ παρόντος τοῦδ’ ἀπαλλαχθεὶς κακοῦ</l>
 						<l n="475">πόλιν νεμοίμην ὡς τὸ πρίν ποτ’ ἀσφαλῆ,</l>
@@ -1038,7 +1038,7 @@ bring up to P3
 						<speaker>Ῥῆσος</speaker>
 						<l>οὐ τούσδ’ ἀριστέας φασὶν Ἑλλήνων μολεῖν;</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l n="480">κοὐ μεμφόμεσθά γ’, ἀλλ’ ἄδην ἐλαύνομεν.</l>
 					</sp>
@@ -1046,7 +1046,7 @@ bring up to P3
 						<speaker>Ῥῆσος</speaker>
 						<l>οὐκ οὖν κτανόντες τούσδε πᾶν εἰργάσμεθα;</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>μή νυν τὰ πόρρω τἀγγύθεν μεθεὶς σκόπει.</l>
 					</sp>
@@ -1054,7 +1054,7 @@ bring up to P3
 						<speaker>Ῥῆσος</speaker>
 						<l>ἀρκεῖν ἔοικέ σοι παθεῖν, δρᾶσαι δὲ μή.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>πολλῆς γὰρ ἄρχω κἀνθάδ’ ὢν τυραννίδος.</l>
 						<l n="485">ἀλλ’ εἴτε λαιὸν εἴτε δεξιὸν κέρας</l>
@@ -1069,7 +1069,7 @@ bring up to P3
 						<l n="490">πρύμνας, πονήσας τὸν πάρος πολὺν χρόνον,</l>
 						<l>τάξον μ’ Ἀχιλλέως καὶ στρατοῦ κατὰ στόμα.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>οὐκ ἔστ’ ἐκείνῳ θοῦρον ἐντάξαι δόρυ.</l>
 					</sp>
@@ -1077,7 +1077,7 @@ bring up to P3
 						<speaker>Ῥῆσος</speaker>
 						<l>καὶ μὴν λόγος γ’ ἦν ὡς ἔπλευσ’ ἐπ’ Ἴλιον.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>ἔπλευσε καὶ πάρεστιν· ἀλλὰ μηνίων</l>
 						<l n="495">στρατηλάταισιν οὐ συναίρεται δόρυ.</l>
@@ -1086,7 +1086,7 @@ bring up to P3
 						<speaker>Ῥῆσος</speaker>
 						<l>τίς δὴ μετ’ αὐτὸν ἄλλος εὐδοξεῖ στρατοῦ;</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>Αἴας ἐμοὶ μὲν οὐδὲν ἡσσᾶσθαι δοκεῖ</l>
 						<l>χὡ Τυδέως παῖς· ἔστι δ’ αἱμυλώτατον</l>
@@ -1113,7 +1113,7 @@ bring up to P3
 						<l>λῃστὴν γὰρ ὄντα καὶ θεῶν ἀνάκτορα</l>
 						<l>συλῶντα δεῖ νιν τῷδε κατθανεῖν μόρῳ.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>νῦν μὲν καταυλίσθητε· καὶ γὰρ εὐφρόνη.</l>
 						<l>δείξω δ’ ἐγώ σοι χῶρον, ἔνθα χρὴ στρατὸν</l>
@@ -1130,7 +1130,7 @@ bring up to P3
 			<milestone ed="p" n="527" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίνος ἁ φυλακά; τίς ἀμείβει</l>
 						<l>τὰν ἐμάν; πρῶτα</l>
@@ -1154,7 +1154,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="547">καὶ μὴν ἀΐω· Σιμόεντος</l>
 						<l>ἡμένα κοίτας</l>
@@ -1180,7 +1180,7 @@ bring up to P3
 			</div1>
 			<milestone ed="p" n="565" unit="card"/>
 			<div1 type="episode">
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="565">Διόμηδες, οὐκ ἤκουσας — ἢ κενὸς ψόφος</l>
 					<l>στάζει δῑ ὤτων; — τευχέων τινὰ κτύπον;</l>
@@ -1191,7 +1191,7 @@ bring up to P3
 					<l>κλάζει σιδήρου· κἀμέ τοι, πρὶν ᾐσθόμην</l>
 					<l>δεσμῶν ἀραγμὸν ἱππικῶν, ἔδυ φόβος.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="570">ὅρα κατ’ ὄρφνην μὴ φύλαξιν ἐντύχῃς.</l>
 				</sp>
@@ -1199,7 +1199,7 @@ bring up to P3
 					<speaker>Διομήδης</speaker>
 					<l>φυλάξομαί τοι κἀν σκότῳ τιθεὶς πόδα.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἢν δ’ οὖν ἐγείρῃς, οἶσθα σύνθημα στρατοῦ;</l>
 				</sp>
@@ -1207,7 +1207,7 @@ bring up to P3
 					<speaker>Διομήδης</speaker>
 					<l>&lt;20Φοῖβον&gt;20 Δόλωνος οἶδα σύμβολον κλύων.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἔα·</l>
 					<l>εὐνὰς ἐρήμους τάσδε πολεμίων ὁρῶ.</l>
@@ -1217,7 +1217,7 @@ bring up to P3
 					<l n="575">καὶ μὴν Δόλων γε τάσδ’ ἔφραζεν Ἕκτορος</l>
 					<l>κοίτας, ἐφ’ ᾧπερ ἔγχος εἵλκυσται τόδε.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τί δῆτ’ ἂν εἴη; μῶν λόχος βέβηκέ ποι;</l>
 				</sp>
@@ -1225,7 +1225,7 @@ bring up to P3
 					<speaker>Διομήδης</speaker>
 					<l>ἴσως ἐφ’ ἡμῖν μηχανὴν στήσων τινά.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>θρασὺς γὰρ Ἕκτωρ νῦν, ἐπεὶ κρατεῖ, θρασύς.</l>
 				</sp>
@@ -1234,7 +1234,7 @@ bring up to P3
 					<l n="580">τί δῆτ’, Ὀδυσσεῦ, δρῶμεν; οὐ γὰρ ηὕρομεν</l>
 					<l>τὸν ἄνδρ’ ἐν εὐναῖς, ἐλπίδων δ’ ἡμάρτομεν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>στείχωμεν ὡς τάχιστα ναυστάθμων πέλας.</l>
 					<l>σῴζει γὰρ αὐτὸν ὅστις εὐτυχῆ θεῶν</l>
@@ -1245,7 +1245,7 @@ bring up to P3
 					<l n="585">οὐκ οὖν ἐπ’ Αἰνέαν ἢ τὸν ἔχθιστον Φρυγῶν</l>
 					<l>Πάριν μολόντε χρὴ καρατομεῖν ξίφει;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>πῶς οὖν ἐν ὄρφνῃ πολεμίων ἀνὰ στρατὸν</l>
 					<l>ζητῶν δυνήσῃ τούσδ’ ἀκινδύνως κτανεῖν;</l>
@@ -1255,7 +1255,7 @@ bring up to P3
 					<l>αἰσχρόν γε μέντοι ναῦς ἐπ’ Ἀργείων μολεῖν</l>
 					<l n="590">δράσαντε μηδὲν πολεμίους νεώτερον.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>πῶς δ’ οὐ δέδρακας; οὐ κτανόντε ναυστάθμων</l>
 					<l>κατάσκοπον Δόλωνα σῴζομεν τάδε</l>
@@ -1282,7 +1282,7 @@ bring up to P3
 					<l>εὐνὰς ἔασον καὶ καρατόμους σφαγάς·</l>
 					<l>ἔσται γὰρ αὐτῷ θάνατος ἐξ ἄλλης χερός.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>δέσποιν’ Ἀθάνα, φθέγματος γὰρ ᾐσθόμην</l>
 					<l>τοῦ σοῦ συνήθη γῆρυν· ἐν πόνοισι γὰρ</l>
@@ -1302,7 +1302,7 @@ bring up to P3
 					<l n="620">κάλλιστον οἴκοις σκῦλον· οὐ γὰρ ἔσθ’ ὅπου</l>
 					<l>τοιόνδ’ ὄχημα χθὼν κέκευθε πωλικόν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>Διόμηδες, ἢ σὺ κτεῖνε Θρῄκιον λεών,</l>
 					<l>ἢ ’μοὶ πάρες γε, σοὶ δὲ χρὴ πώλους μέλειν.</l>
@@ -1344,7 +1344,7 @@ bring up to P3
 					<l>οὐκ οἶδεν οὐδ’ ἤκουσεν ἐγγὺς ὢν λόγου.</l>
 				</sp>
 				<milestone ed="p" n="642" unit="card"/>
-				<sp who="#aleksandros">
+				<sp who="#alexandros">
 					<speaker>Ἀλέξανδρος</speaker>
 					<l>σὲ τὸν στρατηγὸν καὶ κασίγνητον λέγω,</l>
 					<l>Ἕκτορ, καθεύδεις; οὐκ ἐγείρεσθαί σε χρῆν;</l>
@@ -1361,7 +1361,7 @@ bring up to P3
 					<l>τῆς ὑμνοποιοῦ παῖδα Θρῄκιον θεᾶς</l>
 					<l>Μούσης· πατρὸς δὲ Στρυμόνος κικλήσκεται.</l>
 				</sp>
-				<sp who="#aleksandros">
+				<sp who="#alexandros">
 					<speaker>Ἀλέξανδρος</speaker>
 					<l>αἰεί ποτ’ εὖ φρονοῦσα τυγχάνεις πόλει</l>
 					<l>κἀμοί, μέγιστον δ’ ἐν βίῳ κειμήλιον</l>
@@ -1377,7 +1377,7 @@ bring up to P3
 					<l>μηδὲν φοβηθῇς· οὐδὲν ἐν στρατῷ νέον·</l>
 					<l>Ἕκτωρ δὲ φροῦδος Θρῇκα κοιμήσων στρατόν.</l>
 				</sp>
-				<sp who="#aleksandros">
+				<sp who="#alexandros">
 					<speaker>Ἀλέξανδρος</speaker>
 					<l>σύ τοί με πείθεις, σοῖς δὲ πιστεύων λόγοις</l>
 					<l>τάξιν φυλάξων εἶμ’ ἐλεύθερος φόβου.</l>
@@ -1397,7 +1397,7 @@ bring up to P3
 				</sp>
 				<milestone ed="p" n="675" unit="card"/>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="675">ἔα ἔα·</l>
 						<l>βάλε βάλε βάλε βάλε.</l>
@@ -1411,60 +1411,60 @@ bring up to P3
 					<milestone ed="p" n="683" unit="card"/>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#odysseys">
+					<sp who="#odysseus">
 						<speaker>Ὀδυσσεύς</speaker>
 						<l>οὔ σε χρὴ εἰδέναι· θανῇ γὰρ σήμερον δράσας κακῶς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκ ἐρεῖς ξύνθημα, λόγχην πρὶν διὰ στέρνων μολεῖν;</l>
 					</sp>
-					<sp who="#odysseys">
+					<sp who="#odysseus">
 						<speaker>Ὀδυσσεύς</speaker>
 						<l n="685">ἵστω. θάρσει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">πέλας ἴθι. παῖε πᾶς.</l>
 					</sp>
-					<sp who="#odysseys">
+					<sp who="#odysseus">
 						<speaker>Ὀδυσσεύς</speaker>
 						<l>ἦ σὺ δὴ Ῥῆσον κατέκτας;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἀλλὰ τὸν κτενοῦντα σὲ . . .</l>
 					</sp>
-					<sp who="#odysseys">
+					<sp who="#odysseus">
 						<speaker>Ὀδυσσεύς</speaker>
 						<l>ἴσχε πᾶς τις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">οὐ μὲν οὖν.</l>
 					</sp>
-					<sp who="#odysseys">
+					<sp who="#odysseus">
 						<speaker>Ὀδυσσεύς</speaker>
 						<l part="Y">ἆ· φίλιον ἄνδρα μὴ θένῃς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ τί δὴ τὸ σῆμα;</l>
 					</sp>
-					<sp who="#odysseys">
+					<sp who="#odysseus">
 						<speaker>Ὀδυσσεύς</speaker>
 						<l part="Y">Φοῖβος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἔμαθον· ἴσχε πᾶς δόρυ.</l>
 						<l>οἶσθ’ ὅποι βεβᾶσιν ἅνδρες;</l>
 					</sp>
-					<sp who="#odysseys">
+					<sp who="#odysseus">
 						<speaker>Ὀδυσσεύς</speaker>
 						<l part="Y">τῇδέ πῃ κατείδομεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="690">ἕρπω πᾶς κατ’ ἴχνος αὐτῶν.</l>
 						<l part="Y">ἢ βοὴν ἐγερτέον;</l>
@@ -1475,7 +1475,7 @@ bring up to P3
 			<milestone ed="p" n="692" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς ἀνδρῶν ὁ βάς;</l>
 						<l>τίς ὁ μέγα θρασὺς ἐπεύξεται</l>
@@ -1501,7 +1501,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="710">ἔβα καὶ πάρος</l>
 						<l>κατὰ πόλιν, ὕπαφρον ὄμμ’ ἔχων,</l>
@@ -1529,30 +1529,30 @@ bring up to P3
 			<milestone ed="p" n="728" unit="card"/>
 			<div1 type="episode">
 				<div2 type="lyric">
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>ἰὼ, ἰώ, δαίμονος τύχα βαρεῖα. φεῦ φεῦ.</l>
 					</sp>
 				</div2>
 				<div2 type="trochees">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔα, ἔα·</l>
 						<l n="730">σῖγα πᾶς ὕφιζ’· ἴσως γὰρ ἐς βόλον τις ἔρχεται.</l>
 					</sp>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>ἰὼ ἰώ,</l>
 						<l>συμφορὰ βαρεῖα Θρῃκῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">συμμάχων τις ὁ στένων.</l>
 					</sp>
 					<milestone ed="p" n="733" unit="card"/>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l n="733">ἰὼ ἰώ,</l>
 						<l>δύστηνος ἐγώ· σύ τ’, ἄναξ Θρῃκῶν,</l>
@@ -1560,7 +1560,7 @@ bring up to P3
 						<l n="735">οἷόν σε βίου τέλος εἷλεν.</l>
 					</sp>
 					<milestone ed="p" n="736" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς εἶ ποτ’ ἀνδρῶν συμμάχων; κατ’ εὐφρόνην</l>
 						<l>ἀμβλῶπες αὐγαὶ κοὔ σε γιγνώσκω τορῶς.</l>
@@ -1568,7 +1568,7 @@ bring up to P3
 					<milestone ed="p" n="738" unit="card"/>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>ποῦ τιν’ ἀνάκτων Τρωικῶν εὕρω;</l>
 						<l>ποῦ δῆθ’ Ἕκτωρ</l>
@@ -1579,13 +1579,13 @@ bring up to P3
 						<l>Θρῃξὶν πένθος τολυπεύσας;</l>
 					</sp>
 					<milestone ed="p" n="745" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="745">κακὸν κυρεῖν τι Θρῃκίῳ στρατεύματι</l>
 						<l>ἔοικεν, οἷα τοῦδε γιγνώσκω κλύων.</l>
 					</sp>
 					<milestone ed="p" n="747" unit="card"/>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>ἔρρει στρατιά, πέπτωκεν ἄναξ</l>
 						<l>δολίῳ πληγῇ.</l>
@@ -1598,12 +1598,12 @@ bring up to P3
 					<milestone ed="p" n="754" unit="card"/>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάδ’ οὐκ ἐν αἰνιγμοῖσι σημαίνει κακά·</l>
 						<l n="755">σαφῶς γὰρ αὐδᾷ συμμάχους ὀλωλότας.</l>
 					</sp>
-					<sp n="Ἡνίοχος" who="#enioxos">
+					<sp n="Ἡνίοχος" who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>κακῶς πέπρακται κἀπὶ τοῖς κακοῖσι πρὸς</l>
 						<l>αἴσχιστα· καίτοι δὶς τόσον κακὸν τόδε·</l>
@@ -1659,7 +1659,7 @@ bring up to P3
 						<l>οὐδ’ ἐξ ὁποίας χειρός. εἰκάσαι δέ μοι</l>
 						<l>πάρεστι λυπρὰ πρὸς φίλων πεπονθέναι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἡνίοχε Θρῃκὸς τοῦ κακῶς πεπραγότος,</l>
 						<l n="805">μηδὲν δυσοίζου· πολέμιοι ’)/δρασαν τάδε.</l>
@@ -1668,7 +1668,7 @@ bring up to P3
 						<l>Ἕκτωρ δὲ καὐτὸς συμφορᾶς πεπυσμένος</l>
 						<l>χωρεῖ· συναλγεῖ δ’, ὡς ἔοικε, σοῖς κακοῖς.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>πῶς, ὦ μέγιστα πήματ’ ἐξειργασμένοι,</l>
 						<l>μολόντες ὑμᾶς πολεμίων κατάσκοποι</l>
@@ -1686,7 +1686,7 @@ bring up to P3
 					<milestone ed="p" n="820" unit="card"/>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="820">ἰὼ ἰώ,</l>
 						<l>μετὰ σέ, ναί, μετὰ σέ, ὦ πολίοχον κράτος,</l>
@@ -1702,7 +1702,7 @@ bring up to P3
 						<l>ζῶντα πόρευσον· οὐ παραιτοῦμαι.</l>
 						<milestone ed="p" n="833" unit="card"/>
 					</sp>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>τί τοῖσδ’ ἀπειλεῖς βάρβαρός τε βαρβάρου</l>
 						<l>γνώμην ὑφαιρῇ τὴν ἐμήν, πλέκων λόγους;</l>
@@ -1728,7 +1728,7 @@ bring up to P3
 						<l>ἔφραζε τοῖς κτανοῦσιν; οὐδ’ ἀφιγμένον</l>
 						<l n="855">τὸ πάμπαν ᾖσαν· ἀλλὰ μηχανᾷ τάδε.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>χρόνον μὲν ἤδη συμμάχοισι χρώμεθα</l>
 						<l>ὅσονπερ ἐν γῇ τῇδ’ Ἀχαιικὸς λεώς,</l>
@@ -1741,45 +1741,45 @@ bring up to P3
 						<l>μὴ καὶ Δόλωνα συντυχὼν κατακτάνῃ·</l>
 						<l n="865">χρόνον γὰρ ἤδη φροῦδος ὢν οὐ φαίνεται.</l>
 					</sp>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>οὐκ οἶδα τοὺς σοὺς οὓς λέγεις Ὀδυσσέας·</l>
 						<l>ἡμεῖς δ’ ὑπ’ ἐχθρῶν οὐδενὸς πεπλήγμεθα.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>σὺ δ’ οὖν νόμιζε ταῦτ’, ἐπείπερ σοι δοκεῖ.</l>
 					</sp>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>ὦ γαῖα πατρίς, πῶς ἂν ἐνθάνοιμί σοι;</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l n="870">μὴ θνῇσχ’· ἅλις γὰρ τῶν τεθνηκότων ὄχλος.</l>
 					</sp>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>ποῖ δὴ τράπωμαι δεσποτῶν μονούμενος;</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>οἶκός σε κεύθων οὑμὸς ἐξιάσεται.</l>
 					</sp>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l>καὶ πῶς με κηδεύσουσιν αὐθεντῶν χέρες;</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>ὅδ’ αὖ τὸν αὐτὸν μῦθον οὐ λήξει λέγων.</l>
 					</sp>
-					<sp who="#enioxos">
+					<sp who="#heniochos">
 						<speaker>Ἡνίοχος</speaker>
 						<l n="875">ὄλοιθ’ ὁ δράσας. οὐ γὰρ ἐς σὲ τείνεται</l>
 						<l>γλῶσσ’, ὡς σὺ κομπεῖς· ἡ Δίκη δ’ ἐπίσταται.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>λάζυσθ’· ἄγοντες &lt;δ’&gt; αὐτὸν ἐς δόμους ἐμούς,</l>
 						<l>οὕτως ὅπως ἂν μὴ ’γκαλῇ πορσύνετε·</l>
@@ -1790,7 +1790,7 @@ bring up to P3
 					<milestone ed="p" n="882" unit="card"/>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί ποτ’ εὐτυχίας ἐκ τῆς μεγάλης</l>
 						<l>Τροίαν ἀνάγει πάλιν ἐς πένθη</l>
@@ -1802,7 +1802,7 @@ bring up to P3
 						<l>ταρβῶ, λεύσσων τόδε, πῆμα.</l>
 					</sp>
 					<milestone ed="p" n="890" unit="card"/>
-					<sp who="#moysa">
+					<sp who="#mousa">
 						<speaker>Μοῦσα</speaker>
 						<l n="890">ὁρᾶν πάρεστι, Τρῶες· ἡ γὰρ ἐν σοφοῖς</l>
 						<l>τιμὰς ἔχουσα Μοῦσα συγγόνων μία</l>
@@ -1813,7 +1813,7 @@ bring up to P3
 					<milestone ed="p" n="895" unit="card"/>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#moysa">
+					<sp who="#mousa">
 						<speaker>Μοῦσα</speaker>
 						<l n="895">ἰαλέμῳ αὐθιγενεῖ,</l>
 						<l>τέκνον, σ’ ὀλοφύρομαι, ὦ</l>
@@ -1826,7 +1826,7 @@ bring up to P3
 						<l>φιλία κεφαλά, τέκνον, ὤμοι.</l>
 						<milestone ed="p" n="904" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅσον προσήκει μὴ γένους κοινωνίαν</l>
 						<l n="905">ἔχοντι λύπῃ τὸν σὸν οἰκτίρω γόνον.</l>
@@ -1834,7 +1834,7 @@ bring up to P3
 					<milestone ed="p" n="906" unit="card"/>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#moysa">
+					<sp who="#mousa">
 						<speaker>Μοῦσα</speaker>
 						<l>ὄλοιτο μὲν Οἰνεΐδας,</l>
 						<l>ὄλοιτο δὲ Λαρτιάδας,</l>
@@ -1847,7 +1847,7 @@ bring up to P3
 						<l>ἀνδρῶν ἀγαθῶν ἐκένωσεν.</l>
 						<milestone ed="p" n="915" unit="card"/>
 					</sp>
-					<sp who="#moysa">
+					<sp who="#mousa">
 						<speaker>Μοῦσα</speaker>
 						<l n="915">ἦ πολλὰ μὲν ζῶν, πολλὰ δ’ εἰς Ἅιδου μολών,</l>
 						<l>Φιλάμμονος παῖ, τῆς ἐμῆς ἥψω φρενός·</l>
@@ -1891,13 +1891,13 @@ bring up to P3
 						<l>καὶ τῶνδε μισθὸν παῖδ’ ἔχουσ’ ἐν ἀγκάλαις</l>
 						<l>θρηνῶ· σοφιστὴν δ’ ἄλλον οὐκ ἐπάξομαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="950">μάτην ἄρ’ ἡμᾶς Θρῄκιος τροχηλάτης</l>
 						<l>ἐδέννασ’, Ἕκτορ, τῷδε βουλεῦσαι φόνον.</l>
 					</sp>
 					<milestone ed="p" n="952" unit="card"/>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>ᾔδη τάδ’· οὐδὲν μάντεων ἔδει φράσαι</l>
 						<l>Ὀδυσσέως τέχναισι τόνδ’ ὀλωλότα.</l>
@@ -1910,7 +1910,7 @@ bring up to P3
 						<l n="960">καὶ ξυμπυρῶσαι μυρίων πέπλων χλιδήν·</l>
 						<l>φίλος γὰρ ἐλθὼν δυστυχῶς ἀπέρχεται.</l>
 					</sp>
-					<sp who="#moysa">
+					<sp who="#mousa">
 						<speaker>Μοῦσα</speaker>
 						<l>οὐκ εἶσι γαίας ἐς μελάγχιμον πέδον·</l>
 						<l>τοσόνδε Νύμφην τὴν ἔνερθ’ αἰτήσομαι,</l>
@@ -1934,13 +1934,13 @@ bring up to P3
 						<l>ὡς ὅστις ὑμᾶς μὴ κακῶς λογίζεται,</l>
 						<l>ἄπαις διοίσει κοὐ τεκὼν θάψει τέκνα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὗτος μὲν ἤδη μητρὶ κηδεύειν μέλει·</l>
 						<l>σὺ δ’ εἴ τι πράσσειν τῶν προκειμένων θέλεις,</l>
 						<l n="985">Ἕκτορ, πάρεστι· φῶς γὰρ ἡμέρας τόδε.</l>
 					</sp>
-					<sp who="#ektor">
+					<sp who="#hektor">
 						<speaker>Ἕκτωρ</speaker>
 						<l>χωρεῖτε, συμμάχους δ’ ὁπλίζεσθαι τάχος</l>
 						<l>ἄνωχθε πληροῦν τ’ αὐχένας ξυνωρίδων.</l>
@@ -1953,7 +1953,7 @@ bring up to P3
 					<milestone ed="p" n="993" unit="card"/>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πείθου βασιλεῖ· στείχωμεν ὅπλοις</l>
 						<l>κοσμησάμενοι καὶ ξυμμαχίᾳ</l>

--- a/tei/euripides-suppliants.xml
+++ b/tei/euripides-suppliants.xml
@@ -57,28 +57,28 @@
 					<person xml:id="paides">
 						<persName>Παῖδες</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<person xml:id="ifis">
+					<person xml:id="iphis">
 						<persName>Ἶφις</persName>
 					</person>
-					<person xml:id="keryks">
+					<person xml:id="keryx">
 						<persName>Κῆρυξ</persName>
 					</person>
 					<person xml:id="aithra">
 						<persName>Αἴθρα</persName>
 					</person>
-					<person xml:id="theseys">
+					<person xml:id="theseus">
 						<persName>Θησεύς</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="adrastos">
 						<persName>Ἄδραστος</persName>
 					</person>
-					<person xml:id="eyadne">
+					<person xml:id="euadne">
 						<persName>Εὐάδνη</persName>
 					</person>
 				</listPerson>
@@ -211,7 +211,7 @@ bring up to P3
 			<milestone ed="p" n="42" unit="card"/>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἱκετεύω σε, γεραιά,</l>
 						<l>γεραιῶν ἐκ στομάτων, πρὸς</l>
@@ -223,7 +223,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐσιδοῦσ’ οἰκτρὰ μὲν ὄσσων</l>
 						<l>δάκρῡ ἀμφὶ βλεφάροις, ῥυ‐</l>
@@ -235,7 +235,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔτεκες καὶ σύ ποτ’, ὦ πότνια, κοῦρον</l>
 						<l n="55">φίλα ποιησαμένα λέ‐</l>
@@ -250,7 +250,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁσίως οὔχ, ὑπ’ ἀνάγκας δὲ προπίπτου‐</l>
 						<l>σα προσαιτοῦσ’ ἔμολον δε‐</l>
@@ -265,7 +265,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀγὼν ὅδ’ ἄλλος ἔρχεται γόων γόων</l>
 						<l>διάδοχος, ἀχοῦσι προσπόλων χέρες.</l>
@@ -280,7 +280,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄπληστος ἅδε μ’ ἐξάγει χάρις γόων</l>
 						<l n="80">πολύπονος, ὡς ἐξ ἀλιβάτου πέτρας</l>
@@ -296,7 +296,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τίνων γόων ἤκουσα καὶ στέρνων κτύπον</l>
 					<l>νεκρῶν τε θρήνους, τῶνδ’ ἀνακτόρων ἄπο</l>
@@ -320,7 +320,7 @@ bring up to P3
 					<l>ἑπτὰ στρατηγῶν· ἱκεσίοις δὲ σὺν κλάδοις</l>
 					<l>φρουροῦσί μ’, ὡς δέδορκας, ἐν κύκλῳ, τέκνον.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τίς δ’ ὁ στενάζων οἰκτρὸν ἐν πύλαις ὅδε;</l>
 				</sp>
@@ -328,7 +328,7 @@ bring up to P3
 					<speaker>Αἴθρα</speaker>
 					<l n="105">Ἄδραστος, ὡς λέγουσιν, Ἀργείων ἄναξ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οἱ δ’ ἀμφὶ τόνδε παῖδες; ἦ τούτων τέκνα;</l>
 				</sp>
@@ -336,7 +336,7 @@ bring up to P3
 					<speaker>Αἴθρα</speaker>
 					<l>οὔκ, ἀλλὰ νεκρῶν τῶν ὀλωλότων κόροι.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τί γὰρ πρὸς ἡμᾶς ἦλθον ἱκεσίᾳ χερί;</l>
 				</sp>
@@ -344,7 +344,7 @@ bring up to P3
 					<speaker>Αἴθρα</speaker>
 					<l>οἶδ’· ἀλλὰ τῶνδε μῦθος οὑντεῦθεν, τέκνον.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="110">σὲ τὸν κατήρη χλανιδίοις ἀνιστορῶ.</l>
 					<l>λέγ’ ἐκκαλύψας κρᾶτα καὶ πάρες γόον·</l>
@@ -356,7 +356,7 @@ bring up to P3
 					<l>ὦ καλλίνικε γῆς Ἀθηναίων ἄναξ,</l>
 					<l>Θησεῦ, σὸς ἱκέτης καὶ πόλεως ἥκω σέθεν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="115">τί χρῆμα θηρῶν καὶ τίνος χρείαν ἔχων;</l>
 				</sp>
@@ -364,7 +364,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>οἶσθ’ ἣν στρατείαν ἐστράτευσ’ ὀλεθρίαν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὐ γάρ τι σιγῇ διεπέρασας Ἑλλάδα.</l>
 				</sp>
@@ -372,7 +372,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>ἐνταῦθ’ ἀπώλεσ’ ἄνδρας Ἀργείων ἄκρους.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τοιαῦθ’ ὁ τλήμων πόλεμος ἐξεργάζεται.</l>
 				</sp>
@@ -380,7 +380,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l n="120">τούτους θανόντας ἦλθον ἐξαιτῶν πόλιν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>κήρυξιν Ἑρμοῦ πίσυνος, ὡς θάψῃς νεκρούς;</l>
 				</sp>
@@ -388,7 +388,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>κἄπειτά γ’ οἱ κτανόντες οὐκ ἐῶσί με.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τί γὰρ λέγουσιν, ὅσια χρῄζοντος σέθεν;</l>
 				</sp>
@@ -396,7 +396,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>τί δ’; εὐτυχοῦντες οὐκ ἐπίστανται φέρειν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="125">ξύμβουλον οὖν μ’ ἐπῆλθες; ἢ τίνος χάριν;</l>
 				</sp>
@@ -404,7 +404,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>κομίσαι σε, Θησεῦ, παῖδας Ἀργείων θέλων.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τὸ δ’ Ἄργος ἡμῖν ποῦ ’στιν; ἢ κόμποι μάτην;</l>
 				</sp>
@@ -412,7 +412,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>σφαλέντες οἰχόμεσθα. πρὸς σὲ δ’ ἥκομεν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἰδίᾳ δοκῆσάν σοι τόδ’ ἢ πάσῃ πόλει;</l>
 				</sp>
@@ -420,7 +420,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l n="130">πάντες &lt;σ’&gt; ἱκνοῦνται Δαναΐδαι θάψαι νεκρούς.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἐκ τοῦ δ’ ἐλαύνεις ἑπτὰ πρὸς Θήβας λόχους;</l>
 				</sp>
@@ -428,7 +428,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>δισσοῖσι γαμβροῖς τήνδε πορσύνων χάριν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τῷ δ’ ἐξέδωκας παῖδας Ἀργείων σέθεν;</l>
 				</sp>
@@ -436,7 +436,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>οὐκ ἐγγενῆ συνῆψα κηδείαν δόμοις.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="135">ἀλλὰ ξένοις ἔδωκας Ἀργείας κόρας;</l>
 				</sp>
@@ -444,7 +444,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>Τυδεῖ &lt;γε&gt; Πολυνείκει τε τῷ Θηβαιγενεῖ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τίν’ εἰς ἔρωτα τῆσδε κηδείας μολών;</l>
 				</sp>
@@ -452,7 +452,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>Φοίβου μ’ ὑπῆλθε δυστόπαστ’ αἰνίγματα.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τί δ’ εἶπ’ Ἀπόλλων παρθένοις κραίνων γάμον;</l>
 				</sp>
@@ -460,7 +460,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l n="140">κάπρῳ με δοῦναι καὶ λέοντι παῖδ’ ἐμώ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>σὺ δ’ ἐξελίσσεις πῶς θεοῦ θεσπίσματα;</l>
 				</sp>
@@ -468,7 +468,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>ἐλθόντε φυγάδε νυκτὸς εἰς ἐμὰς πύλας — </l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τίς καὶ τίς; εἰπέ· δύο γὰρ ἐξαυδᾷς ἅμα.</l>
 				</sp>
@@ -476,7 +476,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>Τυδεὺς μάχην ξυνῆψε Πολυνείκης θ’ ἅμα.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="145">ἦ τοῖσδ’ ἔδωκας θηρσὶν ὣς κόρας σέθεν;</l>
 				</sp>
@@ -484,7 +484,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>μάχην γε δισσοῖν κνωδάλοιν ἀπεικάσας.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἦλθον δὲ δὴ πῶς πατρίδος ἐκλιπόνθ’ ὅρους;</l>
 				</sp>
@@ -492,7 +492,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>Τυδεὺς μὲν αἷμα συγγενὲς φεύγων χθονός.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ὁ δ’ Οἰδίπου &lt;τί&gt;, τίνι τρόπῳ Θήβας λιπών;</l>
 				</sp>
@@ -500,7 +500,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l n="150">ἀραῖς πατρῴαις, μὴ κασίγνητον κτάνοι.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>σοφήν γ’ ἔλεξας τήνδ’ ἑκούσιον φυγήν.</l>
 				</sp>
@@ -508,7 +508,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>ἀλλ’ οἱ μένοντες τοὺς ἀπόντας ἠδίκουν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὔ πού σφ’ ἀδελφὸς χρημάτων νοσφίζεται;</l>
 				</sp>
@@ -516,7 +516,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>ταύτῃ δικάζων ἦλθον· εἶτ’ ἀπωλόμην.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="155">μάντεις δ’ ἐπῆλθες ἐμπύρων τ’ εἶδες φλόγα;</l>
 				</sp>
@@ -524,7 +524,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>οἴμοι; διώκεις μ’ ᾗ μάλιστ’ ἐγὼ ’σφάλην.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὐκ ἦλθες, ὡς ἔοικεν, εὐνοίᾳ θεῶν.</l>
 				</sp>
@@ -532,7 +532,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>τὸ δὲ πλέον, ἦλθον Ἀμφιάρεώ γε πρὸς βίαν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὕτω τὸ θεῖον ῥᾳδίως ἀπεστράφης;</l>
 				</sp>
@@ -540,7 +540,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l n="160">νέων γὰρ ἀνδρῶν θόρυβος ἐξέπλησσέ με.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>εὐψυχίαν ἔσπευσας ἀντ’ εὐβουλίας.</l>
 					<milestone ed="p" n="162" unit="card"/>
@@ -580,13 +580,13 @@ bring up to P3
 					<l>ἔχει σὲ ποιμέν’ ἐσθλόν· οὗ χρείᾳ πόλεις</l>
 					<l>πολλαὶ διώλοντ’, ἐνδεεῖς στρατηλάτου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>κἀγὼ τὸν αὐτὸν τῷδέ σοι λόγον λέγω,</l>
 					<l>Θησεῦ, δῑ οἴκτου τὰς ἐμὰς λαβεῖν τύχας.</l>
 					<milestone ed="p" n="195" unit="card"/>
 				</sp>
-				<sp n="Θησεύς" who="#theseys">
+				<sp n="Θησεύς" who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="195">ἄλλοισι δὴ ’πόνησ’ ἁμιλληθεὶς λόγῳ</l>
 					<l>τοιῷδ’. ἔλεξε γάρ τις ὡς τὰ χείρονα</l>
@@ -645,7 +645,7 @@ bring up to P3
 					<l>χαίρων ἴθ’· εἰ γὰρ μὴ βεβούλευσαι καλῶς,</l>
 					<l>αὐτὸς πιέζειν τὴν τύχην, ἡμᾶς δ’ ἐᾶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="250">ἥμαρτεν· ἐν νέοισι δ’ ἀνθρώπων τόδε</l>
 					<l>ἔνεστι· συγγνώμην δὲ τῷδ’ ἔχειν χρεών.</l>
@@ -665,7 +665,7 @@ bring up to P3
 					<l>Δήμητρα θέμεναι μάρτυρ’ ἡλίου τε φῶς,</l>
 					<l>ὡς οὐδὲν ἡμῖν ἤρκεσαν λιταὶ θεῶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<!-- a lacuna -->
 					<l>.     .     .     .     .     .     .     .</l>
@@ -680,7 +680,7 @@ bring up to P3
 					<milestone ed="p" n="271" unit="card"/>
 				</sp>
 				<div2 type="hexameter">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βᾶθι, τάλαιν’, ἱερῶν δαπέδων ἄπο Περσεφονείας,</l>
 						<l>βᾶθι καὶ ἀντίασον γονάτων ἔπι χεῖρα βαλοῦσα,</l>
@@ -699,7 +699,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>μῆτερ, τί κλαίεις λέπτ’ ἐπ’ ὀμμάτων φάρη</l>
 						<l>βαλοῦσα τῶν σῶν; ἆρα δυστήνους γόους</l>
@@ -711,7 +711,7 @@ bring up to P3
 						<speaker>Αἴθρα</speaker>
 						<l>αἰαῖ.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l part="Y">τὰ τούτων οὐχὶ σοὶ στενακτέον.</l>
 					</sp>
@@ -719,7 +719,7 @@ bring up to P3
 						<speaker>Αἴθρα</speaker>
 						<l>ὦ τλήμονες γυναῖκες.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l part="Y">οὐ σὺ τῶνδ’ ἔφυς.</l>
 					</sp>
@@ -727,7 +727,7 @@ bring up to P3
 						<speaker>Αἴθρα</speaker>
 						<l>εἴπω τι, τέκνον, σοί τε καὶ πόλει καλόν;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ὡς πολλά γ’ ἐστὶ κἀπὸ θηλειῶν σοφά.</l>
 					</sp>
@@ -735,7 +735,7 @@ bring up to P3
 						<speaker>Αἴθρα</speaker>
 						<l n="295">ἀλλ’ εἰς ὄκνον μοι μῦθος ὃν κεύθω φέρει.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>αἰσχρόν γ’ ἔλεξας, χρήστ’ ἔπη κρύπτειν φίλοις.</l>
 					</sp>
@@ -777,13 +777,13 @@ bring up to P3
 						<l n="330">ἔτ’ αὐτὸν ἄλλα βλήματ’ ἐν κύβοις βαλεῖν</l>
 						<l>πέποιθ’· ὁ γὰρ θεὸς πάντ’ ἀναστρέφει πάλιν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ φιλτάτη μοι, τῷδέ τ’ εἴρηκας καλῶς</l>
 						<l>κἀμοί· διπλοῦν δὲ χάρμα γίγνεται τόδε.</l>
 						<milestone ed="p" n="334" unit="card"/>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἐμοὶ λόγοι μέν, μῆτερ, οἱ λελεγμένοι</l>
 						<l n="335">ὀρθῶς ἔχουσ’ ἐς τόνδε, κἀπεφηνάμην</l>
@@ -822,7 +822,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="365">ἱππόβοτον Ἄργος, ὦ πάτριον ἐμὸν πέδον,</l>
 						<l>ἐκλύετε τάδ’, ἐκλύετε</l>
@@ -833,7 +833,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ γὰρ ἐπὶ τέρμα καὶ τὸ πλέον ἐμῶν κακῶν</l>
 						<l n="370">ἱκόμενος ἔτι ματέρος</l>
@@ -844,7 +844,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καλὸν δ’ ἄγαλμα πόλεσιν εὐσεβὴς πόνος</l>
 						<l>χάριν τ’ ἔχει τὰν ἐς αἰεί.</l>
@@ -854,7 +854,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄμυνε ματρί, πόλις, ἄμυνε, Παλλάδος,</l>
 						<l>νόμους βροτῶν μὴ μιαίνειν.</l>
@@ -865,7 +865,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τέχνην μὲν αἰεὶ τήνδ’ ἔχων ὑπηρετεῖς</l>
 					<l>πόλει τε κἀμοί, διαφέρων κηρύγματα·</l>
@@ -887,14 +887,14 @@ bring up to P3
 					<l>μολὼν ὕπαντα τοῖς ἐμοῖς βουλεύμασιν.</l>
 					<milestone ed="p" n="399" unit="card"/>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>τίς γῆς τύραννος; πρὸς τίν’ ἀγγεῖλαί με χρὴ</l>
 					<l n="400">λόγους Κρέοντος, ὃς κρατεῖ Κάδμου χθονὸς</l>
 					<l>Ἐτεοκλέους θανόντος ἀμφ’ ἑπταστόμους</l>
 					<l>πύλας ἀδελφῇ χειρὶ Πολυνείκους ὕπο;</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>πρῶτον μὲν ἤρξω τοῦ λόγου ψευδῶς, ξένε,</l>
 					<l>ζητῶν τύραννον ἐνθάδ’· οὐ γὰρ ἄρχεται</l>
@@ -903,7 +903,7 @@ bring up to P3
 					<l>ἐνιαυσίαισιν, οὐχὶ τῷ πλούτῳ διδοὺς</l>
 					<l>τὸ πλεῖστον, ἀλλὰ χὡ πένης ἔχων ἴσον.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἓν μὲν τόδ’ ἡμῖν ὥσπερ ἐν πεσσοῖς δίδως</l>
 					<l n="410">κρεῖσσον· πόλις γὰρ ἧς ἐγὼ πάρειμ’ ἄπο</l>
@@ -924,7 +924,7 @@ bring up to P3
 					<l n="425">γλώσσῃ κατασχὼν δῆμον, οὐδὲν ὢν τὸ πρίν.</l>
 					<milestone ed="p" n="426" unit="card"/>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>κομψός γ’ ὁ κῆρυξ καὶ παρεργάτης λόγων.</l>
 					<l>ἐπεὶ δ’ ἀγῶνα καὶ σὺ τόνδ’ ἠγωνίσω,</l>
@@ -964,13 +964,13 @@ bring up to P3
 					<l>χωρεῖν. τὸ λοιπὸν δ’ εἰς ἐμὴν πόλιν Κρέων</l>
 					<l>ἧσσον λάλον σου πεμπέτω τιν’ ἄγγελον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>φεῦ φεῦ· κακοῖσιν ὡς ὅταν δαίμων διδῷ</l>
 					<l>καλῶς, ὑβρίζουσ’ ὡς ἀεὶ πράξοντες εὖ.</l>
 					<milestone ed="p" n="465" unit="card"/>
 				</sp>
-				<sp n="Κῆρυξ" who="#keryks">
+				<sp n="Κῆρυξ" who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="465">λέγοιμ’ ἂν ἤδη. τῶν μὲν ἠγωνισμένων</l>
 					<l>σοὶ μὲν δοκείτω ταῦτ’, ἐμοὶ δὲ τἀντία.</l>
@@ -1020,7 +1020,7 @@ bring up to P3
 					<l>νεώς τε ναύτης ἥσυχος, καιρῷ σοφός.</l>
 					<l n="510">καὶ τοῦτ’ ἐμοὶ τἀνδρεῖον, ἡ προμηθία.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐξαρκέσας ἦν Ζεὺς ὁ τιμωρούμενος,</l>
 					<l>ὑμᾶς δ’ ὑβρίζειν οὐκ ἐχρῆν τοιάνδ’ ὕβριν.</l>
@@ -1029,7 +1029,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>ὦ παγκάκιστε — </l>
 				</sp>
-				<sp n="Θησεύς" who="#theseys">
+				<sp n="Θησεύς" who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="Y">σῖγ’, Ἄδραστ’, ἔχε στόμα,</l>
 					<l>καὶ μὴ ’πίπροσθεν τῶν ἐμῶν τοὺς σοὺς λόγους</l>
@@ -1084,72 +1084,72 @@ bring up to P3
 					<l>ὡς εἰς ἔμ’ ἐλθὼν καὶ πόλιν Πανδίονος</l>
 					<l>νόμος παλαιὸς δαιμόνων διεφθάρη.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θάρσει· τὸ γάρ τοι τῆς Δίκης σῴζων φάος</l>
 					<l n="565">πολλοὺς ὑπεκφύγοις ἂν ἀνθρώπων ψόγους.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>βούλῃ συνάψω μῦθον ἐν βραχεῖ †σέθεν†;</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>λέγ’, εἴ τι βούλῃ· καὶ γὰρ οὐ σιγηλὸς εἶ.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>οὐκ ἄν ποτ’ ἐκ γῆς παῖδας Ἀργείων λάβοις.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>κἀμοῦ νυν ἀντάκουσον, εἰ βούλῃ, πάλιν.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="570">κλύοιμ’ ἄν· οὐ γὰρ ἀλλὰ δεῖ δοῦναι μέρος.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>θάψω νεκροὺς γῆς ἐξελὼν Ἀσωπίας.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἐν ἀσπίσιν σοι πρῶτα κινδυνευτέον.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>πολλοὺς ἔτλην δὴ †χἁτέρους ἄλλους πόνους†.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἦ πᾶσιν οὖν &lt;σ’&gt; ἔφυσεν ἐξαρκεῖν πατήρ;</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="575">ὅσοι γ’ ὑβρισταί· χρηστὰ δ’ οὐ κολάζομεν.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>πράσσειν σὺ πόλλ’ εἴωθας ἥ τε σὴ πόλις.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τοιγὰρ πονοῦσα πολλὰ πόλλ’ εὐδαιμονεῖ.</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l>ἔλθ’, ὥς σε λόγχη σπαρτὸς ἐν πόλει λάβῃ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τίς δ’ ἐκ δράκοντος θοῦρος ἂν γένοιτ’ Ἄρης;</l>
 				</sp>
-				<sp who="#keryks">
+				<sp who="#keryx">
 					<speaker>Κῆρυξ</speaker>
 					<l n="580">γνώσῃ σὺ πάσχων· νῦν δ’ ἔτ’ εἶ νεανίας.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὔτοι μ’ ἐπαρεῖς ὥστε θυμῶσαι φρένας</l>
 					<l>τοῖς σοῖσι κόμποις· ἀλλ’ ἀποστέλλου χθονός,</l>
@@ -1174,7 +1174,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — ὦ μέλεαι μελέων ματέρες λοχαγῶν,</l>
 						<l>ὥς μοι ὑφ’ ἥπατι χλωρὸν δεῖμα θάσσει — </l>
@@ -1189,7 +1189,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — ἀλλὰ τὸν εὐτυχίᾳ λαμπρὸν ἄν τις αἱροῖ</l>
 						<l>μοῖρα πάλιν· τόδε μοι θράσος ἀμφιβαίνει.</l>
@@ -1204,7 +1204,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — τὰ καλλίπυργα πεδία πῶς ἱκοίμεθ’ ἄν,</l>
 						<l>Καλλίχορον θεᾶς ὕδωρ λιποῦσαι — </l>
@@ -1218,7 +1218,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l> — κεκλημένους μὲν ἀνακαλούμεθ’ αὖ θεούς·</l>
 						<l> — ἀλλὰ φόβων πίστις ἅδε πρώτα.</l>
@@ -1233,7 +1233,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>γυναῖκες, ἥκω πόλλ’ ἔχων λέγειν φίλα,</l>
 					<l n="635">αὐτός τε σωθείς· ᾑρέθην γὰρ ἐν μάχῃ,</l>
@@ -1243,25 +1243,25 @@ bring up to P3
 					<l>μακροῦ ἀποπαύσω· Καπανέως γὰρ ἦ λάτρις,</l>
 					<l n="640">ὃν Ζεὺς κεραυνῷ πυρπόλῳ καταιθαλοῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ φίλτατ’, εὖ μὲν νόστον ἀγγέλλεις σέθεν</l>
 					<l>τήν τ’ ἀμφὶ Θησέως βάξιν· εἰ δὲ καὶ στρατὸς</l>
 					<l>σῶς ἐστ’ Ἀθηνῶν, πάντ’ ἂν ἀγγέλλοις φίλα.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>σῶς, καὶ πέπραγεν ὡς Ἄδραστος ὤφελεν</l>
 					<l n="645">πρᾶξαι ξὺν Ἀργείοισιν, οὓς ἀπ’ Ἰνάχου</l>
 					<l>στείλας ἐπεστράτευσε Καδμείων πόλιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πῶς γὰρ τροπαῖα Ζηνὸς Αἰγέως τόκος</l>
 					<l>ἔστησεν οἵ τε συμμετασχόντες δορός;</l>
 					<l>λέξον· παρὼν γὰρ οὐ παρόντας εὐφρανεῖς.</l>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="650">λαμπρὰ μὲν ἀκτὶς ἡλίου, κανὼν σαφής,</l>
 					<l>ἔβαλλε γαῖαν· ἀμφὶ δ’ Ἠλέκτρας πύλας</l>
@@ -1347,7 +1347,7 @@ bring up to P3
 					<l>ἐς ἄκρα βῆναι κλιμάκων ἐνήλατα</l>
 					<l n="730">ζητῶν ἀπώλεσ’ ὄλβον ᾧ χρῆσθαι παρῆν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>νῦν τήνδ’ ἄελπτον ἡμέραν ἰδοῦσ’ ἐγὼ</l>
 					<l>θεοὺς νομίζω, καὶ δοκῶ τῆς συμφορᾶς</l>
@@ -1374,7 +1374,7 @@ bring up to P3
 					<l n="750">ἀτὰρ τί ταῦτα; κεῖνο βούλομαι μαθεῖν,</l>
 					<l>πῶς ἐξεσώθης· εἶτα τἄλλ’ ἐρήσομαι.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐπεὶ ταραγμὸς πόλιν ἐκίνησεν δορί,</l>
 					<l>πύλας διῆλθον, ᾗπερ εἰσῄει στρατός.</l>
@@ -1383,7 +1383,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>ὧν δ’ οὕνεχ’ ἁγὼν ἦν, νεκροὺς κομίζετε;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="755">ὅσοι γε κλεινοῖς ἕπτ’ ἐφέστασαν δόμοις.</l>
 				</sp>
@@ -1391,7 +1391,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>πῶς φῄς; ὁ δ’ ἄλλος ποῦ κεκμηκότων ὄχλος;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τάφῳ δέδονται πρὸς Κιθαιρῶνος πτυχαῖς.</l>
 				</sp>
@@ -1399,7 +1399,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>τοὐκεῖθεν ἢ τοὐνθένδε; τίς δ’ ἔθαψέ νιν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>Θησεύς, σκιώδης ἔνθ’ Ἐλευθερὶς πέτρα.</l>
 				</sp>
@@ -1407,7 +1407,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l n="760">οὓς δ’ οὐκ ἔθαψε ποῦ νεκροὺς ἥκεις λιπών;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐγγύς· πέλας γὰρ πᾶν ὅ τι σπουδάζεται.</l>
 				</sp>
@@ -1415,7 +1415,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>ἦ που πικρῶς νιν θέραπες ἦγον ἐκ φόνου;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐδεὶς ἐπέστη τῷδε δοῦλος ὢν πόνῳ.</l>
 				</sp>
@@ -1427,7 +1427,7 @@ bring up to P3
 						&gt;
 					</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>φαίης ἄν, εἰ παρῆσθ’ ὅτ’ ἠγάπα νεκρούς.</l>
 				</sp>
@@ -1435,7 +1435,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l n="765">ἔνιψεν αὐτὸς τῶν ταλαιπώρων σφαγάς;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>κἄστρωσέ γ’ εὐνὰς κἀκάλυψε σώματα.</l>
 				</sp>
@@ -1443,7 +1443,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>δεινὸν μὲν ἦν βάσταγμα κᾀσχύνην ἔχον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τί δ’ αἰσχρὸν ἀνθρώποισι τἀλλήλων κακά;</l>
 				</sp>
@@ -1451,7 +1451,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>οἴμοι· πόσῳ σφιν συνθανεῖν ἂν ἤθελον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="770">ἄκραντ’ ὀδύρῃ ταῖσδέ τ’ ἐξάγεις δάκρυ.</l>
 				</sp>
@@ -1469,7 +1469,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὰ μὲν εὖ, τὰ δὲ δυστυχῆ.</l>
 						<l>πόλει μὲν εὐδοξία</l>
@@ -1483,7 +1483,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγαμόν μ’ ἔτι δεῦρ’ ἀεὶ</l>
 						<l>Χρόνος παλαιὸς πατὴρ</l>
@@ -1497,7 +1497,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ τάδ’ ἤδη σώματα λεύσσω</l>
 						<l n="795">τῶν οἰχομένων παίδων· μελέα</l>
@@ -1514,7 +1514,7 @@ bring up to P3
 						<l n="800">ἀύσατ’ ἀπύσατ’ ἀντίφων’ ἐμῶν</l>
 						<l>στεναγμάτων κλύουσαι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ παῖδες, ὦ πικρὸν φίλων</l>
 						<l>προσηγόρημα ματέρων,</l>
@@ -1524,7 +1524,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l n="805">ἰὼ ἰώ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τῶν γ’ ἐμῶν κακῶν ἐγώ.</l>
 					</sp>
@@ -1532,7 +1532,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>αἰαῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">.      .      .      .      .</l>
 					</sp>
@@ -1540,7 +1540,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>ἐπάθομεν ὤ . . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τὰ κύντατ’ ἄλγη κακῶν.</l>
 					</sp>
@@ -1548,7 +1548,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>ὦ πόλις Ἀργεία, τὸν ἐμὸν πότμον οὐκ ἐσορᾶτε;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρῶσι κἀμὲ τὰν τάλαι‐</l>
 						<l n="810">ναν, τέκνων ἄπαιδα.</l>
@@ -1563,7 +1563,7 @@ bring up to P3
 						<l>σφαγέντας οὐκ ἄξῑ οὐδ’ ὑπ’ ἀξίων,</l>
 						<l>ἐν οἷς ἀγὼν ἐκράνθη.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="815">δόθ’, ὡς περιπτυχαῖσι δὴ</l>
 						<l>χέρας προσαρμόσασ’ ἐμοῖς</l>
@@ -1573,7 +1573,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>ἔχεις ἔχεις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">πημάτων γ’ ἅλις βάρος.</l>
 					</sp>
@@ -1581,7 +1581,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>αἰαῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">τοῖς τεκοῦσι δ’ οὐ λέγεις;</l>
 					</sp>
@@ -1589,7 +1589,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l n="820">ἀίετέ μου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">στένεις ἐπ’ ἀμφοῖν ἄχη.</l>
 					</sp>
@@ -1597,7 +1597,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>εἴθε με Καδμείων ἔναρον στίχες ἐν κονίαισιν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐμὸν δὲ μήποτ’ ἐζύγη</l>
 						<l>δέμας ἐς ἀνδρὸς εὐνάν.</l>
@@ -1610,7 +1610,7 @@ bring up to P3
 						<l>ἴδετε κακῶν πέλαγος, ὦ</l>
 						<l n="825">ματέρες τάλαιναι τέκνων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κατὰ μὲν ὄνυξιν ἠλοκίσμεθ’, ἀμφὶ δὲ</l>
 						<l>σποδὸν κάρᾳ κεχύμεθα.</l>
@@ -1622,7 +1622,7 @@ bring up to P3
 						<l n="830">διὰ δὲ θύελλα σπάσαι,</l>
 						<l>πυρός τε φλογμὸς ὁ Διὸς ἐν κάρᾳ πέσοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="833">πικροὺς ἐσεῖδες γάμους,</l>
 						<l>πικρὰν δὲ Φοίβου φάτιν·</l>
@@ -1633,7 +1633,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>μέλλων σ’ ἐρωτᾶν, ἡνίκ’ ἐξήντλεις στρατῷ</l>
 					<l>γόους, ἀφήσω· τοὺς ἐκεῖ μὲν ἐκλιπὼν</l>
@@ -1722,7 +1722,7 @@ bring up to P3
 				</sp>
 				<milestone ed="p" n="918" unit="card"/>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ τέκνον, δυστυχῆ σ’</l>
 						<l>ἔτρεφον, ἔφερον ὑφ’ ἥπατος</l>
@@ -1735,7 +1735,7 @@ bring up to P3
 					<milestone ed="p" n="925" unit="card"/>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="925">καὶ μὴν τὸν Οἰκλέους γε γενναῖον τόκον</l>
 						<l>θεοὶ ζῶντ’ ἀναρπάσαντες ἐς μυχοὺς χθονὸς</l>
@@ -1750,7 +1750,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>οὐκ οἶδα πλὴν ἕν, σοῖσι πείθεσθαι λόγοις.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>τὸν μὲν Διὸς πληγέντα Καπανέα πυρὶ . . . .</l>
 					</sp>
@@ -1758,7 +1758,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l n="935">ἦ χωρὶς ἱερὸν ὡς νεκρὸν θάψαι θέλεις;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ναί· τοὺς δέ γ’ ἄλλους πάντας ἐν μιᾷ πυρᾷ.</l>
 					</sp>
@@ -1766,7 +1766,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>ποῦ δῆτα θήσεις μνῆμα τῷδε χωρίσας;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>αὐτοῦ παρ’ οἴκους τούσδε συμπήξας τάφον.</l>
 					</sp>
@@ -1774,7 +1774,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>οὗτος μὲν ἤδη δμωσὶν ἂν μέλοι πόνος.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="940">ἡμῖν δέ γ’ οἵδε· στειχέτω δ’ ἄχθη νεκρῶν.</l>
 					</sp>
@@ -1782,7 +1782,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>ἴτ’, ὦ τάλαιναι μητέρες, τέκνων πέλας.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ἥκιστ’, Ἄδραστε, τοῦτο πρόσφορον λέγεις.</l>
 					</sp>
@@ -1790,7 +1790,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l>πῶς; τὰς τεκούσας οὐ χρεὼν ψαῦσαι τέκνων;</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>ὄλοιντ’ ἰδοῦσαι τούσδ’ ἂν ἠλλοιωμένους.</l>
 					</sp>
@@ -1798,7 +1798,7 @@ bring up to P3
 						<speaker>Ἄδραστος</speaker>
 						<l n="945">πικρὰ γὰρ ὄψις αἷμα κὠτειλαὶ νεκρῶν.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>τί δῆτα λύπην ταῖσδε προσθεῖναι θέλεις;</l>
 					</sp>
@@ -1818,7 +1818,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="955">οὐκέτ’ εὔτεκνος, οὐκέτ’ εὔ‐</l>
 						<l>παις, οὐδ’ εὐτυχίας μέτε‐</l>
@@ -1832,7 +1832,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἑπτὰ ματέρες ἑπτὰ κού‐</l>
 						<l>ρους ἐγεινάμεθ’ αἱ ταλαί‐</l>
@@ -1846,7 +1846,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὑπολελειμμένα μοι δάκρυα·</l>
 						<l>μέλεα παιδὸς ἐν οἴκοις</l>
@@ -1864,7 +1864,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="980">καὶ μὴν θαλάμας τάσδ’ ἐσορῶ δὴ</l>
 						<l>Καπανέως ἤδη τύμβον θ’ ἱερὸν</l>
@@ -1880,7 +1880,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l n="990">τί φέγγος, τίν’ αἴγλαν</l>
 						<l>ἐδίφρευε τόθ’ ἅλιος</l>
@@ -1903,7 +1903,7 @@ bring up to P3
 						<l>εἰ δαίμων τάδε κραίνοι.</l>
 						<milestone ed="p" n="1009" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ὁρᾷς τήνδ’ ἧς ἐφέστηκας πέλας</l>
 						<l n="1010">πυράν, Διὸς θησαυρόν, ἔνθ’ ἔνεστι σὸς</l>
@@ -1912,7 +1912,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>ὁρῶ δὴ τελευτάν,</l>
 						<l>ἵν’ ἕστακα· τύχα δέ μοι</l>
@@ -1935,13 +1935,13 @@ bring up to P3
 						<l n="1030b">γενναίας [ψυχᾶς] ἀλόχοιο.</l>
 						<milestone ed="p" n="1031" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ὅδ’ αὐτὸς σὸς πατὴρ βαίνει πέλας</l>
 						<l>γεραιὸς Ἶφις ἐς νεωτέρους λόγους,</l>
 						<l>οὓς οὐ κατειδὼς πρόσθεν ἀλγήσει κλύων.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>ὦ δυστάλαιναι, δυστάλας δ’ ἐγὼ γέρων,</l>
 						<l n="1035">ἥκω διπλοῦν πένθημ’ ὁμαιμόνων ἔχων,</l>
@@ -1955,91 +1955,91 @@ bring up to P3
 						<l>βέβηκεν. ἀλλὰ τῇδέ νιν δοξάζομεν</l>
 						<l>μάλιστ’ ἂν εἶναι· φράζετ’ εἰ κατείδετε.</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l n="1045">τί τάσδ’ ἐρωτᾷς; ἥδ’ ἐγὼ πέτρας ἔπι</l>
 						<l>ὄρνις τις ὡσεὶ Καπανέως ὑπὲρ πυρᾶς</l>
 						<l>δύστηνον αἰώρημα κουφίζω, πάτερ.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>τέκνον, τίς αὔρα; τίς στόλος; τίνος χάριν</l>
 						<l>δόμων ὑπεκβᾶσ’ ἦλθες ἐς τήνδε χθόνα;</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l n="1050">ὀργὴν λάβοις ἂν τῶν ἐμῶν βουλευμάτων</l>
 						<l>κλύων· ἀκοῦσαι δ’ οὔ σε βούλομαι, πάτερ.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>τί δ’; οὐ δίκαιον πατέρα τὸν σὸν εἰδέναι;</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>κριτὴς ἂν εἴης οὐ σοφὸς γνώμης ἐμῆς.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>σκευῇ δὲ τῇδε τοῦ χάριν κοσμεῖς δέμας;</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l n="1055">θέλει τι κλεινὸν οὗτος ὁ στολμός, πάτερ.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>ὡς οὐκ ἐπ’ ἀνδρὶ πένθιμος πρέπεις ὁρᾶν.</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>ἐς γάρ τι πρᾶγμα νεοχμὸν ἐσκευάσμεθα.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>κἄπειτα τύμβῳ καὶ πυρᾷ φαίνῃ πέλας;</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>ἐνταῦθα γὰρ δὴ καλλίνικος ἔρχομαι.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l n="1060">νικῶσα νίκην τίνα; μαθεῖν χρῄζω σέθεν.</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>πάσας γυναῖκας ἃς δέδορκεν ἥλιος.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>ἔργοις Ἀθάνας ἢ φρενῶν εὐβουλίᾳ;</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>ἀρετῇ· πόσει γὰρ συνθανοῦσα κείσομαι.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>τί φῄς; τί τοῦτ’ αἴνιγμα σημαίνεις σαθρόν;</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l n="1065">ᾄσσω θανόντος Καπανέως τήνδ’ ἐς πυράν.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>ὦ θύγατερ, οὐ μὴ μῦθον ἐς πολλοὺς ἐρεῖς.</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>τοῦτ’ αὐτὸ χρῄζω, πάντας Ἀργείους μαθεῖν.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>ἀλλ’ οὐδέ τοί σοι πείσομαι δρώσῃ τάδε.</l>
 					</sp>
-					<sp who="#eyadne">
+					<sp who="#euadne">
 						<speaker>Εὐάδνη</speaker>
 						<l>ὅμοιον· οὐ γὰρ μὴ κίχῃς μ’ ἑλὼν χερί.</l>
 						<l n="1070">καὶ δὴ παρεῖται σῶμα — σοὶ μὲν οὐ φίλον,</l>
@@ -2048,35 +2048,35 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰώ, γύναι, δεινὸν ἔργον ἐξειργάσω.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>ἀπωλόμην δύστηνος, Ἀργείων κόραι.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἒ ἔ, σχέτλια τάδε παθών,</l>
 						<l n="1075">τὸ πάντολμον ἔργον ὄψῃ τάλας.</l>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l>οὐκ ἄν τιν’ εὕροιτ’ ἄλλον ἀθλιώτερον.</l>
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ τάλας·</l>
 						<l>μετέλαχες τύχας Οἰδιπόδα, γέρον,</l>
 						<l>μέρος καὶ σὺ &lt;καὶ&gt; πόλις ἐμὰ τλάμων.</l>
 						<milestone ed="p" n="1080" unit="card"/>
 					</sp>
-					<sp who="#ifis">
+					<sp who="#iphis">
 						<speaker>Ἶφις</speaker>
 						<l n="1080">οἴμοι· τί δὴ βροτοῖσιν οὐκ ἔστιν τόδε,</l>
 						<l>νέους δὶς εἶναι καὶ γέροντας αὖ πάλιν;</l>
@@ -2118,7 +2118,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ &lt;ἰώ·&gt;</l>
 						<l>τάδε δὴ παίδων †καὶ δὴ† φθιμένων</l>
@@ -2141,7 +2141,7 @@ bring up to P3
 						<l n="1125">βάρος μὲν οὐκ ἀβριθὲς ἀλγέων ὕπερ,</l>
 						<l>ἐν δ’ ὀλίγῳ τἀμὰ πάντα συνθείς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰώ,</l>
 						<l>πᾶ φέρεις δάκρυα φίλᾳ</l>
@@ -2159,7 +2159,7 @@ bring up to P3
 						<l>ἔρημον οἶκον ὀρφανεύσομαι λαβών,</l>
 						<l>οὐ πατρὸς ἐν χερσὶ τοῦ τεκόντος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1135">ἰὼ ἰώ·</l>
 						<l n="1135b">ποῦ δὲ πόνος ἐμῶν τέκνων,</l>
@@ -2175,7 +2175,7 @@ bring up to P3
 						<l>βεβᾶσιν, οὐκέτ’ εἰσίν· οἴμοι πάτερ·</l>
 						<l n="1140">βεβᾶσιν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">αἰθὴρ ἔχει νιν ἤδη,</l>
 						<l>πυρὸς τετακότας σποδῷ·</l>
@@ -2195,7 +2195,7 @@ bring up to P3
 						<l>ἔτ’ ἂν θεοῦ θέλοντος ἔλθοι δίκα</l>
 						<l>πατρῷος·</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">οὔπω κακὸν τόδ’ εὕδει.</l>
 						<l>αἰαῖ γόων· ἅλις τύχας,</l>
@@ -2214,7 +2214,7 @@ bring up to P3
 						<speaker>Παῖδες</speaker>
 						<l>ἔτ’ εἰσορᾶν σε, πάτερ, ἐπ’ ὀμμάτων δοκῶ . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φίλον φίλημα παρὰ γένυν τιθέντα σόν.</l>
 					</sp>
@@ -2223,7 +2223,7 @@ bring up to P3
 						<l n="1155">λόγων δὲ παρακέλευσμα σῶν</l>
 						<l>ἀέρι φερόμενον οἴχεται.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δυοῖν δ’ ἄχη, ματρί τ’ ἔλιπεν — </l>
 						<l>σέ τ’ οὔποτ’ ἄλγη πατρῷα λείψει.</l>
@@ -2235,7 +2235,7 @@ bring up to P3
 						<speaker>Παῖδες</speaker>
 						<l>ἔχω τοσόνδε βάρος ὅσον μ’ ἀπώλεσεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1160">φέρ’, ἀμφὶ μαστὸν ὑποβάλω &lt;φίλαν&gt; σποδόν.</l>
 					</sp>
@@ -2244,7 +2244,7 @@ bring up to P3
 						<l>ἔκλαυσα τόδε κλύων ἔπος</l>
 						<l>στυγνότατον· ἔθιγέ μου φρενῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ τέκνον, ἔβας· οὐκέτι φίλον</l>
 						<l>φίλας ἄγαλμ’ ὄψομαί σε ματρός.</l>
@@ -2253,7 +2253,7 @@ bring up to P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="1165">Ἄδραστε καὶ γυναῖκες Ἀργεῖαι γένος,</l>
 					<l>ὁρᾶτε παῖδας τούσδ’ ἔχοντας ἐν χεροῖν</l>
@@ -2274,7 +2274,7 @@ bring up to P3
 					<l>χάριν τ’ ἀγήρων ἕξομεν· γενναῖα γὰρ</l>
 					<l>παθόντες ὑμᾶς ἀντιδρᾶν ὀφείλομεν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="1180">τί δῆτ’ ἔθ’ ὑμῖν ἄλλ’ ὑπουργῆσαί με χρή;</l>
 				</sp>
@@ -2282,7 +2282,7 @@ bring up to P3
 					<speaker>Ἄδραστος</speaker>
 					<l>χαῖρ’· ἄξιος γὰρ καὶ σὺ καὶ πόλις σέθεν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἔσται τάδ’· ἀλλὰ καὶ σὺ τῶν αὐτῶν τύχοις.</l>
 				</sp>
@@ -2334,7 +2334,7 @@ bring up to P3
 					<l n="1225">κληθέντες ᾠδὰς ὑστέροισι θήσετε·</l>
 					<l>τοῖον στράτευμα σὺν θεῷ πορεύσετε.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>δέσποιν’ Ἀθάνα, πείσομαι λόγοισι σοῖς·</l>
 					<l>σὺ γάρ μ’ ἀνορθοῖς, ὥστε μὴ ’ξαμαρτάνειν·</l>
@@ -2344,7 +2344,7 @@ bring up to P3
 					<milestone ed="p" n="1232" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>στείχωμεν, Ἄδρασθ’, ὅρκια δῶμεν</l>
 						<l>τῷδ’ ἀνδρὶ πόλει τ’· ἄξια δ’ ἡμῖν</l>

--- a/tei/euripides-the-trojan-women.xml
+++ b/tei/euripides-the-trojan-women.xml
@@ -51,28 +51,28 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="andromaxe" sex="FEMALE">
+					<person xml:id="andromache" sex="FEMALE">
 						<persName>Ἀνδρομάχη</persName>
 					</person>
 					<person xml:id="talthybios" sex="MALE">
 						<persName>Ταλθύβιος</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="FEMALE">
+					<personGrp xml:id="choros" sex="FEMALE">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="elene" sex="FEMALE">
+					<person xml:id="helene" sex="FEMALE">
 						<persName>Ἑλένη</persName>
 					</person>
 					<person xml:id="menelaos" sex="MALE">
 						<persName>Μενέλαος</persName>
 					</person>
-					<personGrp xml:id="emixorionb" sex="FEMALE">
+					<personGrp xml:id="hemichorion_b" sex="FEMALE">
 						<name>Ἡμιχόριον Β</name>
 					</personGrp>
-					<person xml:id="ekabe" sex="FEMALE">
+					<person xml:id="hekabe" sex="FEMALE">
 						<persName>Ἑκάβη</persName>
 					</person>
-					<personGrp xml:id="emixoriona" sex="FEMALE">
+					<personGrp xml:id="hemichorion_a" sex="FEMALE">
 						<name>Ἡμιχόριον Α</name>
 					</personGrp>
 					<person xml:id="athena" sex="FEMALE">
@@ -329,7 +329,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 type="anapests">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἄνα, δύσδαιμον, πεδόθεν κεφαλή·</l>
 						<l>ἐπάειρε δέρην· οὐκέτι Τροία</l>
@@ -359,7 +359,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>πρῷραι ναῶν, ὠκείαις</l>
 						<l>Ἴλιον ἱερὰν αἳ κώπαις</l>
@@ -397,7 +397,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>Ἑκάβη, τί θροεῖς; τί δὲ θωΰσσεις;</l>
 						<l>ποῖ λόγος ἥκει; διὰ γὰρ μελάθρων</l>
@@ -406,28 +406,28 @@ bring up to P3
 						<l>Τρῳάσιν, αἳ τῶνδ’ οἴκων εἴσω</l>
 						<l>δουλείαν αἰάζουσιν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ τέκν’, Ἀργείων πρὸς ναῦς ἤδη . . .</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l n="160">κινεῖται κωπήρης χείρ;</l>
 						<l>οἲ ἐγώ, τί θέλουσ’, ἦ πού μ’ ἤδη</l>
 						<l>ναυσθλώσουσιν πατρίας ἐκ γᾶς;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐκ οἶδ’, εἰκάζω δ’ ἄταν.</l>
 					</sp>
-					<sp who="#emixoriona">
+					<sp who="#hemichorion_a">
 						<speaker>Ἡμιχόριον Α</speaker>
 						<l>ἰὼ ἰώ.</l>
 						<l n="165">μέλεαι μόχθων ἐπακουσόμεναι</l>
 						<l>Τρῳάδες, ἔξω † κομίζεσθ’ † οἴκων·</l>
 						<l>στέλλουσ’ Ἀργεῖοι νόστον.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>αἶ, αἶ.</l>
 						<l>μή νύν μοι τὰν</l>
@@ -443,7 +443,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>οἴμοι. τρομερὰ σκηνὰς ἔλιπον</l>
 						<l>τάσδ’ Ἀγαμέμνονος ἐπακουσομένα,</l>
@@ -452,28 +452,28 @@ bring up to P3
 						<l n="180">ἢ κατὰ πρύμνας ἤδη ναῦται</l>
 						<l>στέλλονται κινεῖν κώπας;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ τέκνον, ὀρθρεύου σὰν ψυχάν.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>ἐκπληχθεῖσ’ ἦλθον φρίκᾳ.</l>
 						<l>ἤδη τις ἔβα Δαναῶν κῆρυξ;</l>
 						<l n="185">τῷ πρόσκειμαι δούλα τλάμων;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἐγγύς που κεῖσαι κλήρου.</l>
 					</sp>
-					<sp who="#emixorionb">
+					<sp who="#hemichorion_b">
 						<speaker>Ἡμιχόριον Β</speaker>
 						<l>ἰὼ ἰώ.</l>
 						<l>τίς μ’ Ἀργείων ἢ Φθιωτᾶν</l>
 						<l>ἢ νησαίαν μ’ ἄξει χώραν</l>
 						<l>δύστανον πόρσω Τροίας;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="190">φεῦ φεῦ.</l>
 						<l n="190b">τῷ δ’ ἁ τλάμων</l>
@@ -489,7 +489,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ αἰαῖ, ποίοις δ’ οἴκτοις</l>
 						<l>τὰν σὰν λύμαν ἐξαιάζεις;</l>
@@ -512,7 +512,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὰν Πηνειοῦ σεμνὰν χώραν,</l>
 						<l n="215">κρηπῖδ’ Οὐλύμπου καλλίσταν,</l>
@@ -536,7 +536,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="230">καὶ μὴν Δαναῶν ὅδ’ ἀπὸ στρατιᾶς</l>
 						<l>κῆρυξ, νεοχμῶν μύθων ταμίας,</l>
@@ -554,7 +554,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>&lt;αἰαῖ,&gt; τόδε</l>
 						<l>τόδε, φίλαι Τρῳάδες, ὃ φόβος ἦν πάλαι.</l>
@@ -563,7 +563,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l n="240">ἤδη κεκλήρωσθ’, εἰ τόδ’ ἦν ὑμῖν φόβος.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>αἰαῖ, τίν’ ἢ</l>
 						<l>Θεσσαλίας πόλιν ἢ</l>
@@ -573,7 +573,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>κατ’ ἄνδρ’ ἑκάστη κοὐχ ὁμοῦ λελόγχατε.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τίν’ ἄρα τίς ἔλαχε; τίνα πότμος εὐτυχὴς</l>
 						<l n="245">Ἰλιάδων μένει;</l>
@@ -582,7 +582,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>οἶδ’· ἀλλ’ ἕκαστα πυνθάνου, μὴ πάνθ’ ὁμοῦ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τοὐμὸν τίς ἆρ’</l>
 						<l>ἔλαχε τέκος, ἔνεπε, τλάμονα Κασάνδραν;</l>
@@ -591,7 +591,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l n="249">ἐξαίρετόν νιν ἔλαβεν Ἀγαμέμνων ἄναξ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="250">ἦ τᾷ Λακεδαιμονίᾳ νύμφᾳ</l>
 						<l>δούλαν; ἰώ μοί μοι.</l>
@@ -600,7 +600,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>οὔκ, ἀλλὰ λέκτρων σκότια νυμφευτήρια.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="253">ἦ τὰν τοῦ Φοίβου παρθένον, ᾇ γέρας ὁ</l>
 						<l>χρυσοκόμας ἔδωκ’ ἄλεκτρον ζόαν;</l>
@@ -609,7 +609,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l n="255">ἔρως ἐτόξευσ’ αὐτὸν ἐνθέου κόρης.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ῥῖπτε, τέκνον, ζαθέους κλῇ‐</l>
 						<l>δας καὶ ἀπὸ χροὸς ἐνδυ‐</l>
@@ -619,7 +619,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>οὐ γὰρ μέγ’ αὐτῇ βασιλικῶν λέκτρων τυχεῖν;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="260">τί δ’ ὃ νεοχμὸν ἀπ’ ἐμέθεν ἐλάβετε τέκος, ποῦ μοι;</l>
 					</sp>
@@ -627,7 +627,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l n="262">Πολυξένην ἔλεξας, ἢ τίν’ ἱστορεῖς;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ταύταν· τῷ πάλος ἔζευξεν;</l>
 					</sp>
@@ -635,7 +635,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>τύμβῳ τέτακται προσπολεῖν Ἀχιλλέως.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="265">ὤμοι ἐγώ· τάφῳ πρόσπολον ἐτεκόμαν.</l>
 						<l>ἀτὰρ τίς ὅδ’ ἢ νόμος ἢ τί</l>
@@ -645,7 +645,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>εὐδαιμόνιζε παῖδα σήν· ἔχει καλῶς.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τί τόδ’ ἔλακες; ἆρά μοι ἀέλιον λεύσσει;</l>
 					</sp>
@@ -653,7 +653,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l n="270">ἔχει πότμος νιν, ὥστ’ ἀπηλλάχθαι πόνων.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τί δ’ ἁ τοῦ χαλκεομήστορος Ἕκτορος δάμαρ,</l>
 						<l>Ἀνδρομάχα τάλαινα, τίν’ ἔχει τύχαν;</l>
@@ -662,7 +662,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>καὶ τήνδ’ Ἀχιλλέως ἔλαβε παῖς ἐξαίρετον.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἐγὼ δὲ τῷ</l>
 						<l n="275">πρόσπολος ἁ τριτοβάμονος χερὶ</l>
@@ -673,7 +673,7 @@ bring up to P3
 						<l>Ἰθάκης Ὀδυσσεὺς ἔλαχ’ ἄναξ δούλην σ’ ἔχειν.</l>
 						<milestone ed="p" n="278" unit="card"/>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἒ ἔ.</l>
 						<l>ἄρασσε κρᾶτα κούριμον,</l>
@@ -692,7 +692,7 @@ bring up to P3
 					<milestone ed="p" n="292" unit="card"/>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸ μὲν σὸν οἶσθα, πότνια, τὰς δ’ ἐμὰς τύχας</l>
 						<l>τίς ἆρ’ Ἀχαιῶν ἢ τίς Ἑλλήνων ἔχει;</l>
@@ -712,7 +712,7 @@ bring up to P3
 						<l>ἄνοιγ’ ἄνοιγε, μὴ τὸ ταῖσδε πρόσφορον</l>
 						<l n="305">ἐχθρὸν δ’ Ἀχαιοῖς εἰς ἔμ’ αἰτίαν βάλῃ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐκ ἔστιν, οὐ πιμπρᾶσιν, ἀλλὰ παῖς ἐμὴ</l>
 						<l>μαινὰς θοάζει δεῦρο Κασάνδρα δρόμῳ.</l>
@@ -762,12 +762,12 @@ bring up to P3
 				</div2>
 				<div2 type="iambic">
 					<milestone ed="p" n="341" unit="card"/>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βασίλεια, βακχεύουσαν οὐ λήψῃ κόρην,</l>
 						<l>μὴ κοῦφον αἴρῃ βῆμ’ ἐς Ἀργείων στρατόν;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>Ἥφαιστε, δᾳδουχεῖς μὲν ἐν γάμοις βροτῶν,</l>
 						<l>ἀτὰρ λυγράν γε τήνδ’ ἀναιθύσσεις φλόγα</l>
@@ -838,7 +838,7 @@ bring up to P3
 						<l>οὐ τἀμὰ λέκτρα· τοὺς γὰρ ἐχθίστους ἐμοὶ</l>
 						<l n="405">καὶ σοὶ γάμοισι τοῖς ἐμοῖς διαφθερῶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς ἡδέως κακοῖσιν οἰκείοις γελᾷς,</l>
 						<l>μέλπεις θ’ ἃ μέλπουσ’ οὐ σαφῆ δείξεις ἴσως.</l>
@@ -914,14 +914,14 @@ bring up to P3
 					<milestone ed="p" n="462" unit="card"/>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἑκάβης γεραιᾶς φύλακες, οὐ δεδόρκατε</l>
 						<l>δέσποιναν ὡς ἄναυδος ἐκτάδην πίτνει;</l>
 						<l>οὐκ ἀντιλήψεσθ’; ἦ μεθήσετ’, ὦ κακαί,</l>
 						<l n="465">γραῖαν πεσοῦσαν; αἴρετ’ εἰς ὀρθὸν δέμας.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἐᾶτέ μ’ — οὔτοι φίλα τὰ μὴ φίλ’, ὦ κόραι — </l>
 						<l>κεῖσθαι πεσοῦσαν· πτωμάτων γὰρ ἄξια</l>
@@ -974,7 +974,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="512">ἀμφί μοι Ἴλιον, ὦ</l>
 						<l>Μοῦσα, καινῶν ὕμνων</l>
@@ -998,7 +998,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="532">πᾶσα δὲ γέννα Φρυγῶν</l>
 						<l>πρὸς πύλας ὡρμάθη,</l>
@@ -1022,7 +1022,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="552">ἐγὼ δὲ τὰν ὀρεστέραν</l>
 						<l>τότ’ ἀμφὶ μέλαθρα παρθένον</l>
@@ -1046,7 +1046,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἑκάβη, λεύσσεις τήνδ’ Ἀνδρομάχην</l>
 						<l>ξενικοῖς ἐπ’ ὄχοις πορθμευομένην;</l>
@@ -1062,101 +1062,101 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>Ἀχαιοὶ δεσπόται μ’ ἄγουσιν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οἴμοι.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l part="Y">τί παιᾶν’ ἐμὸν στενάζεις;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>αἰαῖ — </l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l part="Y">τῶνδ’ ἀλγέων — </l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="580">ὦ Ζεῦ — </l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l part="Y">καὶ συμφορᾶς.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τέκεα,</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l part="Y">πρίν ποτ’ ἦμεν.</l>
 						<milestone ed="p" n="582" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>βέβακ’ ὄλβος, βέβακε Τροία</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>τλάμων.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">ἐμῶν τ’ εὐγένεια παίδων.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>φεῦ φεῦ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">φεῦ δῆτ’ ἐμῶν</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l n="585">κακῶν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">οἰκτρὰ τύχα</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>πόλεος,</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">ἃ καπνοῦται.</l>
 						<milestone ed="p" n="587" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>μόλοις, ὦ πόσις, μοι — </l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>βοᾷς τὸν παρ’ Ἅιδᾳ</l>
 						<l>παῖδ’ ἐμόν, ὦ μελέα.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l n="590">σᾶς δάμαρτος ἄλκαρ.</l>
 						<milestone ed="p" n="591" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>σύ τ’, ὦ λῦμ’ Ἀχαιῶν,</l>
 						<l>τέκνων δέσποθ’ ἁμῶν,</l>
@@ -1166,23 +1166,23 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l n="595">οἵδε πόθοι μεγάλοι . . .</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">σχετλία, τάδε πάσχομεν ἄλγη.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>οἰχομένας πόλεως . . .</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">ἐπὶ δ’ ἄλγεσιν ἄλγεα κεῖται.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>δυσφροσύναισι θεῶν, ὅτε σὸς γόνος ἔκφυγεν Ἅιδαν,</l>
 						<l>ὃς λεχέων στυγερῶν χάριν ὤλεσε</l>
@@ -1194,23 +1194,23 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ πατρίς, ὦ μελέα . . .</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l part="Y">καταλειπομέναν σε δακρύω,</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>νῦν τέλος οἰκτρὸν ὁρᾷς.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l part="Y">καὶ ἐμὸν δόμον ἔνθ’  ἐλοχεύθην.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ τέκν’, ἐρημόπολις μάτηρ ἀπολείπεται ὑμῶν,</l>
 						<l>οἷος ἰάλεμος, οἷά τε πένθη</l>
@@ -1222,74 +1222,74 @@ bring up to P3
 						<l>λάθεται ἀλγέων [ἀδάκρυτος].</l>
 						<milestone ed="p" n="608" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς ἡδὺ δάκρυα τοῖς κακῶς πεπραγόσι</l>
 						<l>θρήνων τ’ ὀδυρμοὶ μοῦσά θ’ ἣ λύπας ἔχει.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l n="610">ὦ μῆτερ ἀνδρός, ὅς ποτ’ Ἀργείων δορὶ</l>
 						<l>πλείστους διώλεσ’, Ἕκτορος, τάδ’ εἰσορᾷς;</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὁρῶ τὰ τῶν θεῶν, ὡς τὰ μὲν πυργοῦσ’ ἄνω</l>
 						<l>τὸ μηδὲν ὄντα, τὰ δὲ δοκοῦντ’ ἀπώλεσαν.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>ἀγόμεθα λεία σὺν τέκνῳ· τὸ δ’ εὐγενὲς</l>
 						<l n="615">ἐς δοῦλον ἥκει, μεταβολὰς τοσάσδ’ ἔχον.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τὸ τῆς ἀνάγκης δεινόν· ἄρτι κἀπ’ ἐμοῦ</l>
 						<l>βέβηκ’ ἀποσπασθεῖσα Κασάνδρα βίᾳ.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>φεῦ φεῦ·</l>
 						<l>ἄλλος τις Αἴας, ὡς ἔοικε, δεύτερος</l>
 						<l>παιδὸς πέφηνε σῆς. νοσεῖς δὲ χἅτερα.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="620">ὧν γ’ οὔτε μέτρον οὔτ’ ἀριθμός ἐστί μοι·</l>
 						<l>κακῷ κακὸν γὰρ εἰς ἅμιλλαν ἔρχεται.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>τέθνηκέ σοι παῖς πρὸς τάφῳ Πολυξένη</l>
 						<l>σφαγεῖσ’ Ἀχιλλέως, δῶρον ἀψύχῳ νεκρῷ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οἲ ’γὼ τάλαινα. τοῦτ’ ἐκεῖν’ ὅ μοι πάλαι</l>
 						<l n="625">Ταλθύβιος αἴνιγμ’ οὐ σαφῶς εἶπεν σαφές.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>εἶδόν νιν αὐτή, κἀποβᾶσα τῶνδ’ ὄχων</l>
 						<l>ἔκρυψα πέπλοις κἀπεκοψάμην νεκρόν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>αἰαῖ, τέκνον, σῶν ἀνοσίων προσφαγμάτων·</l>
 						<l>αἰαῖ μάλ’ αὖθις, ὡς κακῶς διόλλυσαι.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l n="630">ὄλωλεν ὡς ὄλωλεν· ἀλλ’ ὅμως ἐμοῦ</l>
 						<l>ζώσης γ’ ὄλωλεν εὐτυχεστέρῳ πότμῳ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οὐ ταὐτόν, ὦ παῖ, τῷ βλέπειν τὸ κατθανεῖν·</l>
 						<l>τὸ μὲν γὰρ οὐδέν, τῷ δ’ ἔνεισιν ἐλπίδες.</l>
 						<milestone ed="p" n="634" unit="card"/>
 					</sp>
-					<sp n="Ἀνδρομάχη" who="#andromaxe">
+					<sp n="Ἀνδρομάχη" who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>ὦ μῆτερ, † ὦ τεκοῦσα †, κάλλιστον λόγον</l>
 						<l n="635">ἄκουσον, ὥς σοι τέρψιν ἐμβαλῶ φρενί.</l>
@@ -1343,12 +1343,12 @@ bring up to P3
 						<l>ξύνεστιν ἐλπίς, οὐδὲ κλέπτομαι φρένας</l>
 						<l>πράξειν τι κεδνόν· ἡδὺ δ’ ἐστὶ καὶ δοκεῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐς ταὐτὸν ἥκεις συμφορᾶς· θρηνοῦσα δὲ</l>
 						<l n="685">τὸ σὸν διδάσκεις μ’ ἔνθα πημάτων κυρῶ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>αὐτὴ μὲν οὔπω ναὸς εἰσέβην σκάφος,</l>
 						<l>γραφῇ δ’ ἰδοῦσα καὶ κλύουσ’ ἐπίσταμαι.</l>
@@ -1381,7 +1381,7 @@ bring up to P3
 						<l n="710">μή με στυγήσῃς· οὐχ ἑκὼν γὰρ ἀγγελῶ.</l>
 						<l>Δαναῶν δὲ κοινὰ Πελοπιδῶν τ’ ἀγγέλματα. . . .</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>τί δ’ ἔστιν; ὥς μοι φροιμίων ἄρχῃ κακῶν.</l>
 					</sp>
@@ -1389,7 +1389,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>ἔδοξε τόνδε παῖδα . . . πῶς εἴπω λόγον;</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>μῶν οὐ τὸν αὐτὸν δεσπότην ἡμῖν ἔχειν;</l>
 					</sp>
@@ -1397,7 +1397,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l n="715">οὐδεὶς Ἀχαιῶν τοῦδε δεσπόσει ποτέ.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>ἀλλ’ ἐνθάδ’ αὐτοῦ λείψανον Φρυγῶν λιπεῖν;</l>
 					</sp>
@@ -1405,7 +1405,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>οὐκ οἶδ’ ὅπως σοι ῥᾳδίως εἴπω κακά.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>ἐπῄνεσ’ αἰδῶ, πλὴν ἐὰν λέγῃς καλά.</l>
 					</sp>
@@ -1413,7 +1413,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>κτενοῦσι σὸν παῖδ’, ὡς πύθῃ κακὸν μέγα.</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l n="720">οἴμοι, γάμων τόδ’ ὡς κλύω μεῖζον κακόν.</l>
 					</sp>
@@ -1421,7 +1421,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>νικᾷ δ’ Ὀδυσσεὺς ἐν Πανέλλησιν λέγων . . .</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>αἰαῖ μάλ’· οὐ γὰρ μέτρια πάσχομεν κακά.</l>
 					</sp>
@@ -1429,7 +1429,7 @@ bring up to P3
 						<speaker>Ταλθύβιος</speaker>
 						<l>λέξας ἀρίστου παῖδα μὴ τρέφειν πατρὸς . . .</l>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l>τοιαῦτα νικήσειε τῶν αὑτοῦ πέρι.</l>
 					</sp>
@@ -1452,7 +1452,7 @@ bring up to P3
 						<l>αὐτή τ’ Ἀχαιῶν πρευμενεστέρων τύχοις.</l>
 						<milestone ed="p" n="740" unit="card"/>
 					</sp>
-					<sp who="#andromaxe">
+					<sp who="#andromache">
 						<speaker>Ἀνδρομάχη</speaker>
 						<l n="740">ὦ φίλτατ’, ὦ περισσὰ τιμηθεὶς τέκνον,</l>
 						<l>θανῇ πρὸς ἐχθρῶν μητέρ’ ἀθλίαν λιπών,</l>
@@ -1495,7 +1495,7 @@ bring up to P3
 						<l>καὶ ῥίπτετ’ ἐς ναῦς· ἐπὶ καλὸν γὰρ ἔρχομαι</l>
 						<l>ὑμέναιον, ἀπολέσασα τοὐμαυτῆς τέκνον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="780">τάλαινα Τροία, μυρίους ἀπώλεσας</l>
 						<l>μιᾶς γυναικὸς καὶ λέχους στυγνοῦ χάριν.</l>
@@ -1516,7 +1516,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="790">ὦ τέκνον, ὦ παῖ παιδὸς μογεροῦ,</l>
 						<l>συλώμεθα σὴν ψυχὴν ἀδίκως</l>
@@ -1533,7 +1533,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μελισσοτρόφου Σαλαμῖνος ὦ βασιλεῦ Τελαμών,</l>
 						<l n="800">νάσου περικύμονος οἰκήσας ἕδραν</l>
@@ -1548,7 +1548,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅθ’ Ἑλλάδος ἄγαγε πρῶτον ἄνθος ἀτυζόμενος</l>
 						<l n="810">πώλων, Σιμόεντι δ’ ἐπ’ εὐρείτᾳ πλάταν</l>
@@ -1563,7 +1563,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="820">μάταν ἄρ’, ὦ χρυσέαις ἐν οἰνοχόαις ἁβρὰ βαίνων,</l>
 						<l>Λαομεδόντιε παῖ,</l>
@@ -1584,7 +1584,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="840">Ἔρως Ἔρως, ὃς τὰ Δαρδάνεια μέλαθρά ποτ’ ἦλθες</l>
 						<l n="842">οὐρανίδαισι μέλων,</l>
@@ -1633,7 +1633,7 @@ bring up to P3
 					<l>κόμης ἐπισπάσαντες· οὔριοι δ’ ὅταν</l>
 					<l>πνοαὶ μόλωσι, πέμψομέν νιν Ἑλλάδα.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ὦ γῆς ὄχημα κἀπὶ γῆς ἔχων ἕδραν,</l>
 					<l n="885">ὅστις ποτ’ εἶ σύ, δυστόπαστος εἰδέναι,</l>
@@ -1645,7 +1645,7 @@ bring up to P3
 					<speaker>Μενέλαος</speaker>
 					<l>τί δ’ ἔστιν; εὐχὰς ὡς ἐκαίνισας θεῶν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l n="890">αἰνῶ σε, Μενέλᾱ, εἰ κτενεῖς δάμαρτα σήν.</l>
 					<l>ὁρᾶν δὲ τήνδε φεῦγε, μή σ’ ἕλῃ πόθῳ.</l>
@@ -1654,7 +1654,7 @@ bring up to P3
 					<l>ἐγώ νιν οἶδα, καὶ σύ, χοἱ πεπονθότες.</l>
 					<milestone ed="p" n="895" unit="card"/>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l n="895">Μενέλαε, φροίμιον μὲν ἄξιον φόβου</l>
 					<l>τόδ’ ἐστίν· ἐν γὰρ χερσὶ προσπόλων σέθεν</l>
@@ -1668,7 +1668,7 @@ bring up to P3
 					<l>οὐκ εἰς ἀκριβὲς ἦλθες, ἀλλ’ ἅπας στρατὸς</l>
 					<l>κτανεῖν ἐμοί σ’ ἔδωκεν, ὅνπερ ἠδίκεις.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἔξεστιν οὖν πρὸς ταῦτ’ ἀμείψασθαι λόγῳ,</l>
 					<l>ὡς οὐ δικαίως, ἢν θάνω, θανούμεθα;</l>
@@ -1677,7 +1677,7 @@ bring up to P3
 					<speaker>Μενέλαος</speaker>
 					<l n="905">οὐκ ἐς λόγους ἐλήλυθ’, ἀλλά σε κτενῶν.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ἄκουσον αὐτῆς, μὴ θάνῃ τοῦδ’ ἐνδεής,</l>
 					<l>Μενέλαε, καὶ δὸς τοὺς ἐναντίους λόγους</l>
@@ -1691,7 +1691,7 @@ bring up to P3
 					<l>ἔξεστι. τῶν σῶν δ’ οὕνεχ’ — ὡς μάθῃ — λόγων</l>
 					<l>δώσω τόδ’ αὐτῇ· τῆσδε δ’ οὐ δώσω χάριν.</l>
 				</sp>
-				<sp n="Ἑλένη" who="#elene">
+				<sp n="Ἑλένη" who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>ἴσως με, κἂν εὖ κἂν κακῶς δόξω λέγειν,</l>
 					<l n="915">οὐκ ἀνταμείψῃ πολεμίαν ἡγούμενος.</l>
@@ -1749,13 +1749,13 @@ bring up to P3
 					<l>πικρῶς ἐδούλευσ’; εἰ δὲ τῶν θεῶν κρατεῖν</l>
 					<l n="965">βούλῃ, τὸ χρῄζειν ἀμαθές ἐστί σου τόδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>βασίλεῑ, ἄμυνον σοῖς τέκνοισι καὶ πάτρᾳ</l>
 					<l>πειθὼ διαφθείρουσα τῆσδ’, ἐπεὶ λέγει</l>
 					<l>καλῶς κακοῦργος οὖσα· δεινὸν οὖν τόδε.</l>
 				</sp>
-				<sp n="Ἑκάβη" who="#ekabe">
+				<sp n="Ἑκάβη" who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>ταῖς θεαῖσι πρῶτα σύμμαχος γενήσομαι</l>
 					<l n="970">καὶ τήνδε δείξω μὴ λέγουσαν ἔνδικα.</l>
@@ -1824,7 +1824,7 @@ bring up to P3
 					<l>γυναιξί, θνῄσκειν ἥτις ἂν προδῷ πόσιν.</l>
 				</sp>
 				<milestone ed="p" n="1033" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Μενέλαε, προγόνων τ’ ἀξίως δόμων τε σῶν</l>
 					<l>τεῖσαι δάμαρτα κἀφελοῦ, πρὸς Ἑλλάδος,</l>
@@ -1839,12 +1839,12 @@ bring up to P3
 					<l n="1040">πόνους τ’ Ἀχαιῶν ἀπόδος ἐν μικρῷ μακροὺς</l>
 					<l>θανοῦσ’, ἵν’ εἰδῇς μὴ καταισχύνειν ἐμέ.</l>
 				</sp>
-				<sp who="#elene">
+				<sp who="#helene">
 					<speaker>Ἑλένη</speaker>
 					<l>μή, πρός σε γονάτων, τὴν νόσον τὴν τῶν θεῶν</l>
 					<l>προσθεὶς ἐμοὶ κτάνῃς με, συγγίγνωσκε δέ.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>μηδ’ οὓς ἀπέκτειν’ ἥδε συμμάχους προδῷς·</l>
 					<l n="1045">ἐγὼ πρὸ κείνων καὶ τέκνων σε λίσσομαι.</l>
@@ -1855,7 +1855,7 @@ bring up to P3
 					<l>λέγω δὲ προσπόλοισι πρὸς πρύμνας νεῶν</l>
 					<l>τήνδ’ ἐκκομίζειν, ἔνθα ναυστολήσεται.</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>μή νυν νεὼς σοὶ ταὐτὸν ἐσβήτω σκάφος.</l>
 				</sp>
@@ -1863,7 +1863,7 @@ bring up to P3
 					<speaker>Μενέλαος</speaker>
 					<l n="1050">τί δ’ ἔστι; μεῖζον βρῖθος ἢ πάροιθ’ ἔχει;</l>
 				</sp>
-				<sp who="#ekabe">
+				<sp who="#hekabe">
 					<speaker>Ἑκάβη</speaker>
 					<l>οὐκ ἔστ’ ἐραστὴς ὅστις οὐκ ἀεὶ φιλεῖ.</l>
 				</sp>
@@ -1882,7 +1882,7 @@ bring up to P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1060">οὕτω δὴ τὸν ἐν Ἰλίῳ</l>
 						<l>ναὸν καὶ θυόεντα βω‐</l>
@@ -1898,7 +1898,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φροῦδαί σοι θυσίαι χορῶν τ’</l>
 						<l>εὔφημοι κέλαδοι κατ’ ὄρ‐</l>
@@ -1914,7 +1914,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ φίλος ὦ πόσι μοι,</l>
 						<l>σὺ μὲν φθίμενος ἀλαίνεις</l>
@@ -1937,7 +1937,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1100">εἴθ’ ἀκάτου Μενέλα</l>
 						<l>μέσον πέλαγος ἰούσας,</l>
@@ -1962,7 +1962,7 @@ bring up to P3
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰώ,</l>
 						<l>καίν’ ἐκ καινῶν μεταβάλλουσαι</l>
@@ -2009,7 +2009,7 @@ bring up to P3
 						<l n="1155">ἐς ἓν ξυνελθόντ’ οἴκαδ’ ὁρμήσῃ πλάτην.</l>
 						<milestone ed="p" n="1156" unit="card"/>
 					</sp>
-					<sp n="Ἑκάβη" who="#ekabe">
+					<sp n="Ἑκάβη" who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>θέσθ’ ἀμφίτορνον ἀσπίδ’ Ἕκτορος πέδῳ,</l>
 						<l>λυπρὸν θέαμα κοὐ φίλον λεύσσειν ἐμοί.</l>
@@ -2064,12 +2064,12 @@ bring up to P3
 						<l n="1205">ἔμπληκτος ὡς ἄνθρωπος, ἄλλοτ’ ἄλλοσε</l>
 						<l>πηδῶσι, κοὐδεὶς αὐτὸς εὐτυχεῖ ποτε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν πρόχειρον αἵδε σοι σκυλευμάτων</l>
 						<l>Φρυγίων φέρουσι κόσμον ἐξάπτειν νεκρῷ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ τέκνον, οὐχ ἵπποισι νικήσαντά σε</l>
 						<l n="1210">οὐδ’ ἥλικας τόξοισιν, οὓς Φρύγες νόμους</l>
@@ -2082,14 +2082,14 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἒ ἔ, φρενῶν</l>
 						<l>ἔθιγες ἔθιγες· ὦ μέγας ἐμοί ποτ’ ἂν</l>
 						<l n="1217b">ἀνάκτωρ πόλεως.</l>
 						<milestone ed="p" n="1218" unit="card"/>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἃ δ’ ἐν γάμοισι χρῆν σε προσθέσθαι χροῒ</l>
 						<l>Ἀσιατίδων γήμαντα τὴν ὑπερτάτην,</l>
@@ -2103,54 +2103,54 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αἰαῖ αἰαῖ· πικρὸν ὄδυρμα . . .</l>
 						<l n="1228">γαῖά σ’ ὦ τέκνον δέξεται.</l>
 						<l>στέναζε, μᾶτερ,</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">αἰαῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1230">νεκρῶν ἴακχον.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l part="Y">οἴμοι [μοι].</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἴμοι δῆτα σῶν ἀλάστων κακῶν.</l>
 						<milestone ed="p" n="1232" unit="card"/>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τελαμῶσιν ἕλκη τὰ μὲν ἐγώ σ’ ἰάσομαι,</l>
 						<l>τλήμων ἰατρός, ὄνομ’ ἔχουσα, τἄργα δ’ οὔ·</l>
 						<l>τὰ δ’ ἐν νεκροῖσι φροντιεῖ πατὴρ σέθεν.</l>
 						<milestone ed="p" n="1235" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1235">ἄρασσ’ ἄρασσε κρᾶτα</l>
 						<l>πιτύλους διδοῦσα χειρός,</l>
 						<l>ἰώ μοί μοι.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ φίλταται γυναῖκες . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἑκάβη, σὰς ἔνεπε· τίνα θροεῖς αὐδάν;</l>
 						<milestone ed="p" n="1240" unit="card"/>
 					</sp>
 				</div2>
 				<div2 type="iambic">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1240">οὐκ ἦν ἄρ’ ἐν θεοῖσι πλὴν οὑμοὶ πόνοι</l>
 						<l>Τροία τε πόλεων ἔκκριτον μισουμένη,</l>
@@ -2167,7 +2167,7 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰώ·</l>
 						<l>μελέα μήτηρ, ἣ τὰς μεγάλας</l>
@@ -2197,7 +2197,7 @@ bring up to P3
 						<l n="1270">ἕπου. μεθήκουσίν σ’ Ὀδυσσέως πάρα</l>
 						<l>οἵδ’, ᾧ σε δούλην κλῆρος ἐκπέμπει πάτρας.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>οἲ ’γὼ τάλαινα· τοῦτο δὴ τὸ λοίσθιον</l>
 						<l>καὶ τέρμα πάντων τῶν ἐμῶν ἤδη κακῶν·</l>
@@ -2221,26 +2221,26 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 type="lyric">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὀττοτοτοτοτοῖ.</l>
 						<l>Κρόνιε, πρύτανι Φρύγιε, γενέτα</l>
 						<l>πάτερ, ἀνάξια τᾶς Δαρδάνου</l>
 						<l n="1290">γονᾶς τάδ’ οἷα πάσχομεν δέδορκας;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δέδορκεν, ἁ δὲ μεγαλόπολις</l>
 						<l>ἄπολις ὄλωλεν οὐδ’ ἔτ’ ἔστι Τροία.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1294">ὀττοτοτοτοτοῖ.</l>
 						<l n="1295">λέλαμπεν Ἴλιος, Περ‐</l>
 						<l>γάμων τε πυρὶ καταίθεται τέραμνα</l>
 						<l>καὶ πόλις ἄκρα τε τειχέων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πτέρυγι δὲ καπνὸς ὥς τις οὐ‐</l>
 						<l>ρανίᾳ πεσοῦσα δορὶ καταφθίνει γᾶ.</l>
@@ -2250,57 +2250,57 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἰὼ γᾶ τρόφιμε τῶν ἐμῶν τέκνων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἓ ἕ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ὦ τέκνα, κλύετε, μάθετε ματρὸς αὐδάν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰαλέμῳ τοὺς θανόντας ἀπύεις.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1305">γεραιά γ’ ἐς πέδον τιθεῖσα μέλεα καὶ</l>
 						<l>χερσὶ γαῖαν κτυποῦσα δισσαῖς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>διάδοχά σοι γόνυ τίθημι γαίᾳ</l>
 						<l>τοὺς ἐμοὺς καλοῦσα νέρθεν</l>
 						<l>ἀθλίους ἀκοίτας.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1310">ἀγόμεθα φερόμεθ’ . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἄλγος ἄλγος βοᾷς.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>δούλειον ὑπὸ μέλαθρον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἐκ πάτρας γ’ ἐμᾶς.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἰώ.</l>
 						<l>Πρίαμε Πρίαμε, σὺ μὲν ὀλόμενος</l>
 						<l>ἄταφος ἄφιλος</l>
 						<l>ἄτας ἐμᾶς ἄιστος εἶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1315">μέλας γὰρ ὄσσε κατεκάλυψε</l>
 						<l>θάνατος ὅσιος ἀνοσίαις σφαγαῖσιν.</l>
@@ -2308,57 +2308,57 @@ bring up to P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἰὼ θεῶν μέλαθρα καὶ πόλις φίλα,</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἓ ἕ.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>τὰν φόνιον ἔχετε φλόγα δορός τε λόγχαν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τάχ’ ἐς φίλαν γᾶν πεσεῖσθ’ ἀνώνυμοι.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1320">κόνις δ’ ἴσα καπνῷ πτέρυγι πρὸς αἰθέρα</l>
 						<l>ᾆστον οἴκων ἐμῶν με θήσει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὄνομα δὲ γᾶς ἀφανὲς εἶσιν· ἄλλᾳ δ’</l>
 						<l>ἄλλο φροῦδον, οὐδ’ ἔτ’ ἔστιν</l>
 						<l>ἁ τάλαινα Τροία.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l n="1325">ἐμάθετ’, ἐκλύετε;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">Περγάμων &lt;γε&gt; κτύπον.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἔνοσις ἅπασαν ἔνοσις . . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="Y">ἐπικλύσει πόλιν.</l>
 					</sp>
-					<sp who="#ekabe">
+					<sp who="#hekabe">
 						<speaker>Ἑκάβη</speaker>
 						<l>ἰώ·</l>
 						<l>τρομερὰ μέλεα, φέρετ’ ἐμὸν ἴχνος·</l>
 						<l>ἴτ’ ἐπί, τάλανα,</l>
 						<l n="1330">δούλειον ἁμέραν βίου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ τάλαινα πόλις· ὅμως δὲ</l>
 						<l>πρόφερε πόδα σὸν ἐπὶ πλάτας Ἀχαιῶν.</l>

--- a/tei/sophocles-ajax.xml
+++ b/tei/sophocles-ajax.xml
@@ -55,16 +55,19 @@
 					<person xml:id="menelaos" sex="MALE">
 						<persName>Μενέλαος</persName>
 					</person>
-					<person xml:id="aggelos" sex="MALE">
+					<person xml:id="angelos" sex="MALE">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<person xml:id="odysseys" sex="MALE">
+					<person xml:id="odysseus" sex="MALE">
 						<persName>Ὀδυσσεύς</persName>
 					</person>
-					<person xml:id="teykros" sex="MALE">
+					<person xml:id="teukros" sex="MALE">
 						<persName>Τεῦκρος</persName>
 					</person>
-					<personGrp xml:id="emixorion2" sex="MALE">
+					<personGrp xml:id="hemichorion_1" sex="MALE">
+						<name>Ἡμιχόριον 1</name>
+					</personGrp>
+					<personGrp xml:id="hemichorion_2" sex="MALE">
 						<name>Ἡμιχόριον 2</name>
 					</personGrp>
 					<person xml:id="athena" sex="FEMALE">
@@ -73,7 +76,7 @@
 					<person xml:id="agamemnon" sex="MALE">
 						<persName>Ἀγαμέμνων</persName>
 					</person>
-					<personGrp xml:id="xoros" sex="MALE">
+					<personGrp xml:id="choros" sex="MALE">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="aias" sex="MALE">
@@ -82,9 +85,6 @@
 					<person xml:id="tekmessa" sex="FEMALE">
 						<persName>Τέκμησσα</persName>
 					</person>
-					<personGrp xml:id="emixorion1" sex="MALE">
-						<name>Ἡμιχόριον 1</name>
-					</personGrp>
 				</listPerson>
 			</particDesc>
 			<textClass>
@@ -201,7 +201,7 @@ antilabe in all files
 					<l>ἔτ’ ἔργον ἐστίν, ἐννέπειν δ’ ὅτου χάριν</l>
 					<l>σπουδὴν ἔθου τήνδ’, ὡς παρ’ εἰδυίας μάθῃς.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ὦ φθέγμ’ Ἀθάνας, φιλτάτης ἐμοὶ θεῶν,</l>
 					<l n="15">ὡς εὐμαθές σου, κἂν ἄποπτος ᾖς ὅμως,</l>
@@ -232,7 +232,7 @@ antilabe in all files
 					<l>ἔγνων, Ὀδυσσεῦ, καὶ πάλαι φύλαξ ἔβην</l>
 					<l>τῇ σῇ πρόθυμος εἰς ὁδὸν κυναγίᾳ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἦ καί, φίλη δέσποινα, πρὸς καιρὸν πονῶ;</l>
 				</sp>
@@ -240,7 +240,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>ὡς ἔστιν ἀνδρὸς τοῦδε τἄργα ταῦτά σοι.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="40">καὶ πρὸς τί δυσλόγιστον ὧδ’ ᾖξεν χέρα;</l>
 				</sp>
@@ -248,7 +248,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>χόλῳ βαρυνθεὶς τῶν Ἀχιλλείων ὅπλων.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τί δῆτα ποίμναις τήνδ’ ἐπεμπίπτει βάσιν;</l>
 				</sp>
@@ -256,7 +256,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>δοκῶν ἐν ὑμῖν χεῖρα χραίνεσθαι φόνῳ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἦ καὶ τὸ βούλευμ’ ὡς ἐπ’ Ἀργείοις τόδ’ ἦν;</l>
 				</sp>
@@ -264,7 +264,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l n="45">κἂν ἐξεπράξατ’, εἰ κατημέλησ’ ἐγώ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ποίαισι τόλμαις ταῖσδε καὶ φρενῶν θράσει;</l>
 				</sp>
@@ -272,7 +272,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>νύκτωρ ἐφ’ ὑμᾶς δόλιος ὁρμᾶται μόνος.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἦ καὶ παρέστη κἀπὶ τέρμ’ ἀφίκετο;</l>
 				</sp>
@@ -280,7 +280,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>καὶ δὴ ’πὶ δισσαῖς ἦν στρατηγίσιν πύλαις.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="50">καὶ πῶς ἐπέσχε χεῖρα μαιμῶσαν φόνου;</l>
 				</sp>
@@ -311,7 +311,7 @@ antilabe in all files
 					<l>Αἴαντα φωνῶ· στεῖχε δωμάτων πάρος.</l>
 					<milestone ed="p" n="74" unit="card"/>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τί δρᾷς, Ἀθάνα; μηδαμῶς σφ’ ἔξω κάλει.</l>
 				</sp>
@@ -319,7 +319,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l n="75">οὐ σῖγ’ ἀνέξει μηδὲ δειλίαν ἀρεῖ;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>μὴ πρὸς θεῶν, ἀλλ’ ἔνδον ἀρκείτω μένων.</l>
 				</sp>
@@ -327,7 +327,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>τί μὴ γένηται; πρόσθεν οὐκ ἀνὴρ ὅδ’ ἦν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἐχθρός γε τῷδε τἀνδρὶ καὶ τανῦν ἔτι.</l>
 				</sp>
@@ -335,7 +335,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>οὔκουν γέλως ἥδιστος εἰς ἐχθροὺς γελᾶν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="80">ἐμοὶ μὲν ἀρκεῖ τοῦτον ἐν δόμοις μένειν.</l>
 				</sp>
@@ -343,7 +343,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>μεμηνότ’ ἄνδρα περιφανῶς ὀκνεῖς ἰδεῖν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>φρονοῦντα γάρ νιν οὐκ ἂν ἐξέστην ὄκνῳ.</l>
 				</sp>
@@ -351,7 +351,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>ἀλλ’ οὐδὲ νῦν σε μὴ παρόντ’ ἴδῃ πέλας.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>πῶς, εἴπερ ὀφθαλμοῖς γε τοῖς αὐτοῖς ὁρᾷ;</l>
 				</sp>
@@ -359,7 +359,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l n="85">ἐγὼ σκοτώσω βλέφαρα καὶ δεδορκότα.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>γένοιτο μέντἂν πᾶν θεοῦ τεχνωμένου.</l>
 				</sp>
@@ -367,7 +367,7 @@ antilabe in all files
 					<speaker>Ἀθήνα</speaker>
 					<l>σίγα νυν ἑστὼς καὶ μέν’ ὡς κυρεῖς ἔχων.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>μένοιμ’ ἄν· ἤθελον δ’ ἂν ἐκτὸς ὢν τυχεῖν.</l>
 				</sp>
@@ -467,7 +467,7 @@ antilabe in all files
 					<l>τούτου τίς ἄν σοι τἀνδρὸς ἢ προνούστερος</l>
 					<l n="120">ἢ δρᾶν ἀμείνων ηὑρέθη τὰ καίρια;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἐγὼ μὲν οὐδέν’ οἶδ’· ἐποικτίρω δέ νιν</l>
 					<l>δύστηνον ἔμπας, καίπερ ὄντα δυσμενῆ,</l>
@@ -488,7 +488,7 @@ antilabe in all files
 					<milestone ed="p" n="134" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Τελαμώνιε παῖ, τῆς ἀμφιρύτου</l>
 						<l n="135">Σαλαμῖνος ἔχων βάθρον ἀγχιάλου,</l>
@@ -534,7 +534,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ ῥά σε Ταυροπόλα Διὸς Ἄρτεμις—</l>
 						<l>ὦ μεγάλα φάτις, ὦ</l>
@@ -550,7 +550,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔ ποτε γὰρ φρενόθεν γ’ ἐπ’ ἀριστερά,</l>
 						<l>παῖ Τελαμῶνος, ἔβας</l>
@@ -566,7 +566,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἄνα ἐξ ἑδράνων, ὅπου μακραίωνι</l>
 						<l>στηρίζει ποτὲ τᾷδ’ ἀγωνίῳ σχολᾷ</l>
@@ -592,7 +592,7 @@ antilabe in all files
 						<l>Αἴας θολερῷ</l>
 						<l>κεῖται χειμῶνι νοσήσας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί δ’ ἐνήλλακται τῆς ἡμερίας</l>
 						<l n="210">νὺξ ἥδε βάρος;</l>
@@ -618,7 +618,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἵαν ἐδήλωσας ἀνέρος αἴθονος</l>
 						<l>ἀγγελίαν ἄτλατον οὐδὲ φευκτάν,</l>
@@ -649,7 +649,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="245">ὥρα τιν’ ἤδη τοι κρᾶτα καλύμμασι</l>
 						<l>κρυψάμενον ποδοῖν κλοπὰν ἀρέσθαι</l>
@@ -675,7 +675,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εἰ πέπαυται, κάρτ’ ἂν εὐτυχεῖν δοκῶ·</l>
 					<l>φρούδου γὰρ ἤδη τοῦ κακοῦ μείων λόγος.</l>
@@ -686,7 +686,7 @@ antilabe in all files
 					<l>φίλους ἀνιῶν αὐτὸς ἡδονὰς ἔχειν,</l>
 					<l>ἢ κοινὸς ἐν κοινοῖσι λυπεῖσθαι ξυνών;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τό τοι διπλάζον, ὦ γύναι, μεῖζον κακόν.</l>
 				</sp>
@@ -694,7 +694,7 @@ antilabe in all files
 					<speaker>Τέκμησσα</speaker>
 					<l>ἡμεῖς ἄρ’ οὐ νοσοῦντες ἀτώμεσθα νῦν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="270">πῶς τοῦτ’ ἔλεξας;  οὐ κάτοιδ’ ὅπως λέγεις.</l>
 				</sp>
@@ -708,7 +708,7 @@ antilabe in all files
 					<l>ἡμεῖς θ’ ὁμοίως οὐδὲν ἧσσον ἢ πάρος.</l>
 					<l>ἆρ’ ἔστι ταῦτα δὶς τόσ’ ἐξ ἁπλῶν κακά;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ξύμφημι δή σοι καὶ δέδοικα μὴ ’κ θεοῦ</l>
 					<l>πληγή τις ἥκῃ.  πῶς γάρ, εἰ πεπαυμένος</l>
@@ -718,7 +718,7 @@ antilabe in all files
 					<speaker>Τέκμησσα</speaker>
 					<l>ὡς ὧδ’ ἐχόντων τῶνδ’ ἐπίστασθαί σε χρή.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τίς γάρ ποτ’ ἀρχὴ τοῦ κακοῦ προσέπτατο;</l>
 					<l>δήλωσον ἡμῖν τοῖς ξυναλγοῦσιν τύχας.</l>
@@ -775,7 +775,7 @@ antilabe in all files
 					<l n="330">φίλων γὰρ οἱ τοιοίδε νικῶνται λόγοις.</l>
 					<milestone ed="p" n="331" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Τέκμησσα, δεινά, παῖ Τελεύταντος, λέγεις</l>
 					<l>ἡμῖν, τὸν ἄνδρα διαπεφοιβάσθαι κακοῖς.</l>
@@ -793,7 +793,7 @@ antilabe in all files
 					<speaker>Αἴας</speaker>
 					<l>ἰώ μοί μοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἁνὴρ ἔοικεν ἢ νοσεῖν ἢ τοῖς πάλαι</l>
 					<l>νοσήμασιν ξυνοῦσι λυπεῖσθαι παρών.</l>
@@ -812,7 +812,7 @@ antilabe in all files
 					<l>Τεῦκρον καλῶ.  ποῦ Τεῦκρος; ἢ τὸν εἰσαεὶ</l>
 					<l>λεηλατήσει χρόνον, ἐγὼ δ’ ἀπόλλυμαι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἁνὴρ φρονεῖν ἔοικεν.  ἀλλ’ ἀνοίγετε.</l>
 					<l n="345">τάχ’ ἄν τιν’ αἰδῶ κἀπ’ ἐμοὶ βλέψας λάβοι.</l>
@@ -834,7 +834,7 @@ antilabe in all files
 						<l>ἴδεσθέ μ’ οἷον ἄρτι κῦμα φοινίας ὑπὸ ζάλης</l>
 						<l>ἀμφίδρομον κυκλεῖται.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἴμ’ ὡς ἔοικας ὀρθὰ μαρτυρεῖν ἄγαν.</l>
 						<l n="355">δηλοῖ δὲ τοὔργον ὡς ἀφροντίστως ἔχει.</l>
@@ -850,7 +850,7 @@ antilabe in all files
 						<l n="360">σέ τοι σέ τοι μόνον δέδορκα πημονὰν ἐπαρκέσοντ’·</l>
 						<l>ἀλλά με συνδάϊξον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὔφημα φώνει· μὴ κακὸν κακῷ διδοὺς</l>
 						<l>ἄκος, πλέον τὸ πῆμα τῆς ἄτης τίθει.</l>
@@ -874,7 +874,7 @@ antilabe in all files
 						<l>οὐκ ἐκτός; οὐκ ἄψορρον ἐκνεμεῖ πόδα;</l>
 						<l n="370">αἰαῖ αἰαῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πρὸς θεῶν ὕπεικε καὶ φρόνησον εὖ.</l>
 					</sp>
@@ -886,7 +886,7 @@ antilabe in all files
 						<l>ἐρεμνὸν αἷμ’ ἔδευσα.</l>
 						<milestone ed="p" n="377" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί δῆτ’ ἂν ἀλγοίης ἐπ’ ἐξειργασμένοις;</l>
 						<l>οὐ γὰρ γένοιτ’ ἂν ταῦθ’ ὅπως οὐχ ὧδ’ ἔχειν.</l>
@@ -901,7 +901,7 @@ antilabe in all files
 						<l>κακοπινέστατόν τ’ ἄλημα στρατοῦ,</l>
 						<l>ἦ που πολὺν γέλωθ’ ὑφ’ ἡδονῆς ἄγεις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ξύν τοι θεῷ πᾶς καὶ γελᾷ κὠδύρεται.</l>
 					</sp>
@@ -910,7 +910,7 @@ antilabe in all files
 						<l>ἴδοιμι μήν νιν, καίπερ ὧδ’ ἀτώμενος.</l>
 						<l n="385">ἰώ μοί μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μηδὲν μέγ’ εἴπῃς· οὐχ ὁρᾷς ἵν’ εἶ κακοῦ;</l>
 					</sp>
@@ -976,7 +976,7 @@ antilabe in all files
 						<l>ὧδε πρόκειμαι.</l>
 						<milestone ed="p" n="428" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔτοι σ’ ἀπείργειν οὐδ’ ὅπως ἐῶ λέγειν</l>
 						<l>ἔχω, κακοῖς τοιοῖσδε συμπεπτωκότα.</l>
@@ -1040,7 +1040,7 @@ antilabe in all files
 					<l n="480">τὸν εὐγενῆ χρή.  πάντ’ ἀκήκοας λόγον.</l>
 					<milestone ed="p" n="481" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐδεὶς ἐρεῖ ποθ’ ὡς ὑπόβλητον λόγον,</l>
 					<l>Αἴας, ἔλεξας, ἀλλὰ τῆς σαυτοῦ φρενός·</l>
@@ -1091,7 +1091,7 @@ antilabe in all files
 					<l>οὐκ ἂν γένοιτ’ ἔθ’ οὗτος εὐγενὴς ἀνήρ.</l>
 					<milestone ed="p" n="525" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="525">Αἴας, ἔχειν σ’ ἂν οἶκτον ὡς κἀγὼ φρενὶ</l>
 					<l>θέλοιμ’ ἄν· αἰνοίης γὰρ ἂν τὰ τῆσδ’ ἔπη.</l>
@@ -1206,7 +1206,7 @@ antilabe in all files
 					<l>θρηνεῖν ἐπῳδὰς πρὸς τομῶντι πήματι.</l>
 					<milestone ed="p" n="583" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δέδοικ’ ἀκούων τήνδε τὴν προθυμίαν·</l>
 					<l>οὐ γάρ μ’ ἀρέσκει γλῶσσά σου τεθηγμένη.</l>
@@ -1266,7 +1266,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ κλεινὰ Σαλαμίς, σὺ μέν που</l>
 						<l>ναίεις ἁλίπλακτος, εὐδαίμων,</l>
@@ -1282,7 +1282,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καί μοι δυσθεράπευτος Αἴας</l>
 						<l n="610">ξύνεστιν ἔφεδρος, ὤμοι μοι,</l>
@@ -1298,7 +1298,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ που παλαιᾷ μὲν σύντροφος ἁμέρᾳ,</l>
 						<l n="625">λευκῷ δὲ γήρᾳ μάτηρ νιν ὅταν νοσοῦντα</l>
@@ -1313,7 +1313,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="635">κρείσσων παρ’ Ἅιδᾳ κεύθων ὁ νοσῶν μάταν,</l>
 						<l>ὃς ἐκ πατρῴας ἥκων γενεᾶς ἄριστος</l>
@@ -1383,7 +1383,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔφριξ’ ἔρωτι, περιχαρὴς δ’ ἀνεπτόμαν.</l>
 						<l>ἰὼ ἰὼ Πὰν Πάν,</l>
@@ -1399,7 +1399,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔλυσεν αἰνὸν ἄχος ἀπ’ ὀμμάτων Ἄρης.</l>
 						<l>ἰὼ ἰώ, νῦν αὖ,</l>
@@ -1416,7 +1416,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἄνδρες φίλοι, τὸ πρῶτον ἀγγεῖλαι θέλω·</l>
 					<l n="720">Τεῦκρος πάρεστιν ἄρτι Μυσίων ἀπὸ</l>
@@ -1435,42 +1435,42 @@ antilabe in all files
 					<l>ἀλλ’ ἡμὶν Αἴας ποῦ ’στιν, ὡς φράσω τάδε;</l>
 					<l>τοῖς κυρίοις γὰρ πάντα χρὴ δηλοῦν λόγον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="735">οὐκ ἔνδον, ἀλλὰ φροῦδος ἀρτίως, νέας</l>
 					<l>βουλὰς νέοισιν ἐγκαταζεύξας τρόποις.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἰοὺ ἰού·</l>
 					<l>βραδεῖαν ἡμᾶς ἆρ’ ὁ τήνδε τὴν ὁδὸν</l>
 					<l>πέμπων ἔπεμψεν ἢ ’φάνην ἐγὼ βραδύς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="740">τί δ’ ἐστὶ χρείας τῆσδ’ ὑπεσπανισμένον;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τὸν ἄνδρ’ ἀπηύδα Τεῦκρος ἔνδοθεν στέγης</l>
 					<l>μὴ ’ξω παρήκειν, πρὶν παρὼν αὐτὸς τύχῃ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ οἴχεταί τοι, πρὸς τὸ κέρδιστον τραπεὶς</l>
 					<l>γνώμης, θεοῖσιν ὡς καταλλαχθῇ χόλου.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="745">ταῦτ’ ἐστὶ τἄπη μωρίας πολλῆς πλέα,</l>
 					<l>εἴπερ τι Κάλχας εὖ φρονῶν μαντεύεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ποῖον; τί δ’ εἰδὼς τοῦδε πράγματος πάρει;</l>
 					<milestone ed="p" n="748" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τοσοῦτον οἶδα καὶ παρὼν ἐτύγχανον.</l>
 					<l>ἐκ γὰρ συνέδρου καὶ τυραννικοῦ κύκλου</l>
@@ -1510,7 +1510,7 @@ antilabe in all files
 					<l>οὐκ ἔστιν ἁνὴρ κεῖνος, εἰ Κάλχας σοφός.</l>
 					<milestone ed="p" n="784" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ δαΐα Τέκμησσα, δύσμορον γένος,</l>
 					<l n="785">ὅρα μολοῦσα τόνδ’ ὁποῖ’ ἔπη θροεῖ·</l>
@@ -1521,7 +1521,7 @@ antilabe in all files
 					<l>τί μ’ αὖ τάλαιναν, ἀρτίως πεπαυμένην </l>
 					<l>κακῶν ἀτρύτων, ἐξ ἕδρας ἀνίστατε;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τοῦδ’ εἰσάκουε τἀνδρός, ὡς ἥκει φέρων</l>
 					<l n="790">Αἴαντος ἡμῖν πρᾶξιν ἣν ἤλγησ’ ἐγώ.</l>
@@ -1530,7 +1530,7 @@ antilabe in all files
 					<speaker>Τέκμησσα</speaker>
 					<l>οἴμοι, τί φής, ἄνθρωπε; μῶν ὀλώλαμεν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐκ οἶδα τὴν σὴν πρᾶξιν, Αἴαντος δ’ ὅτι,</l>
 					<l>θυραῖος εἴπερ ἐστίν, οὐ θαρσῶ πέρι.</l>
@@ -1539,7 +1539,7 @@ antilabe in all files
 					<speaker>Τέκμησσα</speaker>
 					<l>καὶ μὴν θυραῖος, ὥστε μ’ ὠδίνειν τί φής.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="795">ἐκεῖνον εἴργειν Τεῦκρος ἐξεφίεται</l>
 					<l>σκηνῆς ὕπαυλον μηδ’ ἀφιέναι μόνον.</l>
@@ -1548,7 +1548,7 @@ antilabe in all files
 					<speaker>Τέκμησσα</speaker>
 					<l>ποῦ δ’ ἐστὶ Τεῦκρος, κἀπὶ τῷ λέγει τάδε;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>πάρεστ’ ἐκεῖνος ἄρτι· τήνδε δ’ ἔξοδον</l>
 					<l>ὀλεθρίαν Αἴαντος ἐλπίζει φέρειν.</l>
@@ -1557,7 +1557,7 @@ antilabe in all files
 					<speaker>Τέκμησσα</speaker>
 					<l n="800">οἴμοι τάλαινα, τοῦ ποτ’ ἀνθρώπων μαθών;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τοῦ Θεστορείου μάντεως, καθ’ ἡμέραν</l>
 					<l>τὴν νῦν, ὅτ’ αὐτῷ θάνατον ἢ βίον φέρει.</l>
@@ -1575,7 +1575,7 @@ antilabe in all files
 					<l>χωρῶμεν, ἐγκονῶμεν, οὐχ ἕδρας ἀκμὴ</l>
 					<l>σῴζειν θέλοντας ἄνδρα γ’ ὃς σπεύδῃ θανεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>χωρεῖν ἕτοιμος, κοὐ λόγῳ δείξω μόνον·</l>
 					<l>τάχος γὰρ ἔργου καὶ ποδῶν ἅμ’ ἕψεται,</l>
@@ -1637,7 +1637,7 @@ antilabe in all files
 					<milestone ed="p" n="866" unit="card"/>
 				</sp>
 				<div2 type="kommos">
-					<sp who="#emixorion">
+					<sp who="#hemichorion_1">
 						<speaker>Ἡμιχόριον 1</speaker>
 						<l>πόνος πόνῳ πόνον φέρει.</l>
 						<l>πᾷ πᾷ</l>
@@ -1646,27 +1646,27 @@ antilabe in all files
 						<l n="870">ἰδού.</l>
 						<l>δοῦπον αὖ κλύω τινά.</l>
 					</sp>
-					<sp who="#emixorion">
+					<sp who="#hemichorion_2">
 						<speaker>Ἡμιχόριον 2</speaker>
 						<l>ἡμῶν γε ναὸς κοινόπλουν ὁμιλίαν.</l>
 					</sp>
-					<sp who="#emixorion">
+					<sp who="#hemichorion_1">
 						<speaker>Ἡμιχόριον 1</speaker>
 						<l>τί οὖν δή;</l>
 					</sp>
-					<sp who="#emixorion">
+					<sp who="#hemichorion_2">
 						<speaker>Ἡμιχόριον 2</speaker>
 						<l>πᾶν ἐστίβηται πλευρὸν ἕσπερον νεῶν</l>
 					</sp>
-					<sp who="#emixorion">
+					<sp who="#hemichorion_1">
 						<speaker>Ἡμιχόριον 1</speaker>
 						<l n="875">ἔχεις οὖν;</l>
 					</sp>
-					<sp who="#emixorion">
+					<sp who="#hemichorion_2">
 						<speaker>Ἡμιχόριον 2</speaker>
 						<l>πόνου γε πλῆθος, κοὐδὲν εἰς ὄψιν πλέον.</l>
 					</sp>
-					<sp who="#emixorion">
+					<sp who="#hemichorion_1">
 						<speaker>Ἡμιχόριον 1</speaker>
 						<l>ἀλλ’ οὐδὲ μὲν δὴ τὴν ἀφ’ ἡλίου βολῶν</l>
 						<l>κέλευθον ἁνὴρ οὐδαμοῦ δηλοῖ φανείς.</l>
@@ -1676,7 +1676,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς ἂν δῆτά μοι, τίς ἂν φιλοπόνων</l>
 						<l n="880">ἁλιαδᾶν ἔχων ἀΰπνους ἄγρας,</l>
@@ -1692,7 +1692,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l>ἰώ μοί μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίνος βοὴ πάραυλος ἐξέβη νάπους;</l>
 					</sp>
@@ -1700,7 +1700,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l>ἰὼ τλήμων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὴν δουρίληπτον δύσμορον νύμφην ὁρῶ</l>
 						<l n="895">Τέκμησσαν, οἴκτῳ, τῷδε συγκεκραμένην.</l>
@@ -1709,7 +1709,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l>ᾤχωκ’, ὄλωλα, διαπεπόρθημαι, φίλοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί δ’ ἔστιν;</l>
 					</sp>
@@ -1718,7 +1718,7 @@ antilabe in all files
 						<l>Αἴας ὅδ’ ἡμῖν ἀρτίως νεοσφαγὴς</l>
 						<l>κεῖται, κρυφαίῳ φασγάνῳ περιπτυχής.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="900">ὤμοι ἐμῶν νόστων·</l>
 						<l>ὤμοι, κατέπεφνες, ἄναξ,</l>
@@ -1729,7 +1729,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l n="905">ὡς ὧδε τοῦδ’ ἔχοντος αἰάζειν πάρα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίνος ποτ’ ἆρ’ ἔπραξε χειρὶ δύσμορος;</l>
 					</sp>
@@ -1738,7 +1738,7 @@ antilabe in all files
 						<l>αὐτὸς πρὸς αὑτοῦ, δῆλον· ἐν γάρ οἱ χθονὶ</l>
 						<l n="910">πηκτὸν τόδ’ ἔγχος περιπετὲς κατηγορεῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὤμοι ἐμᾶς ἄτας, οἶος ἄρ’ αἱμάχθης, ἄφαρκτος φίλων·</l>
 						<l>ἐγὼ δ’ ὁ πάντα κωφός, ὁ πάντ’ ἄϊδρις, κατημέλησα.  πᾷ πᾷ</l>
@@ -1761,7 +1761,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔμελλες, τάλας, ἔμελλες χρόνῳ</l>
 						<l>στερεόφρων ἄρ’ ἐξανύσσειν κακὰν</l>
@@ -1777,7 +1777,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l>ἰώ μοί μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χωρεῖ πρὸς ἧπαρ, οἶδα, γενναία δύη.</l>
 					</sp>
@@ -1785,7 +1785,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l>ἰώ μοί μοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="940">οὐδέν σ’ ἀπιστῶ καὶ δὶς οἰμῶξαι, γύναι,</l>
 						<l>τοιοῦδ’ ἀποβλαφθεῖσαν ἀρτίως φίλου.</l>
@@ -1794,7 +1794,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l>σοὶ μὲν δοκεῖν ταῦτ’ ἔστ’, ἐμοὶ δ’ ἄγαν φρονεῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ξυναυδῶ.</l>
 					</sp>
@@ -1803,7 +1803,7 @@ antilabe in all files
 						<l>οἴμοι, τέκνον, πρὸς οἷα δουλείας ζυγὰ</l>
 						<l n="945">χωροῦμεν, οἷοι νῷν ἐφεστᾶσιν σκοποί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὤμοι, ἀναλγήτων</l>
 						<l>δισσῶν ἐθρόησας ἄναυδ’</l>
@@ -1814,7 +1814,7 @@ antilabe in all files
 						<speaker>Τέκμησσα</speaker>
 						<l n="950">οὐκ ἂν τάδ’ ἔστη τῇδε μὴ θεῶν μέτα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄγαν ὑπερβριθὲς γὰρ ἄχθος ἤνυσαν.</l>
 					</sp>
@@ -1823,7 +1823,7 @@ antilabe in all files
 						<l>τοιόνδε μέντοι Ζηνὸς ἡ δεινὴ θεὸς</l>
 						<l>Παλλὰς φυτεύει πῆμ’ Ὀδυσσέως χάριν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="955">ἦ ῥα κελαινώπαν θυμὸν ἐφυβρίζει πολύτλας ἀνήρ,</l>
 						<l>γελᾷ δὲ τοῖσδε μαινομένοις ἄχεσιν πολὺν γέλωτα, φεῦ φεῦ,</l>
@@ -1849,58 +1849,58 @@ antilabe in all files
 					<l>Αἴας γὰρ αὐτοῖς οὐκέτ’ ἐστίν, ἀλλ’ ἐμοὶ</l>
 					<l>λιπὼν ἀνίας καὶ γόους διοίχεται.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l part="Y">ἰώ μοί μοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="975">σίγησον· αὐδὴν γὰρ δοκῶ Τεύκρου κλύειν</l>
 					<l>βοῶντος ἄτης τῆσδ’ ἐπίσκοπον μέλος.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὦ φίλτατ’ Αἴας, ὦ ξύναιμον ὄμμ’ ἐμοί,</l>
 					<l>ἆρ’ ἠμπόληκας, ὥσπερ ἡ φάτις κρατεῖ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὄλωλεν ἁνήρ, Τεῦκρε, τοῦτ’ ἐπίστασο.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="980">ὤμοι βαρείας ἆρα τῆς ἐμῆς τύχης.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">ὡς ὧδ’ ἐχόντων</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l part="F">ὦ τάλας ἐγώ, τάλας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">πάρα στενάζειν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l part="F">ὦ περισπερχὲς πάθος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">ἄγαν γε, Τεῦκρε.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l part="F">φεῦ τάλας· τί γὰρ τέκνον</l>
 					<l>τὸ τοῦδε, ποῦ μοι γῆς κυρεῖ τῆς Τρῳάδος;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="985" part="I">μόνος παρὰ σκηναῖσιν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l part="F">οὐχ ὅσον τάχος</l>
 					<l>δῆτ’ αὐτὸν ἄξεις δεῦρο, μή τις ὡς κενῆς</l>
@@ -1908,13 +1908,13 @@ antilabe in all files
 					<l>ἴθ’, ἐγκόνει, σύγκαμνε· τοῖς θανοῦσί τοι</l>
 					<l>φιλοῦσι πάντες κειμένοις ἐπεγγελᾶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="990">καὶ μὴν ἔτι ζῶν, Τεῦκρε, τοῦδέ σοι μέλειν</l>
 					<l>ἐφίεθ’ ἁνὴρ κεῖνος, ὥσπερ οὖν μέλει.</l>
 					<milestone ed="p" n="992" unit="card"/>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὦ τῶν ἁπάντων δὴ θεαμάτων ἐμοὶ</l>
 					<l>ἄλγιστον ὧν προσεῖδον ὀφθαλμοῖς ἐγώ,</l>
@@ -1966,22 +1966,22 @@ antilabe in all files
 					<l>κεῖνός τ’ ἐκεῖνα στεργέτω κἀγὼ τάδε.</l>
 					<milestone ed="p" n="1040" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1040">μὴ τεῖνε μακράν, ἀλλ’ ὅπως κρύψεις τάφῳ</l>
 					<l>φράζου τὸν ἄνδρα χὤ τι μυθήσει τάχα.</l>
 					<l>βλέπω γὰρ ἐχθρὸν φῶτα, καὶ τάχ’ ἂν κακοῖς</l>
 					<l>γελῶν ἃ δὴ κακοῦργος ἐξίκοιτ’ ἀνήρ.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>τίς δ’ ἐστὶν ὅντιν’ ἄνδρα προσλεύσσεις στρατοῦ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1045">Μενέλαος, ᾧ δὴ τόνδε πλοῦν ἐστείλαμεν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ὁρῶ· μαθεῖν γὰρ ἐγγὺς ὢν οὐ δυσπετής.</l>
 				</sp>
@@ -1990,7 +1990,7 @@ antilabe in all files
 					<l>οὗτος, σὲ φωνῶ τόνδε τὸν νεκρὸν χεροῖν</l>
 					<l>μὴ συγκομίζειν, ἀλλ’ ἐᾶν ὅπως ἔχει.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>τίνος χάριν τοσόνδ’ ἀνήλωσας λόγον;</l>
 				</sp>
@@ -1998,7 +1998,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l n="1050">δοκοῦντ’ ἐμοί, δοκοῦντα δ’ ὃς κραίνει στρατοῦ.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>οὔκουν ἂν εἴποις ἥντιν’ αἰτίαν προθείς;</l>
 				</sp>
@@ -2045,12 +2045,12 @@ antilabe in all files
 					<l n="1090">μὴ τόνδε θάπτων αὐτὸς εἰς ταφὰς πέσῃς.</l>
 					<milestone ed="p" n="1091" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Μενέλαε, μὴ γνώμας ὑποστήσας σοφὰς</l>
 					<l>εἶτ’ αὐτὸς ἐν θανοῦσιν ὑβριστὴς γένῃ.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>οὐκ ἄν ποτ’, ἄνδρες, ἄνδρα θαυμάσαιμ’ ἔτι,</l>
 					<l>ὃς μηδὲν ὢν γοναῖσιν εἶθ’ ἁμαρτάνει,</l>
@@ -2078,7 +2078,7 @@ antilabe in all files
 					<l>καὶ τὸν στρατηγὸν ἧκε, τοῦ δὲ σοῦ ψόφου</l>
 					<l>οὐκ ἂν στραφείην, ἕως ἂν ᾖς οἷός περ εἶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐδ’ αὖ τοιαύτην γλῶσσαν ἐν κακοῖς φιλῶ·</l>
 					<l>τὰ σκληρὰ γάρ τοι, κἂν ὑπέρδικ’ ᾖ, δάκνει.</l>
@@ -2088,7 +2088,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l n="1120">ὁ τοξότης ἔοικεν οὐ σμικρὸν φρονεῖν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>οὐ γὰρ βάναυσον τὴν τέχνην ἐκτησάμην.</l>
 				</sp>
@@ -2096,7 +2096,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>μέγ’ ἄν τι κομπάσειας, ἀσπίδ’ εἰ λάβοις.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>κἂν ψιλὸς ἀρκέσαιμι σοί γ’ ὡπλισμένῳ.</l>
 				</sp>
@@ -2104,7 +2104,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>ἡ γλῶσσά σου τὸν θυμὸν ὡς δεινὸν τρέφει.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="1125">ξὺν τῷ δικαίῳ γὰρ μέγ’ ἔξεστιν φρονεῖν.</l>
 				</sp>
@@ -2112,7 +2112,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>δίκαια γὰρ τόνδ’ εὐτυχεῖν κτείναντά με;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>κτείναντα; δεινόν γ’ εἶπας, εἰ καὶ ζῇς θανών.</l>
 				</sp>
@@ -2120,7 +2120,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>θεὸς γὰρ ἐκσῴζει με, τῷδε δ’ οἴχομαι.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>μή νυν ἀτίμα θεούς, θεοῖς σεσωσμένος.</l>
 				</sp>
@@ -2128,7 +2128,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l n="1130">ἐγὼ γὰρ ἂν ψέξαιμι δαιμόνων νόμους;</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>εἰ τοὺς θανόντας οὐκ ἐᾷς θάπτειν παρών.</l>
 				</sp>
@@ -2136,7 +2136,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>τούς γ’ αὐτὸς αὑτοῦ πολεμίους.  οὐ γὰρ καλόν.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ἦ σοὶ γὰρ Αἴας πολέμιος προύστη ποτέ;</l>
 				</sp>
@@ -2144,7 +2144,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>μισοῦντ’ ἐμίσει· καὶ σὺ τοῦτ’ ἠπίστασο.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="1135">κλέπτης γὰρ αὐτοῦ ψηφοποιὸς ηὑρέθης.</l>
 				</sp>
@@ -2152,7 +2152,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>ἐν τοῖς δικασταῖς, κοὐκ ἐμοί, τόδ’ ἐσφάλη.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>πόλλ’ ἂν κακῶς λάθρᾳ σὺ κλέψειας κακά.</l>
 				</sp>
@@ -2160,7 +2160,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l>τοῦτ’ εἰς ἀνίαν τοὔπος ἔρχεταί τινι.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>οὐ μᾶλλον, ὡς ἔοικεν, ἢ λυπήσομεν.</l>
 				</sp>
@@ -2168,7 +2168,7 @@ antilabe in all files
 					<speaker>Μενέλαος</speaker>
 					<l n="1140">ἕν σοι φράσω· τόνδ’ ἐστὶν οὐχὶ θαπτέον.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ἀλλ’ ἀντακούσει τοῦτον ὡς τεθάψεται.</l>
 				</sp>
@@ -2184,7 +2184,7 @@ antilabe in all files
 					<l>χειμὼν κατασβέσειε τὴν πολλὴν βοήν.</l>
 					<milestone ed="p" n="1150" unit="card"/>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l n="1150">ἐγὼ δέ γ’ ἄνδρ’ ὄπωπα μωρίας πλέων,</l>
 					<l>ὃς ἐν κακοῖς ὕβριζε τοῖσι τῶν πέλας.</l>
@@ -2201,14 +2201,14 @@ antilabe in all files
 					<l>ἄπειμι· καὶ γὰρ αἰσχρόν, εἰ πύθοιτό τις</l>
 					<l n="1160">λόγοις κολάζειν ᾧ βιάζεσθαι πάρα.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ἄφερπέ νυν· κἀμοὶ γὰρ αἴσχιστον κλύειν</l>
 					<l>ἀνδρὸς ματαίου φλαῦρ’ ἔπη μυθουμένου.</l>
 					<milestone ed="p" n="1163" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔσται μεγάλης ἔριδός τις ἀγών.</l>
 						<l>ἀλλ’ ὡς δύνασαι, Τεῦκρε, ταχύνας</l>
@@ -2219,7 +2219,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="dialogue">
-					<sp who="#teykros">
+					<sp who="#teukros">
 						<speaker>Τεῦκρος</speaker>
 						<l>καὶ μὴν ἐς αὐτὸν καιρὸν οἵδε πλησίοι</l>
 						<l>πάρεισιν ἀνδρὸς τοῦδε παῖς τε καὶ γυνή,</l>
@@ -2244,7 +2244,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1185">τίς ἄρα νέατος ἐς πότε λήξει πολυπλάγκτων ἐτέων ἀριθμός,</l>
 						<l>τὰν ἄπαυστον αἰὲν ἐμοὶ δορυσσοήτων</l>
@@ -2255,7 +2255,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὄφελε πρότερον αἰθέρα δῦναι μέγαν ἢ τὸν πολύκοινον Ἅιδαν</l>
 						<l n="1195">κεῖνος ἁνήρ, ὃς στυγερῶν ἔδειξεν ὅπλων</l>
@@ -2266,7 +2266,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐκεῖνος οὔτε στεφάνων</l>
 						<l n="1200">οὔτε βαθεῖαν κυλίκων</l>
@@ -2283,7 +2283,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ πρὶν μὲν αἰὲν νυχίου</l>
 						<l>δείματος ἦν μοι προβολὰ</l>
@@ -2301,7 +2301,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>καὶ μὴν ἰδὼν ἔσπευσα τὸν στρατηλάτην</l>
 					<l>Ἀγαμέμνον’ ἡμῖν δεῦρο τόνδ’ ὁρμώμενον·</l>
@@ -2349,12 +2349,12 @@ antilabe in all files
 					<l>τὴν βάρβαρον γὰρ γλῶσσαν οὐκ ἐπαΐω.</l>
 					<milestone ed="p" n="1264" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εἴθ’ ὑμὶν ἀμφοῖν νοῦς γένοιτο σωφρονεῖν·</l>
 					<l n="1265">τούτου γὰρ οὐδὲν σφῷν ἔχω λῷον φράσαι.</l>
 				</sp>
-				<sp n="Τεῦκρος" who="#teykros">
+				<sp n="Τεῦκρος" who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>φεῦ· τοῦ θανόντος ὡς ταχεῖά τις βροτοῖς</l>
 					<l>χάρις διαρρεῖ καὶ προδοῦσ’ ἁλίσκεται,</l>
@@ -2409,12 +2409,12 @@ antilabe in all files
 					<l n="1315">καὶ δειλὸς εἶναι μᾶλλον ἢ ’ν ἐμοὶ θρασύς.</l>
 				</sp>
 				<milestone ed="p" n="1316" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄναξ, Ὀδυσσεῦ, καιρὸν ἴσθ’ ἐληλυθώς,</l>
 					<l>εἰ μὴ ξυνάψων, ἀλλὰ συλλύσων πάρει.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τί δ’ ἔστιν, ἄνδρες; τηλόθεν γὰρ ᾐσθόμην</l>
 					<l>βοὴν Ἀτρειδῶν τῷδ’ ἐπ’ ἀλκίμῳ νεκρῷ.</l>
@@ -2424,7 +2424,7 @@ antilabe in all files
 					<l n="1320">οὐ γὰρ κλύοντές ἐσμεν αἰσχίστους λόγους,</l>
 					<l>ἄναξ Ὀδυσσεῦ, τοῦδ’ ὑπ’ ἀνδρὸς ἀρτίως;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ποίους; ἐγὼ γὰρ ἀνδρὶ συγγνώμην ἔχω</l>
 					<l>κλύοντι φλαῦρα συμβαλεῖν ἔπη κακά.</l>
@@ -2433,7 +2433,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>ἤκουσεν αἰσχρά· δρῶν γὰρ ἦν τοιαῦτά με.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1325">τί γάρ σ’ ἔδρασεν, ὥστε καὶ βλάβην ἔχειν;</l>
 				</sp>
@@ -2442,7 +2442,7 @@ antilabe in all files
 					<l>οὔ φησ’ ἐάσειν τόνδε τὸν νεκρὸν ταφῆς</l>
 					<l>ἄμοιρον, ἀλλὰ πρὸς βίαν θάψειν  ἐμοῦ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἔξεστιν οὖν εἰπόντι τἀληθῆ φίλῳ</l>
 					<l>σοὶ μηδὲν ἧσσον ἢ πάρος ξυνηρετεῖν;</l>
@@ -2452,7 +2452,7 @@ antilabe in all files
 					<l n="1330">εἴπ’· ἦ γὰρ εἴην οὐκ ἂν εὖ φρονῶν, ἐπεὶ</l>
 					<l>φίλον σ’ ἐγὼ μέγιστον Ἀργείων νέμω.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἄκουέ νυν.  τὸν ἄνδρα τόνδε πρὸς θεῶν</l>
 					<l>μὴ τλῇς ἄθαπτον ὧδ’ ἀναλγήτως βαλεῖν·</l>
@@ -2474,7 +2474,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>σὺ ταῦτ’, Ὀδυσσεῦ, τοῦδ’ ὑπερμαχεῖς ἐμοί;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἔγωγ’· ἐμίσουν δ’, ἡνίκ’ ἦν μισεῖν καλόν.</l>
 				</sp>
@@ -2482,7 +2482,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>οὐ γὰρ θανόντι καὶ προσεμβῆναί σε χρή;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>μὴ χαῖρ’, Ἀτρείδη, κέρδεσιν τοῖς μὴ καλοῖς.</l>
 				</sp>
@@ -2490,7 +2490,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l n="1350">τόν τοι τύραννον εὐσεβεῖν οὐ ῥᾴδιον.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἀλλ’ εὖ λέγουσι τοῖς φίλοις τιμὰς νέμειν.</l>
 				</sp>
@@ -2498,7 +2498,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>κλύειν τὸν ἐσθλὸν ἄνδρα χρὴ τῶν ἐν τέλει.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>παῦσαι· κρατεῖς τοι τῶν φίλων νικώμενος.</l>
 				</sp>
@@ -2506,7 +2506,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>μέμνησ’ ὁποίῳ φωτὶ τὴν χάριν δίδως.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1355">ὅδ’ ἐχθρὸς ἁνήρ, ἀλλὰ γενναῖός ποτ’ ἦν.</l>
 				</sp>
@@ -2514,7 +2514,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>τί ποτε ποήσεις; ἐχθρὸν ὧδ’ αἰδεῖ νέκυν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>νικᾷ γὰρ ἁρετή με τῆς ἔχθρας πολύ.</l>
 				</sp>
@@ -2522,7 +2522,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>τοιοίδε μέντοι φῶτες ἔμπληκτοι βροτῶν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἦ κάρτα πολλοὶ νῦν φίλοι καὖθις πικροί.</l>
 				</sp>
@@ -2530,7 +2530,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l n="1360">τοιούσδ’ ἐπαινεῖς δῆτα σὺ κτᾶσθαι φίλους;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>σκληρὰν ἐπαινεῖν οὐ φιλῶ ψυχὴν ἐγώ.</l>
 				</sp>
@@ -2538,7 +2538,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>ἡμᾶς σὺ δειλοὺς τῇδε θἠμέρᾳ φανεῖς.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἄνδρας μὲν οὖν Ἕλλησι πᾶσιν ἐνδίκους.</l>
 				</sp>
@@ -2546,7 +2546,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>ἄνωγας οὖν με τὸν νεκρὸν θάπτειν ἐᾶν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1365">ἔγωγε· καὶ γὰρ αὐτὸς ἐνθάδ’ ἵξομαι.</l>
 				</sp>
@@ -2554,7 +2554,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>ἦ πάνθ’ ὅμοια πᾶς ἀνὴρ αὑτῷ πονεῖ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τῷ γάρ με μᾶλλον εἰκὸς ἢ ’μαυτῷ πονεῖν;</l>
 				</sp>
@@ -2562,7 +2562,7 @@ antilabe in all files
 					<speaker>Ἀγαμέμνων</speaker>
 					<l>σὸν ἆρα τοὔργον, οὐκ ἐμὸν κεκλήσεται.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ὡς ἂν ποήσῃς, πανταχῇ χρηστός γ’ ἔσει.</l>
 				</sp>
@@ -2573,13 +2573,13 @@ antilabe in all files
 					<l>οὗτος δὲ κἀκεῖ κἀνθάδ’ ὢν ἔμοιγ’ ὁμῶς</l>
 					<l>ἔχθιστος ἔσται· σοὶ δὲ δρᾶν ἔξεσθ’ ἃ χρῇς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅστις σ’, Ὀδυσσεῦ, μὴ λέγει γνώμῃ σοφὸν</l>
 					<l n="1375">φῦναι, τοιοῦτον ὄντα, μῶρός ἐστ’ ἀνήρ.</l>
 					<milestone ed="p" n="1376" unit="card"/>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>καὶ νῦν γε Τεύκρῳ τἀπὸ τοῦδ’ ἀγγέλλομαι,</l>
 					<l>ὅσον τότ’ ἐχθρὸς ἦ, τοσόνδ’ εἶναι φίλος.</l>
@@ -2587,7 +2587,7 @@ antilabe in all files
 					<l>καὶ ξυμπονεῖν καὶ μηδὲν ἐλλείπειν ὅσων</l>
 					<l n="1380">χρὴ τοῖς ἀρίστοις ἀνδράσιν πονεῖν βροτούς.</l>
 				</sp>
-				<sp who="#teykros">
+				<sp who="#teukros">
 					<speaker>Τεῦκρος</speaker>
 					<l>ἄριστ’ Ὀδυσσεῦ, πάντ’ ἔχω σ’ ἐπαινέσαι</l>
 					<l>λόγοισι, καί μ’ ἔψευσας ἐλπίδος πολύ.</l>
@@ -2609,13 +2609,13 @@ antilabe in all files
 					<l>ἐγὼ δὲ τἄλλα πάντα πορσυνῶ· σὺ δὲ</l>
 					<l>ἀνὴρ καθ’ ἡμᾶς ἐσθλὸς ὢν ἐπίστασο.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1400">ἀλλ’ ἤθελον μέν· εἰ δὲ μή ’στί σοι φίλον</l>
 					<l>πράσσειν τάδ’ ἡμᾶς, εἶμ’ ἐπαινέσας τὸ σόν.</l>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#teykros">
+					<sp who="#teukros">
 						<speaker>Τεῦκρος</speaker>
 						<l>ἅλις· ἤδη γὰρ πολὺς ἐκτέταται</l>
 						<l>χρόνος.  ἀλλ’ οἱ μὲν κοίλην κάπετον</l>
@@ -2634,7 +2634,7 @@ antilabe in all files
 						<l>κοὐδενί πω λῴονι θνητῶν</l>
 						<l>[Αἴαντος, ὅτ’ ἦν, τότε φωνῶ.]</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ πολλὰ βροτοῖς ἔστιν ἰδοῦσιν</l>
 						<l n="1420">γνῶναι· πρὶν ἰδεῖν δ’ οὐδεὶς μάντις</l>

--- a/tei/sophocles-antigone.xml
+++ b/tei/sophocles-antigone.xml
@@ -52,19 +52,19 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="fylaks">
+					<person xml:id="phylax">
 						<persName>Φύλαξ</persName>
 					</person>
-					<person xml:id="eksaggelos">
+					<person xml:id="exangelos">
 						<persName>Ἐξάγγελος</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
 					<person xml:id="teiresias">
 						<persName>Τειρεσίας</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="ismene">
@@ -76,10 +76,10 @@
 					<person xml:id="antigone">
 						<persName>Ἀντιγόνη</persName>
 					</person>
-					<person xml:id="aimon">
+					<person xml:id="haimon">
 						<persName>Αἵμων</persName>
 					</person>
-					<person xml:id="eyrydike">
+					<person xml:id="eurydike">
 						<persName>Εὐρυδίκη</persName>
 					</person>
 				</listPerson>
@@ -391,7 +391,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="100">ἀκτὶς ἀελίου, τὸ κάλλιστον ἑπταπύλῳ φανὲν</l>
 						<l>Θήβᾳ τῶν προτέρων φάος,</l>
@@ -404,7 +404,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="110">ὃς ἐφ’ ἡμετέρᾳ γᾷ  Πολυνείκους</l>
 						<l>ἀρθεὶς νεικέων ἐξ ἀμφιλόγων</l>
@@ -417,7 +417,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ξύν θ’  ἱπποκόμοις κορύθεσσιν.</l>
 						<l>στὰς δ’ ὑπὲρ μελάθρων φονώσαισιν ἀμφιχανὼν κύκλῳ</l>
@@ -430,7 +430,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ζεὺς γὰρ μεγάλης γλώσσης κόμπους</l>
 						<l>ὑπερεχθαίρει, καὶ σφας ἐσιδὼν</l>
@@ -443,7 +443,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀντιτύπᾳ δ’  ἐπὶ γᾷ πέσε τανταλωθεὶς</l>
 						<l n="135">πυρφόρος, ὃς τότε μαινομένᾳ ξὺν ὁρμᾷ</l>
@@ -456,7 +456,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἑπτὰ λοχαγοὶ γὰρ ἐφ’ ἑπτὰ πύλαις</l>
 						<l>ταχθέντες ἴσοι πρὸς ἴσους ἔλιπον</l>
@@ -469,7 +469,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ γὰρ ἁ μεγαλώνυμος ἦλθε Νίκα</l>
 						<l>τᾷ πολυαρμάτῳ ἀντιχαρεῖσα Θήβᾳ,</l>
@@ -482,7 +482,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="155">ἀλλ’ ὅδε γὰρ δὴ βασιλεὺς χώρας,</l>
 						<l>Κρέων ὁ Μενοικέως [ἄρχων] νεοχμὸς</l>
@@ -549,7 +549,7 @@ antilabe in all files
 					<l n="210">καὶ ζῶν ὁμοίως ἐξ ἐμοῦ τιμήσεται.</l>
 					<milestone ed="p" n="211" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σοὶ ταῦτ’ ἀρέσκει, παῖ Μενοικέως Κρέον,</l>
 					<l>τὸν τῇδε δύσνουν κἀς τὸν εὐμενῆ πόλει·</l>
@@ -560,7 +560,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l n="215">ὡς ἂν σκοποὶ νῦν εἴτε τῶν εἰρημένων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>νεωτέρῳ τῳ τοῦτο βαστάζειν πρόθες.</l>
 				</sp>
@@ -568,7 +568,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ἀλλ’ εἴσ’ ἑτοῖμοι τοῦ νεκροῦ γ’ ἐπίσκοποι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δῆτ’ ἂν ἄλλο τοῦτ’ ἐπεντέλλοις ἔτι;</l>
 				</sp>
@@ -576,7 +576,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>τὸ μὴ ’πιχωρεῖν τοῖς ἀπιστοῦσιν τάδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="220">οὔκ ἔστιν οὕτω μῶρος ὃς θανεῖν ἐρᾷ.</l>
 				</sp>
@@ -585,7 +585,7 @@ antilabe in all files
 					<l>καὶ μὴν ὁ μισθός γ’, οὗτος·  ἀλλ’ ὑπ’ ἐλπίδων</l>
 					<l>ἄνδρας τὸ κέρδος πολλάκις διώλεσεν.</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>ἄναξ, ἐρῶ μὲν οὐχ ὅπως τάχους ὕπο</l>
 					<l>δύσπνους ἱκάνω κοῦφον ἐξάρας πόδα.</l>
@@ -607,7 +607,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>τί δ’ ἐστὶν ἀνθ’ οὗ τήνδ’ ἔχεις ἀθυμίαν;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>φράσαι θέλω σοι πρῶτα τἀμαυτοῦ· τὸ γὰρ</l>
 					<l>πρᾶγμ’ οὔτ’ ἔδρασ’ οὔτ’ εἶδον ὅστις ἦν ὁ δρῶν,</l>
@@ -618,7 +618,7 @@ antilabe in all files
 					<l>εὖ γε στοχάζει κἀποφάργνυσαι κύκλῳ</l>
 					<l>τὸ πρᾶγμα·  δηλοῖς δ’ ὥς τι σημανῶν νέον.</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>τὰ δεινὰ γάρ τοι προστίθησ’ ὄκνον πολύν.</l>
 				</sp>
@@ -626,7 +626,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>οὔκουν ἐρεῖς ποτ’, εἶτ’ ἀπαλλαχθεὶς ἄπει;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l n="245">καὶ δὴ λέγω σοι.  τὸν νεκρόν τις ἀρτίως</l>
 					<l>θάψας βέβηκε κἀπὶ χρωτὶ διψίαν</l>
@@ -636,7 +636,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>τί φής; τίς ἀνδρῶν ἦν ὁ τολμήσας τάδε;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>οὐκ οἶδ’·  ἐκεῖ γὰρ οὔτε του γενῇδος ἦν</l>
 					<l n="250">πλῆγμ’, οὐ δικέλλης ἐκβολή.  στύφλος δὲ γῆ</l>
@@ -669,7 +669,7 @@ antilabe in all files
 					<l>στέργει γὰρ οὐδεὶς ἄγγελον κακῶν ἐπῶν.</l>
 					<milestone ed="p" n="278" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄναξ, ἐμοί τοί, μή τι καὶ θεήλατον</l>
 					<l>τοὔργον τόδ’, ἡ ξύννοια βουλεύει πάλαι</l>
@@ -713,7 +713,7 @@ antilabe in all files
 					<l>ἀτωμένους ἴδοις ἂν ἢ σεσωσμένους.</l>
 					<milestone ed="p" n="315" unit="card"/>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l n="315">εἰπεῖν τι δώσεις ἢ στραφεὶς οὕτως ἴω;</l>
 				</sp>
@@ -721,7 +721,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>οὐκ οἶσθα καὶ νῦν ὡς ἀνιαρῶς λέγεις;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>ἐν τοῖσιν ὠσὶν ἢ ’πὶ τῇ ψυχῇ δάκνει;</l>
 				</sp>
@@ -729,7 +729,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>τί δὲ ῥυθμίζεις τὴν ἐμὴν λύπην ὅπου;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>ὁ δρῶν σ’ ἀνιᾷ τὰς φρένας, τὰ δ’ ὦτ’ ἐγώ.</l>
 				</sp>
@@ -737,7 +737,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l n="320">οἴμ’  ὡς λάλημα δῆλον ἐκπεφυκὸς εἶ.</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>οὔκουν τό γ’ ἔργον τοῦτο ποιήσας ποτέ.</l>
 				</sp>
@@ -745,7 +745,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>καὶ ταῦτ’ ἐπ’ ἀργύρῳ γε τὴν ψυχὴν προδούς.</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l part="Y">φεῦ·</l>
 					<l>ἦ δεινὸν ᾧ δοκῇ γε καὶ ψευδῆ δοκεῖν.</l>
@@ -756,7 +756,7 @@ antilabe in all files
 					<l n="325">φανεῖτέ μοι τοὺς δρῶντας, ἐξερεῖθ’ ὅτι</l>
 					<l>τὰ δειλὰ κέρδη πημονὰς ἐργάζεται.</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>ἀλλ’ εὑρεθείη μὲν μάλιστ’·  ἐὰν δέ τοι</l>
 					<l>ληφθῇ τε καὶ μή, τοῦτο γὰρ τύχη κρινεῖ,</l>
@@ -768,7 +768,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλὰ τὰ δεινὰ κοὐδὲν ἀνθρώπου δεινότερον πέλει.</l>
 						<l n="335">τοῦτο καὶ πολιοῦ πέραν πόντου χειμερίῳ νότῳ</l>
@@ -782,7 +782,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κουφονόων τε φῦλον ὀρνίθων ἀμφιβαλὼν ἄγει</l>
 						<l n="345">καὶ θηρῶν ἀγρίων ἔθνη πόντου τ’ εἰναλίαν φύσιν</l>
@@ -796,7 +796,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="355">καὶ φθέγμα καὶ ἀνεμόεν φρόνημα καὶ ἀστυνόμους</l>
 						<l>ὀργὰς ἐδιδάξατο καὶ δυσαύλων</l>
@@ -808,7 +808,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="365">σοφόν τι τὸ μηχανόεν τέχνας ὑπὲρ ἐλπίδ’ ἔχων</l>
 						<l>τοτὲ μὲν κακόν, ἄλλοτ’ ἐπ’ ἐσθλὸν ἕρπει,</l>
@@ -820,7 +820,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐς δαιμόνιον τέρας ἀμφινοῶ</l>
 						<l>τόδε·  πῶς εἰδὼς ἀντιλογήσω</l>
@@ -835,12 +835,12 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>ἥδ’ ἔστ’ ἐκείνη τοὔργον ἡ ’ξειργασμένη·</l>
 					<l n="385">τήνδ’ εἵλομεν θάπτουσαν.  ἀλλὰ ποῦ Κρέων;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅδ’ ἐκ δόμων ἄψορρος εἰς δέον περᾷ.</l>
 				</sp>
@@ -848,7 +848,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>τί δ’ ἔστι; ποίᾳ ξύμμετρος προὔβην τύχῃ;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>ἄναξ, βροτοῖσιν οὐδέν ἔστ’ ἀπώμοτον.</l>
 					<l>ψεύδει γὰρ ἡ ’πίνοια τὴν γνώμην·  ἐπεὶ</l>
@@ -868,7 +868,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ἄγεις δὲ τήνδε τῷ τρόπῳ πόθεν λαβών;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>αὕτη τὸν ἄνδρ’ ἔθαπτε·  πάντ’ ἐπίστασαι.</l>
 				</sp>
@@ -876,7 +876,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ἦ καὶ ξυνίης καὶ λέγεις ὀρθῶς ἃ φῄς;</l>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>ταύτην γ’ ἰδὼν θάπτουσαν ὃν σὺ τὸν νεκρὸν</l>
 					<l n="405">ἀπεῖπας.  ἆρ’ ἔνδηλα καὶ σαφῆ λέγω;</l>
@@ -886,7 +886,7 @@ antilabe in all files
 					<l>καὶ πῶς ὁρᾶται κἀπίληπτος ᾑρέθη;</l>
 					<milestone ed="p" n="407" unit="card"/>
 				</sp>
-				<sp who="#fylaks">
+				<sp who="#phylax">
 					<speaker>Φύλαξ</speaker>
 					<l>τοιοῦτον ἦν τὸ πρᾶγμ’.  ὅπως γὰρ ἥκομεν,</l>
 					<l>πρὸς σοῦ τὰ δείν’ ἐκεῖν’ ἐπηπειλημένοι,</l>
@@ -973,7 +973,7 @@ antilabe in all files
 					<l n="470">σχεδόν τι μώρῳ μωρίαν ὀφλισκάνω.</l>
 					<milestone ed="p" n="471" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δηλοῖ τὸ γέννημ’ ὠμὸν ἐξ ὠμοῦ πατρὸς</l>
 					<l>τῆς παιδός.  εἴκειν δ’ οὐκ ἐπίσταται κακοῖς.</l>
@@ -1097,7 +1097,7 @@ antilabe in all files
 					<milestone ed="p" n="526" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν πρὸ πυλῶν ἥδ’ Ἰσμήνη,</l>
 						<l>φιλάδελφα κάτω δάκρῡ εἰβομένη·</l>
@@ -1240,7 +1240,7 @@ antilabe in all files
 						<speaker>Κρέων</speaker>
 						<l>ἄγαν γε λυπεῖς καὶ σὺ καὶ τὸ σὸν λέχος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ γὰρ στερήσεις τῆσδε τὸν σαυτοῦ γόνον;</l>
 					</sp>
@@ -1248,7 +1248,7 @@ antilabe in all files
 						<speaker>Κρέων</speaker>
 						<l n="575">Ἅιδης ὁ παύσων τούσδε τοὺς γάμους ἔφυ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεδογμέν’, ὡς ἔοικε, τήνδε κατθανεῖν.</l>
 					</sp>
@@ -1265,7 +1265,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐδαίμονες οἷσι κακῶν ἄγευστος αἰών.</l>
 						<l>οἷς γὰρ ἂν σεισθῇ θεόθεν δόμος, ἄτας</l>
@@ -1278,7 +1278,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀρχαῖα τὰ Λαβδακιδᾶν οἴκων ὁρῶμαι</l>
 						<l n="595">πήματα φθιτῶν ἐπὶ πήμασι πίπτοντ’,</l>
@@ -1291,7 +1291,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="605">τεάν, Ζεῦ, δύνασιν τίς ἀνδρῶν ὑπερβασία κατάσχοι;</l>
 						<l>τὰν οὔθ’ ὕπνος αἱρεῖ ποθ’ ὁ πάντ’ ἀγρεύων,</l>
@@ -1305,7 +1305,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="615">ἁ γὰρ δὴ πολύπλαγκτος ἐλπὶς πολλοῖς μὲν ὄνασις ἀνδρῶν,</l>
 						<l>πολλοῖς δ’ ἀπάτα κουφονόων ἐρώτων·</l>
@@ -1315,7 +1315,7 @@ antilabe in all files
 						<l>τῷδ’ ἔμμεν ὅτῳ φρένας</l>
 						<l>θεὸς ἄγει πρὸς ἄταν·</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="625">πράσσει δ’ ὀλίγιστον χρόνον ἐκτὸς ἄτας.</l>
 						<milestone ed="p" n="626" unit="card"/>
@@ -1339,7 +1339,7 @@ antilabe in all files
 					<l>τῆς μελλονύμφου πατρὶ λυσσαίνων πάρει;</l>
 					<l>ἢ σοὶ μὲν ἡμεῖς πανταχῇ, δρῶντες φίλοι;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l n="635">πάτερ, σός εἰμι, καὶ σύ μοι γνώμας ἔχων</l>
 					<l>χρηστὰς ἀπορθοῖς, αἷς ἔγωγ’ ἐφέψομαι.</l>
@@ -1392,12 +1392,12 @@ antilabe in all files
 					<l n="680">κοὐκ ἂν γυναικῶν ἥσσονες καλοίμεθ’  ἄν.</l>
 					<milestone ed="p" n="681" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμῖν μέν, εἰ μὴ τῷ χρόνῳ κεκλέμμεθα,</l>
 					<l>λέγειν φρονούντως ὧν λέγεις δοκεῖς πέρι.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>πάτερ, θεοὶ φύουσιν ἀνθρώποις φρένας,</l>
 					<l>πάντων ὅσ’ ἐστὶ κτημάτων ὑπέρτατον.</l>
@@ -1442,7 +1442,7 @@ antilabe in all files
 					<l>καὶ τῶν λεγόντων εὖ καλὸν τὸ μανθάνειν.</l>
 					<milestone ed="p" n="724" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄναξ, σέ τ’ εἰκός, εἴ τι καίριον λέγει,</l>
 					<l n="725">μαθεῖν, σέ τ’ αὖ τοῦδ’·  εὖ γὰρ εἴρηται διπλῇ.</l>
@@ -1452,7 +1452,7 @@ antilabe in all files
 					<l>οἱ τηλικοίδε καὶ διδαξόμεσθα δὴ</l>
 					<l>φρονεῖν ὑπ’ ἀνδρὸς  τηλικοῦδε τὴν φύσιν;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>μηδὲν τὸ μὴ δίκαιον·  εἰ δ’ ἐγὼ νέος,</l>
 					<l>οὐ τὸν χρόνον χρὴ μᾶλλον ἢ τἄργα σκοπεῖν.</l>
@@ -1461,7 +1461,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l n="730">ἔργον γάρ ἐστι τοὺς ἀκοσμοῦντας σέβειν;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>οὐδ’ ἂν κελεύσαιμ’, εὐσεβεῖν εἰς τοὺς κακούς.</l>
 				</sp>
@@ -1469,7 +1469,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>οὐχ ἥδε γὰρ τοιᾷδ’ ἐπείληπται νόσῳ;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>οὔ φησι Θήβης τῆσδ’ ὁμόπτολις λεώς.</l>
 				</sp>
@@ -1477,7 +1477,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>πόλις γὰρ ἡμῖν ἁμὲ χρὴ τάσσειν ἐρεῖ;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l n="735">ὁρᾷς τόδ’ ὡς εἴρηκας ὡς ἄγαν νέος;</l>
 				</sp>
@@ -1485,7 +1485,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ἄλλῳ γὰρ ἢ ’μοὶ χρή με τῆσδ’ ἄρχειν χθονός;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>πόλις γὰρ οὐκ ἔσθ’ ἥτις ἀνδρός ἐσθ’ ἑνός.</l>
 				</sp>
@@ -1493,7 +1493,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>οὐ τοῦ κρατοῦντος ἡ πόλις νομίζεται;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>καλῶς γ’ ἐρήμης ἂν   σὺ γῆς ἄρχοις μόνος.</l>
 				</sp>
@@ -1501,7 +1501,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l n="740">ὅδ’, ὡς ἔοικε, τῇ γυναικὶ συμμαχεῖ.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>εἴπερ γυνὴ σύ.  σοῦ γὰρ οὖν προκήδομαι.</l>
 				</sp>
@@ -1509,7 +1509,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ὦ παγκάκιστε, διὰ δίκης ἰὼν πατρί;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>οὐ γὰρ δίκαιά σ’  ἐξαμαρτάνονθ’ ὁρῶ.</l>
 				</sp>
@@ -1517,7 +1517,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ἁμαρτάνω γὰρ τὰς ἐμὰς ἀρχὰς σέβων;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l n="745">οὐ γὰρ σέβεις τιμάς γε τὰς θεῶν πατῶν.</l>
 				</sp>
@@ -1525,7 +1525,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ὦ μιαρὸν ἦθος καὶ γυναικὸς ὕστερον.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>οὔ τἂν ἕλοις ἥσσω γε τῶν αἰσχρῶν ἐμέ.</l>
 				</sp>
@@ -1533,7 +1533,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ὁ γοῦν λόγος σοι  πᾶς ὑπὲρ κείνης ὅδε.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>καὶ σοῦ γε κἀμοῦ, καὶ θεῶν τῶν νερτέρων.</l>
 				</sp>
@@ -1541,7 +1541,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l n="750">ταύτην ποτ’  οὐκ ἔσθ’  ὡς ἔτι ζῶσαν γαμεῖς.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>ἣ δ’ οὖν θανεῖται καὶ θανοῦσ’ ὀλεῖ τινα.</l>
 				</sp>
@@ -1549,7 +1549,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>ἦ κἀπαπειλῶν ὧδ’ ἐπεξέρχει θρασύς;</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>τίς δ’ ἔστ’ ἀπειλὴ πρὸς κενὰς γνώμας λέγειν;</l>
 				</sp>
@@ -1557,7 +1557,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>κλαίων φρενώσεις, ὢν φρενῶν αὐτὸς κενός.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l n="755">εἰ μὴ πατὴρ ἦσθ’, εἶπον ἄν σ’ οὐκ εὖ φρονεῖν.</l>
 				</sp>
@@ -1565,7 +1565,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>γυναικὸς ὢν δούλευμα μὴ κώτιλλέ με.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>βούλει λέγειν τι καὶ λέγων μηδὲν κλύειν;</l>
 					<milestone ed="p" n="758" unit="card"/>
@@ -1577,14 +1577,14 @@ antilabe in all files
 					<l n="760">ἄγαγε τὸ μῖσος  ὡς κατ’  ὄμματ’  αὐτίκα</l>
 					<l>παρόντι θνῄσκῃ πλησία τῷ νυμφίῳ.</l>
 				</sp>
-				<sp who="#aimon">
+				<sp who="#haimon">
 					<speaker>Αἵμων</speaker>
 					<l>οὐ δῆτ’ ἔμοιγε, τοῦτο μὴ δόξῃς ποτέ,</l>
 					<l>οὔθ’ ἥδ’ ὀλεῖται πλησία, σύ τ’ οὐδαμὰ</l>
 					<l>τοὐμὸν προσόψει κρᾶτ’ ἐν ὀφθαλμοῖς ὁρῶν,</l>
 					<l n="765">ὡς τοῖς θέλουσι τῶν φίλων μαίνῃ συνών.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἁνήρ, ἄναξ, βέβηκεν ἐξ ὀργῆς ταχύς·</l>
 					<l>νοῦς δ’ ἐστὶ τηλικοῦτος ἀλγήσας βαρύς.</l>
@@ -1594,7 +1594,7 @@ antilabe in all files
 					<l>δράτω·  φρονείτω μεῖζον ἢ κατ’ ἄνδρ’ ἰών·</l>
 					<l>τὼ δ’ οὖν κόρα τώδ’ οὐκ ἀπαλλάξει μόρου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="770">ἄμφω γὰρ αὐτὼ καὶ κατακτεῖναι νοεῖς;</l>
 				</sp>
@@ -1602,7 +1602,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>οὐ τήν γε μὴ θιγοῦσαν·  εὖ γὰρ οὖν λέγεις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μόρῳ δὲ ποίῳ καί σφε βουλεύει κτανεῖν;</l>
 				</sp>
@@ -1621,7 +1621,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ἔρως ἀνίκατε μάχαν, Ἔρως, ὃς ἐν κτήμασι πίπτεις,</l>
 						<l>ὃς ἐν μαλακαῖς παρειαῖς νεάνιδος ἐννυχεύεις,</l>
@@ -1632,7 +1632,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὺ καὶ δικαίων ἀδίκους φρένας παρασπᾷς ἐπὶ λώβᾳ,</l>
 						<l>σὺ καὶ τόδε νεῖκος ἀνδρῶν ξύναιμον ἔχεις ταράξας·</l>
@@ -1643,7 +1643,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν δ’ ἤδη ’γὼ καὐτὸς θεσμῶν</l>
 						<l>ἔξω φέρομαι τάδ’ ὁρῶν ἴσχειν δ’</l>
@@ -1668,7 +1668,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκοῦν κλεινὴ καὶ ἔπαινον ἔχουσ’</l>
 						<l>ἐς τόδ’ ἀπέρχει κεῦθος νεκύων,</l>
@@ -1692,7 +1692,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλὰ θεός τοι καὶ θεογεννής,</l>
 						<l n="835">ἡμεῖς δὲ βροτοὶ καὶ θνητογενεῖς.</l>
@@ -1718,7 +1718,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>προβᾶσ’ ἐπ’ ἔσχατον θράσους</l>
 						<l>ὑψηλὸν ἐς Δίκας βάθρον</l>
@@ -1743,7 +1743,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σέβειν μὲν εὐσέβειά τις,</l>
 						<l>κράτος δ’ ὅτῳ κράτος μέλει</l>
@@ -1820,7 +1820,7 @@ antilabe in all files
 					<milestone ed="p" n="929" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔτι τῶν αὐτῶν ἀνέμων αὑταὶ</l>
 						<l n="930">ψυχῆς ῥιπαὶ τήνδε γ’  ἔχουσιν.</l>
@@ -1835,7 +1835,7 @@ antilabe in all files
 						<l>οἴμοι, θανάτου τοῦτ’ ἐγγυτάτω</l>
 						<l>τοὔπος ἀφῖκται.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="935">θαρσεῖν οὐδὲν παραμυθοῦμαι</l>
 						<l>μὴ οὐ τάδε ταύτῃ κατακυροῦσθαι.</l>
@@ -1855,7 +1855,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔτλα καὶ Δανάας οὐράνιον φῶς</l>
 						<l n="945">ἀλλάξαι δέμας ἐν χαλκοδέτοις αὐλαῖς·</l>
@@ -1869,7 +1869,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="955">ζεύχθη δ’   ὀξύχολος παῖς ὁ Δρύαντος,</l>
 						<l>Ἠδωνῶν βασιλεύς, κερτομίοις ὀργαῖς</l>
@@ -1883,7 +1883,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παρὰ δὲ κυανεᾶν πελάγει διδύμας ἁλὸς</l>
 						<l>ἀκταὶ Βοσπόριαι ἥδ’ ὁ Θρῃκῶν ἄξενος</l>
@@ -1898,7 +1898,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κατὰ δὲ τακόμενοι μέλεοι μελέαν πάθαν</l>
 						<l n="980">κλαῖον, ματρὸς ἔχοντες ἀνύμφευτον γονάν·</l>
@@ -2102,7 +2102,7 @@ antilabe in all files
 					<l n="1090">τὸν νοῦν τ’  ἀμείνω τῶν φρενῶν ἢ νῦν φέρει.</l>
 					<milestone ed="p" n="1091" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἁνήρ, ἄναξ, βέβηκε δεινὰ θεσπίσας·</l>
 					<l>ἐπιστάμεσθα δ’, ἐξ ὅτου λευκὴν ἐγὼ</l>
@@ -2115,7 +2115,7 @@ antilabe in all files
 					<l>τό τ’ εἰκαθεῖν γὰρ δεινόν, ἀντιστάντα δὲ</l>
 					<l>ἄτῃ πατάξαι θυμὸν ἐν δεινῷ πάρα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εὐβουλίας  δεῖ, παῖ Μενοικέως, λαβεῖν.</l>
 				</sp>
@@ -2123,7 +2123,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>τί δῆτα χρὴ δρᾶν; φράζε.  πείσομαι δ’ ἐγώ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1100">ἐλθὼν κόρην μὲν ἐκ κατώρυχος στέγης</l>
 					<l>ἄνες, κτίσον δὲ τῷ προκειμένῳ, τάφον.</l>
@@ -2132,7 +2132,7 @@ antilabe in all files
 					<speaker>Κρέων</speaker>
 					<l>καὶ ταῦτ’  ἐπαινεῖς καὶ δοκεῖς  παρεικαθεῖν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅσον γ’, ἄναξ, τάχιστα·  συντέμνουσι γὰρ</l>
 					<l>θεῶν ποδώκεις τοὺς κακόφρονας βλάβαι.</l>
@@ -2142,7 +2142,7 @@ antilabe in all files
 					<l n="1105">οἴμοι·  μόλις μέν,    καρδίας δ’ ἐξίσταμαι</l>
 					<l>τὸ δρᾶν·   ἀνάγκῃ δ’ οὐχὶ δυσμαχητέον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δρᾶ νυν τάδ’ ἐλθὼν μηδ’ ἐπ’ ἄλλοισιν τρέπε.</l>
 				</sp>
@@ -2160,7 +2160,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1115">πολυώνυμε, Καδμείας νύμφας ἄγαλμα</l>
 						<l>καὶ Διὸς βαρυβρεμέτα</l>
@@ -2175,7 +2175,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σὲ δ’ ὑπὲρ διλόφου πέτρας στέροψ ὄπωπε</l>
 						<l>λιγνύς, ἔνθα Κωρύκιαι</l>
@@ -2190,7 +2190,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὰν ἐκ πᾶσαι τιμᾷς ὑπερτάταν πόλεων</l>
 						<l>ματρὶ σὺν κεραυνίᾳ·</l>
@@ -2202,7 +2202,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ πῦρ πνειόντων χοράγ’ ἄστρων, νυχίων</l>
 						<l>φθεγμάτων ἐπίσκοπε,</l>
@@ -2215,7 +2215,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1155">Κάδμου πάροικοι καὶ δόμων Ἀμφίονος,</l>
 					<l>οὐκ ἔσθ’ ὁποῖον στάντ’ ἂν ἀνθρώπου βίον</l>
@@ -2235,46 +2235,46 @@ antilabe in all files
 					<l n="1170">τούτων τὸ χαίρειν, τἄλλ’ ἐγὼ καπνοῦ σκιᾶς</l>
 					<l>οὐκ ἂν πριαίμην ἀνδρὶ πρὸς τὴν ἡδονήν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’ αὖ τόδ’ ἄχθος βασιλέων ἥκεις φέρων;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τεθνᾶσιν.  οἱ δὲ ζῶντες αἴτιοι θανεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ τίς φονεύει; τίς δ’ ὁ κείμενος; λέγε.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1175">Αἵμων ὄλωλεν·  αὐτόχειρ δ’ αἱμάσσεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πότερα πατρῴας ἢ πρὸς οἰκείας χερός;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>αὐτὸς πρὸς αὑτοῦ, πατρὶ μηνίσας φόνου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ μάντι, τοὔπος ὡς ἄρ’ ὀρθὸν ἤνυσας.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὡς ὧδ’ ἐχόντων τἄλλα βουλεύειν πάρα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1180">καὶ μὴν ὁρῶ τάλαιναν Εὐρυδίκην ὁμοῦ</l>
 					<l>δάμαρτα τὴν Κρέοντος.  ἐκ δὲ δωμάτων</l>
 					<l>ἤτοι κλύουσα παιδὸς ἢ τύχῃ πάρα.</l>
 					<milestone ed="p" n="1183" unit="card"/>
 				</sp>
-				<sp who="#eyrydike">
+				<sp who="#eurydike">
 					<speaker>Εὐρυδίκη</speaker>
 					<l>ὦ πάντες ἀστοί, τῶν λόγων ἐπῃσθόμην</l>
 					<l>πρὸς ἔξοδον στείχουσα, Παλλάδος θεᾶς</l>
@@ -2286,7 +2286,7 @@ antilabe in all files
 					<l n="1190">ἀλλ’  ὅστις ἦν ὁ μῦθος αὖθις εἴπατε·</l>
 					<l>κακῶν γὰρ οὐκ ἄπειρος οὖσ’ ἀκούσομαι.</l>
 				</sp>
-				<sp n="Ἄγγελος" who="#aggelos">
+				<sp n="Ἄγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐγώ, φίλη δέσποινα, καὶ παρὼν ἐρῶ</l>
 					<l>κοὐδὲν παρήσω τῆς ἀληθείας ἔπος.</l>
@@ -2343,12 +2343,12 @@ antilabe in all files
 					<l>ὅσῳ μέγιστον ἀνδρὶ πρόσκειται κακόν.</l>
 				</sp>
 				<milestone ed="p" n="1244" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί τοῦτ’ ἂν εἰκάσειας; ἡ γυνὴ πάλιν</l>
 					<l n="1245">φρούδη, πρὶν εἰπεῖν ἐσθλὸν ἢ κακὸν λόγον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>καὐτὸς τεθάμβηκ’·  ἐλπίσιν δὲ βόσκομαι</l>
 					<l>ἄχη τέκνου κλύουσαν ἐς πόλιν γόους</l>
@@ -2356,12 +2356,12 @@ antilabe in all files
 					<l>δμωαῖς προθήσειν πένθος οἰκεῖον στένειν.</l>
 					<l n="1250">γνώμης γὰρ οὐκ ἄπειρος, ὥσθ’  ἁμαρτάνειν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ οἶδ’·  ἐμοὶ δ’ οὖν ἥ τ’ ἄγαν σιγὴ βαρὺ</l>
 					<l>δοκεῖ προσεῖναι χἠ μάτην πολλὴ βοή.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἀλλ’ εἰσόμεσθα, μή τι καὶ κατάσχετον</l>
 					<l>κρυφῇ καλύπτει καρδίᾳ θυμουμένῃ,</l>
@@ -2370,7 +2370,7 @@ antilabe in all files
 					<milestone ed="p" n="1257" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν ὅδ’ ἄναξ αὐτὸς ἐφήκει</l>
 						<l>μνῆμ’ ἐπίσημον διὰ χειρὸς ἔχων,</l>
@@ -2398,7 +2398,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1270">οἴμ’  ὡς ἔοικας ὀψὲ τὴν δίκην ἰδεῖν.</l>
 					</sp>
@@ -2412,7 +2412,7 @@ antilabe in all files
 						<l>φεῦ φεῦ, ὦ πόνοι βροτῶν δύσπονοι.</l>
 						<milestone ed="p" n="1278" unit="card"/>
 					</sp>
-					<sp who="#eksaggelos">
+					<sp who="#exangelos">
 						<speaker>Ἐξάγγελος</speaker>
 						<l>ὦ δέσποθ’, ὡς ἔχων τε καὶ κεκτημένος,</l>
 						<l>τὰ μὲν πρὸ χειρῶν τάδε φέρων, τὰ δ’ ἐν δόμοις</l>
@@ -2423,7 +2423,7 @@ antilabe in all files
 						<speaker>Κρέων</speaker>
 						<l>τί δ’ ἔστιν αὖ κάκιον ἐκ κακῶν ἔτι;</l>
 					</sp>
-					<sp who="#eksaggelos">
+					<sp who="#exangelos">
 						<speaker>Ἐξάγγελος</speaker>
 						<l>γυνὴ τέθνηκε, τοῦδε παμμήτωρ νεκροῦ,</l>
 						<l>δύστηνος, ἄρτι νεοτόμοισι πλήγμασιν.</l>
@@ -2445,7 +2445,7 @@ antilabe in all files
 						<l>γυναικεῖον ἀμφικεῖσθαι μόρον;</l>
 						<milestone ed="p" n="1293" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁρᾶν πάρεστιν·  οὐ γὰρ ἐν μυχοῖς ἔτι.</l>
 						<milestone ed="p" n="1294" unit="card"/>
@@ -2461,7 +2461,7 @@ antilabe in all files
 						<l>τάλας, τὸν δ’ ἔναντα προσβλέπω νεκρόν.</l>
 						<l n="1300">φεῦ φεῦ μᾶτερ ἀθλία, φεῦ τέκνον.</l>
 					</sp>
-					<sp who="#eksaggelos">
+					<sp who="#exangelos">
 						<speaker>Ἐξάγγελος</speaker>
 						<l>ἡ δ’ ὀξυθήκτῳ βωμία περὶ ξίφει</l>
 						<l>λύει κελαινὰ βλέφαρα, κωκύσασα μὲν</l>
@@ -2480,7 +2480,7 @@ antilabe in all files
 						<l n="1310">δείλαιος ἐγώ, αἰαῖ,</l>
 						<l>δειλαίᾳ δὲ συγκέκραμαι δύᾳ.</l>
 					</sp>
-					<sp who="#eksaggelos">
+					<sp who="#exangelos">
 						<speaker>Ἐξάγγελος</speaker>
 						<l>ὡς αἰτίαν γε τῶνδε κἀκείνων ἔχων</l>
 						<l>πρὸς τῆς θανούσης τῆσδ’ ἐπεσκήπτου μόρων</l>
@@ -2489,7 +2489,7 @@ antilabe in all files
 						<speaker>Κρέων</speaker>
 						<l>ποίῳ δὲ κἀπελύσατ’ ἐν φοναῖς τρόπῳ;</l>
 					</sp>
-					<sp who="#eksaggelos">
+					<sp who="#exangelos">
 						<speaker>Ἐξάγγελος</speaker>
 						<l n="1315">παίσας ὑφ’ ἧπαρ αὐτόχειρ αὑτήν, ὅπως</l>
 						<l>παιδὸς τόδ’ ᾔσθετ’ ὀξυκώκυτον πάθος.</l>
@@ -2506,7 +2506,7 @@ antilabe in all files
 						<l>ἄγετέ μ’ ὅτι τάχιστ’, ἄγετέ μ’ ἐκποδών,</l>
 						<l n="1325">τὸν οὐκ ὄντα μᾶλλον ἢ μηδένα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>κέρδη παραινεῖς, εἴ τι κέρδος ἐν κακοῖς.</l>
 						<l>βράχιστα γὰρ κράτιστα τἀν ποσὶν κακά.</l>
@@ -2523,7 +2523,7 @@ antilabe in all files
 						<l>ὅπως μηκέτ’  ἆμαρ ἄλλ’ εἰσίδω.</l>
 						<milestone ed="p" n="1334" unit="card"/>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μέλλοντα ταῦτα. τῶν προκειμένων τι χρὴ μέλειν</l>
 						<l n="1335">πράσσειν.  μέλει γὰρ τῶνδ’ ὅτοισι χρὴ μέλειν</l>
@@ -2532,7 +2532,7 @@ antilabe in all files
 						<speaker>Κρέων</speaker>
 						<l>ἀλλ’ ὧν ἐρῶ, τοιαῦτα συγκατηυξάμην.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μή νυν προσεύχου μηδέν·  ὡς πεπρωμένης</l>
 						<l>οὐκ ἔστι θνητοῖς συμφορᾶς ἀπαλλαγή.</l>
@@ -2554,7 +2554,7 @@ antilabe in all files
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλῷ τὸ  φρονεῖν εὐδαιμονίας</l>
 						<l>πρῶτον ὑπάρχει.  χρὴ δὲ τά γ’ εἰς θεοὺς</l>

--- a/tei/sophocles-electra.xml
+++ b/tei/sophocles-electra.xml
@@ -52,7 +52,7 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="xrysothemis">
+					<person xml:id="chrysothemis">
 						<persName>Χρυσόθεμις</persName>
 					</person>
 					<person xml:id="aigisthos">
@@ -67,7 +67,7 @@
 					<person xml:id="paidagogos">
 						<persName>Παιδαγωγός</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="elektra">
@@ -320,7 +320,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ παῖ, παῖ δυστανοτάτας</l>
 						<l>Ἠλέκτρα ματρός, τίν’ ἀεὶ</l>
@@ -344,7 +344,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ οὔτοι τόν γ’ ἐξ Ἀΐδα</l>
 						<l>παγκοίνου λίμνας πατέρ’ ἀν‐</l>
@@ -368,7 +368,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔτοι σοὶ μούνᾳ, τέκνον,</l>
 						<l n="155">ἄχος ἐφάνη βροτῶν,</l>
@@ -395,7 +395,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θάρσει μοι, θάρσει, τέκνον.</l>
 						<l n="175">ἔτι μέγας οὐρανῷ</l>
@@ -422,7 +422,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἰκτρὰ μὲν νόστοις αὐδά,</l>
 						<l>οἰκτρὰ δ’ ἐν κοίταις πατρῴαις</l>
@@ -450,7 +450,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φράζου μὴ πόρσω φωνεῖν.</l>
 						<l>οὐ γνώμαν ἴσχεις ἐξ οἵων</l>
@@ -478,7 +478,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ οὖν εὐνοίᾳ γ’ αὐδῶ,</l>
 						<l>μάτηρ ὡσεί τις πιστά,</l>
@@ -505,7 +505,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐγὼ μέν, ὦ παῖ, καὶ τὸ σὸν σπεύδουσ’ ἅμα</l>
 					<l>καὶ τοὐμὸν αὐτῆς ἦλθον· εἰ δὲ μὴ καλῶς</l>
@@ -572,7 +572,7 @@ antilabe in all files
 					<l>πολλή ’στ’ ἀνάγκη κἀπιτηδεύειν κακά.</l>
 				</sp>
 				<milestone ed="p" n="310" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="310">φέρ’ εἰπέ, πότερον ὄντος Αἰγίσθου πέλας</l>
 					<l>λέγεις τάδ’ ἡμῖν ἢ βεβῶτος ἐκ δόμων;</l>
@@ -582,7 +582,7 @@ antilabe in all files
 					<l>ἦ κάρτα· μὴ δόκει μ’ ἄν, εἴπερ ἦν πέλας,</l>
 					<l>θυραῖον οἰχνεῖν· νῦν δ’ ἀγροῖσι τυγχάνει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἦ κἂν ἐγὼ θαρσοῦσα μᾶλλον ἐς λόγους</l>
 					<l n="315">τοὺς σοὺς ἱκοίμην, εἴπερ ὧδε ταῦτ’ ἔχει;</l>
@@ -591,7 +591,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ὡς νῦν ἀπόντος ἱστόρει· τί σοι φίλον;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ δή σ’ ἐρωτῶ· τοῦ κασιγνήτου τί φής,</l>
 					<l>ἥξοντος ἢ μέλλοντος; εἰδέναι θέλω.</l>
@@ -600,7 +600,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>φησίν γε· φάσκων δ’ οὐδὲν ὧν λέγει ποεῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="320">φιλεῖ γὰρ ὀκνεῖν πρᾶγμ’ ἀνὴρ πράσσων μέγα.</l>
 				</sp>
@@ -608,7 +608,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>καὶ μὴν ἔγωγ’ ἔσωσ’ ἐκεῖνον οὐκ ὄκνῳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θάρσει· πέφυκεν ἐσθλός, ὥστ’ ἀρκεῖν φίλοις.</l>
 				</sp>
@@ -616,14 +616,14 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>πέποιθ’, ἐπεί τἂν οὐ μακρὰν ἔζων ἐγώ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μὴ νῦν ἔτ’ εἴπῃς μηδέν· ὡς δόμων ὁρῶ</l>
 					<l n="325">τὴν σὴν ὅμαιμον ἐκ πατρὸς ταὐτοῦ φύσιν,</l>
 					<l>Χρυσόθεμιν, ἔκ τε μητρός, ἐντάφια χεροῖν</l>
 					<l>φέρουσαν, οἷα τοῖς κάτω νομίζεται.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>τίν’ αὖ σὺ τήνδε πρὸς θυρῶνος ἐξόδοις</l>
 					<l>ἐλθοῦσα φωνεῖς, ὦ κασιγνήτη, φάτιν,</l>
@@ -672,13 +672,13 @@ antilabe in all files
 					<l>θανόντα πατέρα καὶ φίλους προδοῦσα σούς.</l>
 					<milestone ed="p" n="369" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μηδὲν πρὸς ὀργήν, πρὸς θεῶν· ὡς τοῖς λόγοις</l>
 					<l n="370">ἔνεστιν ἀμφοῖν κέρδος, εἰ σὺ μὲν μάθοις</l>
 					<l>τοῖς τῆσδε χρῆσθαι, τοῖς δὲ σοῖς αὕτη πάλιν.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἐγὼ μέν, ὦ γυναῖκες, ἠθάς εἰμί πως</l>
 					<l>τῶν τῆσδε μύθων· οὐδ’ ἂν ἐμνήσθην ποτέ,</l>
@@ -690,7 +690,7 @@ antilabe in all files
 					<l>φέρ’ εἰπὲ δὴ τὸ δεινόν· εἰ γὰρ τῶνδέ μοι</l>
 					<l>μεῖζόν τι λέξεις, οὐκ ἂν ἀντείποιμ’ ἔτι.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀλλ’ ἐξερῶ σοι πᾶν ὅσον κάτοιδ’ ἐγώ.</l>
 					<l>μέλλουσι γάρ σ’, εἰ τῶνδε μὴ λήξεις γόων,</l>
@@ -705,7 +705,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="385">ἦ ταῦτα δή με καὶ βεβούλευνται ποεῖν;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>μάλισθ’· ὅταν περ οἴκαδ’ Αἴγισθος μόλῃ.</l>
 				</sp>
@@ -713,7 +713,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἀλλ’ ἐξίκοιτο τοῦδέ γ’ οὕνεκ’ ἐν τάχει.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>τίν’, ὦ τάλαινα, τόνδ’ ἐπηράσω λόγον;</l>
 				</sp>
@@ -721,7 +721,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἐλθεῖν ἐκεῖνον, εἴ τι τῶνδε δρᾶν νοεῖ.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="390">ὅπως πάθῃς τί χρῆμα; ποῦ ποτ’ εἶ φρενῶν;</l>
 				</sp>
@@ -729,7 +729,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ὅπως ἀφ’ ὑμῶν ὡς προσωτάτω φύγω.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>βίου δὲ τοῦ παρόντος οὐ μνείαν ἔχεις;</l>
 				</sp>
@@ -737,7 +737,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>καλὸς γὰρ οὑμὸς βίοτος ὥστε θαυμάσαι.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀλλ’ ἦν ἄν, εἰ σύ γ’ εὖ φρονεῖν ἠπίστασο.</l>
 				</sp>
@@ -745,7 +745,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="395">μή μ’ ἐκδίδασκε τοῖς φίλοις εἶναι κακήν.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀλλ’ οὐ διδάσκω· τοῖς κρατοῦσι δ’ εἰκαθεῖν.</l>
 				</sp>
@@ -753,7 +753,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>σὺ ταῦτα θώπεῡ· οὐκ ἐμοὺς τρόπους λέγεις.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>καλόν γε μέντοι μὴ ’ξ ἀβουλίας πεσεῖν.</l>
 				</sp>
@@ -761,7 +761,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>πεσούμεθ’, εἰ χρή, πατρὶ τιμωρούμενοι.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="400">πατὴρ δὲ τούτων, οἶδα, συγγνώμην ἔχει.</l>
 				</sp>
@@ -769,7 +769,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ταῦτ’ ἐστὶ τἄπη πρὸς κακῶν ἐπαινέσαι.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>σὺ δ’ οὐχὶ πείσει καὶ συναινέσεις ἐμοί;</l>
 				</sp>
@@ -777,7 +777,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>οὐ δῆτα· μή πω νοῦ τοσόνδ’ εἴην κενή.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>χωρήσομαί τἄρ’ οἷπερ ἐστάλην ὁδοῦ.</l>
 				</sp>
@@ -785,7 +785,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ποῖ δ’ ἐμπορεύει; τῷ φέρεις τάδ’ ἔμπυρα;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>μήτηρ με πέμπει πατρὶ τυμβεῦσαι χοάς.</l>
 				</sp>
@@ -793,7 +793,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>πῶς εἶπας; ἦ τῷ δυσμενεστάτῳ βροτῶν;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ὃν ἔκταν’ αὐτή· τοῦτο γὰρ λέξαι θέλεις.</l>
 				</sp>
@@ -801,7 +801,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἐκ τοῦ φίλων πεισθεῖσα; τῷ τοῦτ’ ἤρεσεν;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="410">ἐκ δείματός του νυκτέρου, δοκεῖν ἐμοί;</l>
 				</sp>
@@ -809,7 +809,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ὦ θεοὶ πατρῷοι, συγγένεσθέ γ’ ἀλλὰ νῦν.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἔχεις τι θάρσος τοῦδε τοῦ τάρβους πέρι;</l>
 				</sp>
@@ -817,7 +817,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>εἴ μοι λέγοις τὴν ὄψιν, εἴποιμ’ ἂν τότε.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀλλ’ οὐ κάτοιδα πλὴν ἐπὶ σμικρὸν φράσαι.</l>
 					<milestone ed="p" n="415" unit="card"/>
@@ -827,7 +827,7 @@ antilabe in all files
 					<l n="415">λέγ’ ἀλλὰ τοῦτο· πολλά τοι σμικροὶ λόγοι</l>
 					<l>ἔσφηλαν ἤδη καὶ κατώρθωσαν βροτούς.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>λόγος τις αὐτήν ἐστιν εἰσιδεῖν πατρὸς</l>
 					<l>τοῦ σοῦ τε κἀμοῦ δευτέραν ὁμιλίαν</l>
@@ -882,12 +882,12 @@ antilabe in all files
 					<l>πάντων, ἐν Ἅιδου κειμένῳ κοινῷ πατρί.</l>
 					<milestone ed="p" n="464" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πρὸς εὐσέβειαν ἡ κόρη λέγει· σὺ δέ,</l>
 					<l n="465">εἰ σωφρονήσεις, ὦ φίλη, δράσεις τάδε.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>δράσω· τὸ γὰρ δίκαιον οὐχ ἔχει λόγον</l>
 					<l>δυοῖν ἐρίζειν, ἀλλ’ ἐπισπεύδειν τὸ δρᾶν.</l>
@@ -900,7 +900,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ μὴ ’γὼ παράφρων μάντις ἔφυν καὶ γνώμας</l>
 						<l>λειπομένα σοφᾶς,</l>
@@ -917,7 +917,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἥξει καὶ πολύπους καὶ πολύχειρ ἁ δεινοῖς</l>
 						<l n="490">κρυπτομένα λόχοις</l>
@@ -934,7 +934,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Πέλοπος ἁ πρόσθεν</l>
 						<l n="505">πολύπονος ἱππεία,</l>
@@ -1062,7 +1062,7 @@ antilabe in all files
 					<l>σχεδόν τι τὴν σὴν οὐ καταισχύνω φύσιν.</l>
 					<milestone ed="p" n="610" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="610">ὁρῶ μένος πνέουσαν· εἰ δὲ σὺν δίκῃ</l>
 					<l>ξύνεστι, τοῦδε φροντίδ’ οὐκέτ’ εἰσορῶ.</l>
@@ -1149,7 +1149,7 @@ antilabe in all files
 					<l n="660">ξέναι γυναῖκες, πῶς ἂν εἰδείην σαφῶς</l>
 					<l>εἰ τοῦ τυράννου δώματ’ Αἰγίσθου τάδε;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τάδ’ ἐστίν, ὦ ξέν’· αὐτὸς ᾔκασας καλῶς.</l>
 				</sp>
@@ -1158,7 +1158,7 @@ antilabe in all files
 					<l>ἦ καὶ δάμαρτα τήνδ’ ἐπεικάζων κυρῶ</l>
 					<l>κείνου; πρέπει γὰρ ὡς τύραννος εἰσορᾶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="665">μάλιστα πάντων· ἥδε σοι κείνη πάρα.</l>
 				</sp>
@@ -1296,7 +1296,7 @@ antilabe in all files
 					<l>μέγιστα πάντων ὧν ὄπωπ’ ἐγὼ κακῶν.</l>
 				</sp>
 				<milestone ed="p" n="764" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>φεῦ φεῦ· τὸ πᾶν δὴ δεσπόταισι τοῖς πάλαι</l>
 					<l n="765">πρόρριζον, ὡς ἔοικεν, ἔφθαρται γένος.</l>
@@ -1412,7 +1412,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποῦ ποτε κεραυνοὶ Διὸς ἢ ποῦ φαέθων</l>
 						<l n="825">Ἅλιος, εἰ ταῦτ’ ἐφορῶντες κρύπτουσιν ἕκηλοι;</l>
@@ -1421,7 +1421,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l>ἒ ἔ, αἰαῖ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ παῖ, τί δακρύεις;</l>
 					</sp>
@@ -1429,7 +1429,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l>φεῦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="830">μηδὲν μέγ’ ἀΰσῃς.</l>
 					</sp>
@@ -1437,7 +1437,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l part="I">ἀπολεῖς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">πῶς;</l>
 					</sp>
@@ -1450,7 +1450,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἶδα γὰρ ἄνακτ’ Ἀμφιάρεων χρυσοδέτοις</l>
 						<l>ἕρκεσι κρυφθέντα γυναικῶν· καὶ νῦν ὑπὸ γαίας</l>
@@ -1459,7 +1459,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l n="840">ἒ ἔ, ἰώ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πάμψυχος ἀνάσσει.</l>
 					</sp>
@@ -1467,7 +1467,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l>φεῦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φεῦ δῆτ’· ὀλοὰ γὰρ</l>
 					</sp>
@@ -1475,7 +1475,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l n="845" part="I">ἐδάμη.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">ναί.</l>
 					</sp>
@@ -1488,7 +1488,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δειλαία δειλαίων κυρεῖς.</l>
 					</sp>
@@ -1498,7 +1498,7 @@ antilabe in all files
 						<l>πανσύρτῳ παμμήνῳ πολλῶν</l>
 						<l>δεινῶν στυγνῶν τ’ αἰῶνι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἴδομεν ἁθρήνεις.</l>
 					</sp>
@@ -1507,7 +1507,7 @@ antilabe in all files
 						<l n="855">μή μέ νυν μηκέτι</l>
 						<l>παραγάγῃς, ἵν’ οὐ</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί φής;</l>
 					</sp>
@@ -1519,7 +1519,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="860">πᾶσι θνατοῖς ἔφυ μόρος.</l>
 					</sp>
@@ -1529,7 +1529,7 @@ antilabe in all files
 						<l>οὕτως, ὡς κείνῳ δυστάνῳ,</l>
 						<l>τμητοῖς ὁλκοῖς ἐγκῦρσαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄσκοπος ἁ λώβα.</l>
 					</sp>
@@ -1538,7 +1538,7 @@ antilabe in all files
 						<l n="865">πῶς γὰρ οὔκ; εἰ ξένος</l>
 						<l>ἄτερ ἐμᾶν χερῶν</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παπαῖ.</l>
 					</sp>
@@ -1551,7 +1551,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ὑφ’ ἡδονῆς τοι, φιλτάτη, διώκομαι</l>
 					<l>τὸ κόσμιον μεθεῖσα σὺν τάχει μολεῖν·</l>
@@ -1563,7 +1563,7 @@ antilabe in all files
 					<l n="875">πόθεν δ’ ἂν εὕροις τῶν ἐμῶν σὺ πημάτων</l>
 					<l>ἄρηξιν, οἷς ἴασιν οὐκ ἔνεστ’ ἰδεῖν;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>πάρεστ’ Ὀρέστης ἡμίν, ἴσθι τοῦτ’ ἐμοῦ</l>
 					<l>κλύουσ’, ἐναργῶς, ὥσπερ εἰσορᾷς ἐμέ.</l>
@@ -1573,7 +1573,7 @@ antilabe in all files
 					<l>ἀλλ’ ἦ μέμηνας, ὦ τάλαινα, κἀπὶ τοῖς</l>
 					<l n="880">σαυτῆς κακοῖσι κἀπὶ τοῖς ἐμοῖς γελᾷς;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>μὰ τὴν πατρῴαν ἑστίαν, ἀλλ’ οὐχ ὕβρει</l>
 					<l>λέγω τάδ’, ἀλλ’ ἐκεῖνον ὡς παρόντα νῷν.</l>
@@ -1583,7 +1583,7 @@ antilabe in all files
 					<l>οἴμοι τάλαινα· καὶ τίνος βροτῶν λόγον</l>
 					<l>τόνδ’ εἰσακούσασ’ ὧδε πιστεύεις ἄγαν;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="885">ἐγὼ μὲν ἐξ ἐμοῦ τε κοὐκ ἄλλης, σαφῆ</l>
 					<l>σημεῖ’ ἰδοῦσα, τῷδε πιστεύω λόγῳ.</l>
@@ -1593,7 +1593,7 @@ antilabe in all files
 					<l>τίν’, ὦ τάλαιν’, ἔχουσα πίστιν; ἐς τί μοι</l>
 					<l>βλέψασα θάλπει τῷδ’ ἀνηκέστῳ πυρί;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>πρός νυν θεῶν ἄκουσον, ὡς μαθοῦσά μου</l>
 					<l n="890">τὸ λοιπὸν ἢ φρονοῦσαν ἢ μωρὰν λέγῃς.</l>
@@ -1603,7 +1603,7 @@ antilabe in all files
 					<l>σὺ δ’ οὖν λέγ’, εἴ σοι τῷ λόγῳ τις ἡδονή.</l>
 					<milestone ed="p" n="892" unit="card"/>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>καὶ δὴ λέγω σοι πᾶν ὅσον κατειδόμην.</l>
 					<l>ἐπεὶ γὰρ ἦλθον πατρὸς ἀρχαῖον τάφον,</l>
@@ -1639,7 +1639,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="920">φεῦ, τῆς ἀνοίας ὥς σ’ ἐποικτίρω πάλαι.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>τί δ’ ἔστιν; οὐ πρὸς ἡδονὴν λέγω τάδε;</l>
 				</sp>
@@ -1647,7 +1647,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>οὐκ οἶσθ’ ὅποι γῆς οὐδ’ ὅποι γνώμης φέρει.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>πῶς δ’ οὐκ ἐγὼ κάτοιδ’ ἅ γ’ εἶδον ἐμφανῶς;</l>
 				</sp>
@@ -1656,7 +1656,7 @@ antilabe in all files
 					<l>τέθνηκεν, ὦ τάλαινα, τἀκείνου δέ σοι</l>
 					<l n="925">σωτήρῑ ἔρρει· μηδὲν εἰς κεῖνόν γ’ ὅρα.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>οἴμοι τάλαινα· τοῦ τάδ’ ἤκουσας βροτῶν;</l>
 				</sp>
@@ -1664,7 +1664,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τοῦ πλησίον παρόντος, ἡνίκ’ ὤλλυτο.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>καὶ ποῦ ’στιν οὗτος; θαῦμά τοί μ’ ὑπέρχεται.</l>
 				</sp>
@@ -1672,7 +1672,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>κατ’ οἶκον, ἡδὺς οὐδὲ μητρὶ δυσχερής.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="930">οἴμοι τάλαινα· τοῦ γὰρ ἀνθρώπων ποτ’ ἦν</l>
 					<l>τὰ πολλὰ πατρὸς πρὸς τάφον κτερίσματα;</l>
@@ -1682,7 +1682,7 @@ antilabe in all files
 					<l>οἶμαι μάλιστ’ ἔγωγε τοῦ τεθνηκότος</l>
 					<l>μνημεῖ’ Ὀρέστου ταῦτα προσθεῖναί τινα.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ὦ δυστυχής· ἐγὼ δὲ σὺν χαρᾷ λόγους</l>
 					<l n="935">τοιούσδ’ ἔχουσ’ ἔσπευδον, οὐκ εἰδυῖ’ ἄρα</l>
@@ -1694,7 +1694,7 @@ antilabe in all files
 					<l>οὕτως ἔχει σοι ταῦτ’· ἐὰν δέ μοι πίθῃ,</l>
 					<l>τῆς νῦν παρούσης πημονῆς λύσεις βάρος.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="940">ἦ τοὺς θανόντας ἐξαναστήσω ποτέ;</l>
 				</sp>
@@ -1702,7 +1702,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>οὐκ ἔσθ’ ὅ γ’ εἶπον· οὐ γὰρ ὧδ’ ἄφρων ἔφυν.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>τί γὰρ κελεύεις ὧν ἐγὼ φερέγγυος;</l>
 				</sp>
@@ -1710,7 +1710,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τλῆναί σε δρῶσαν ἃν ἐγὼ παραινέσω.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀλλ’ εἴ τις ὠφέλειά γ’, οὐκ ἀπώσομαι.</l>
 				</sp>
@@ -1718,7 +1718,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="945">ὅρα, πόνου τοι χωρὶς οὐδὲν εὐτυχεῖ.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ὁρῶ.  ξυνοίσω πᾶν ὅσονπερ ἂν σθένω.</l>
 					<milestone ed="p" n="947" unit="card"/>
@@ -1770,12 +1770,12 @@ antilabe in all files
 					<l>ζῆν αἰσχρὸν αἰσχρῶς τοῖς καλῶς πεφυκόσιν.</l>
 					<milestone ed="p" n="990" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="990">ἐν τοῖς τοιούτοις ἐστὶν ἡ προμηθία</l>
 					<l>καὶ τῷ λέγοντι καὶ κλύοντι σύμμαχος.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>καὶ πρίν γε φωνεῖν, ὦ γυναῖκες, εἰ φρενῶν</l>
 					<l>ἐτύγχαν’ αὕτη μὴ κακῶν, ἐσῴζετ’ ἂν</l>
@@ -1802,7 +1802,7 @@ antilabe in all files
 					<l>σθένουσα μηδὲν τοῖς κρατοῦσιν εἰκαθεῖν.</l>
 					<milestone ed="p" n="1015" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1015">πείθου· προνοίας οὐδὲν ἀνθρώποις ἔφυ</l>
 					<l>κέρδος λαβεῖν ἄμεινον οὐδὲ νοῦ σοφοῦ.</l>
@@ -1814,7 +1814,7 @@ antilabe in all files
 					<l>ἀλλ’ αὐτόχειρί μοι μόνῃ τε δραστέον</l>
 					<l n="1020">τοὔργον τόδ’·  οὐ γὰρ δὴ κενόν γ’ ἀφήσομεν.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>φεῦ·</l>
 					<l>εἴθ’ ὤφελες τοιάδε τὴν γνώμην πατρὸς</l>
@@ -1824,7 +1824,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἀλλ’ ἦ φύσιν γε, τὸν δὲ νοῦν ἥσσων τότε.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἄσκει τοιαύτη νοῦν δῑ αἰῶνος μένειν.</l>
 				</sp>
@@ -1832,7 +1832,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="1025">ὡς οὐχὶ συνδράσουσα νουθετεῖς τάδε.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>εἰκὸς γὰρ ἐγχειροῦντα καὶ πράσσειν κακῶς.</l>
 				</sp>
@@ -1840,7 +1840,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ζηλῶ σε τοῦ νοῦ, τῆς δὲ δειλίας στυγῶ.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀνέξομαι κλύουσα χὤταν εὖ λέγῃς.</l>
 				</sp>
@@ -1848,7 +1848,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἀλλ’ οὔ ποτ’ ἐξ ἐμοῦ γε μὴ πάθῃς τόδε.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="1030">μακρὸς τὸ κρῖναι ταῦτα χὠ λοιπὸς χρόνος.</l>
 				</sp>
@@ -1856,7 +1856,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἄπελθε· σοὶ γὰρ ὠφέλησις οὐκ ἔνι.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἔνεστιν· ἀλλὰ σοὶ μάθησις οὐ πάρα.</l>
 				</sp>
@@ -1864,7 +1864,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἐλθοῦσα μητρὶ ταῦτα πάντ’ ἔξειπε σῇ.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>οὐδ’ αὖ τοσοῦτον ἔχθος ἐχθαίρω σ’ ἐγώ.</l>
 				</sp>
@@ -1872,7 +1872,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="1035">ἀλλ’ οὖν ἐπίστω γ’ οἷ μ’ ἀτιμίας ἄγεις.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀτιμίας μὲν οὔ, προμηθίας δὲ σοῦ.</l>
 				</sp>
@@ -1880,7 +1880,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τῷ σῷ δικαίῳ δῆτ’ ἐπισπέσθαι με δεῖ;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ὅταν γὰρ εὖ φρονῇς, τόθ’ ἡγήσει σὺ νῷν.</l>
 				</sp>
@@ -1888,7 +1888,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>ἦ δεινὸν εὖ λέγουσαν ἐξαμαρτάνειν.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="1040">εἴρηκας ὀρθῶς ᾧ σὺ πρόσκεισαι κακῷ.</l>
 				</sp>
@@ -1896,7 +1896,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τί δ’; οὐ δοκῶ σοι ταῦτα σὺν δίκῃ λέγειν;</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀλλ’ ἔστιν ἔνθα χἠ δίκη βλάβην φέρει.</l>
 				</sp>
@@ -1904,7 +1904,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>τούτοις ἐγὼ ζῆν τοῖς νόμοις οὐ βούλομαι.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>ἀλλ’ εἰ ποήσεις ταῦτ’, ἐπαινέσεις ἐμέ.</l>
 				</sp>
@@ -1912,7 +1912,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l n="1045">καὶ μὴν ποήσω γ’ οὐδὲν ἐκπλαγεῖσά σε.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>καὶ τοῦτ’ ἀληθές, οὐδὲ βουλεύσει πάλιν;</l>
 				</sp>
@@ -1920,7 +1920,7 @@ antilabe in all files
 					<speaker>Ἠλέκτρα</speaker>
 					<l>βουλῆς γὰρ οὐδέν ἐστιν ἔχθιον κακῆς.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l>φρονεῖν ἔοικας οὐδὲν ὧν ἐγὼ λέγω.</l>
 				</sp>
@@ -1929,7 +1929,7 @@ antilabe in all files
 					<l>πάλαι δέδοκται ταῦτα κοὐ νεωστί μοι.</l>
 					<milestone ed="p" n="1050" unit="card"/>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="1050">ἄπειμι τοίνυν· οὔτε γὰρ σὺ τἄμ’ ἔπη</l>
 					<l>τολμᾷς ἐπαινεῖν οὔτ’ ἐγὼ τοὺς σοὺς τρόπους.</l>
@@ -1940,7 +1940,7 @@ antilabe in all files
 					<l>οὐδ’ ἢν σφόδρ’ ἱμείρουσα τυγχάνῃς· ἐπεὶ</l>
 					<l>πολλῆς ἀνοίας καὶ τὸ θηρᾶσθαι κενά.</l>
 				</sp>
-				<sp who="#xrysothemis">
+				<sp who="#chrysothemis">
 					<speaker>Χρυσόθεμις</speaker>
 					<l n="1055">ἀλλ’  εἰ σεαυτῇ τυγχάνεις δοκοῦσά τι</l>
 					<l>φρονεῖν, φρόνει τοιαῦθ’.  ὅταν γὰρ ἐν κακοῖς</l>
@@ -1950,7 +1950,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1060">τί τοὺς ἄνωθεν φρονιμωτάτους οἰωνοὺς ἐσορώμενοι τροφᾶς</l>
 						<l>κηδομένους ἀφ’ ὧν τε βλάστωσιν ἀφ’ ὧν τ’ ὄνασιν εὕρ‐</l>
@@ -1965,7 +1965,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1070">ὅτι σφὶν ἤδη τὰ μὲν ἐκ δόμων νοσεῖ δή, τὰ δὲ πρὸς τέκνων διπλῆ</l>
 						<l>φύλοπις οὐκέτ’ ἐξισοῦται φιλοτασίῳ διαί‐</l>
@@ -1979,7 +1979,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδεὶς τῶν ἀγαθῶν γὰρ</l>
 						<l>ζῶν κακῶς εὔκλειαν αἰσχῦναι θέλει</l>
@@ -1991,7 +1991,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1090">ζῴης μοι καθύπερθεν</l>
 						<l>χειρὶ καὶ πλούτῳ τεῶν ἐχθρῶν ὅσον</l>
@@ -2009,7 +2009,7 @@ antilabe in all files
 					<l>ἆρ’, ὦ γυναῖκες, ὀρθά τ’ εἰσηκούσαμεν</l>
 					<l>ὀρθῶς θ’ ὁδοιποροῦμεν ἔνθα χρῄζομεν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1100">τί δ’ ἐξερευνᾷς καὶ τί βουληθεὶς πάρει;</l>
 				</sp>
@@ -2017,7 +2017,7 @@ antilabe in all files
 					<speaker>Ὀρέστης</speaker>
 					<l>Αἴγισθον ἔνθ’ ᾤκηκεν ἱστορῶ πάλαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εὖ θ’ ἱκάνεις χὠ φράσας ἀζήμιος.</l>
 				</sp>
@@ -2026,7 +2026,7 @@ antilabe in all files
 					<l>τίς οὖν ἂν ὑμῶν τοῖς ἔσω φράσειεν ἂν</l>
 					<l>ἡμῶν ποθεινὴν κοινόπουν παρουσίαν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1105">ἥδ’, εἰ τὸν ἄγχιστόν γε κηρύσσειν χρεών.</l>
 				</sp>
@@ -2128,7 +2128,7 @@ antilabe in all files
 					<l n="1170">τοὺς γὰρ θανόντας οὐχ ὁρῶ λυπουμένους.</l>
 				</sp>
 				<milestone ed="p" n="1171" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θνητοῦ πέφυκας πατρός, Ἠλέκτρα, φρόνει,</l>
 					<l>θνητὸς δ’ Ὀρέστης.  ὥστε μὴ λίαν στένε.</l>
@@ -2372,7 +2372,7 @@ antilabe in all files
 					<l>ὁρᾶτ’ Ὀρέστην τόνδε, μηχαναῖσι μὲν</l>
 					<l>θανόντα, νῦν δὲ μηχαναῖς σεσωσμένον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1230">ὁρῶμεν, ὦ παῖ, κἀπὶ συμφοραῖσί μοι</l>
 					<l>γεγηθὸς ἕρπει δάκρυον ὀμμάτων ἄπο.</l>
@@ -2693,7 +2693,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴδεθ’ ὅποι προνέμεται</l>
 						<l n="1385">τὸ δυσέριστον αἷμα φυσῶν Ἄρης.</l>
@@ -2705,7 +2705,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παράγεται γὰρ ἐνέρων</l>
 						<l>δολιόπους ἀρωγὸς εἴσω στέγας,</l>
@@ -2722,7 +2722,7 @@ antilabe in all files
 						<l>ὦ φίλταται γυναῖκες, ἅνδρες αὐτίκα</l>
 						<l>τελοῦσι τοὔργον· ἀλλὰ σῖγα πρόσμενε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1400" part="I">πῶς δή; τί νῦν πράσσουσιν;</l>
 					</sp>
@@ -2731,7 +2731,7 @@ antilabe in all files
 						<l part="F">ἡ μὲν ἐς τάφον</l>
 						<l>λέβητα κοσμεῖ, τὼ δ’ ἐφέστατον πέλας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">σὺ δ’ ἐκτὸς ᾖξας πρὸς τί;</l>
 					</sp>
@@ -2749,7 +2749,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l>βοᾷ τις ἔνδον· οὐκ ἀκούετ’, ὦ φίλαι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἤκουσ’ ἀνήκουστα δύστανος, ὥστε φρῖξαι.</l>
 					</sp>
@@ -2771,7 +2771,7 @@ antilabe in all files
 						<l part="F">ἀλλ’ οὐκ ἐκ σέθεν</l>
 						<l>ᾠκτίρεθ’ οὗτος οὐδ’ ὁ γεννήσας πατήρ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πόλις, ὦ γενεὰ τάλαινα, νῦν σοι</l>
 						<l>μοῖρα καθαμερία φθίνει φθίνει.</l>
@@ -2792,7 +2792,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l part="F">εἰ γὰρ Αἰγίσθῳ θ’ ὁμοῦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τελοῦσ’ ἀραί· ζῶσιν οἱ γᾶς ὑπαὶ κείμενοι.</l>
 						<l n="1420">παλίρρυτον γὰρ αἷμ’ ὑπεξαιροῦσι τῶν</l>
@@ -2801,7 +2801,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ μὴν πάρεισιν οἵδε· φοινία δὲ χεὶρ</l>
 						<l>στάζει θυηλῆς Ἄρεος, οὐδ’ ἔχω ψέγειν.</l>
@@ -2824,7 +2824,7 @@ antilabe in all files
 						<l part="F">μηκέτ’ ἐκφοβοῦ</l>
 						<l>μητρῷον ὥς σε λῆμ’ ἀτιμάσει ποτέ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>παύσασθε· λεύσσω γὰρ Αἴγισθον ἐκ προδήλου.</l>
 					</sp>
@@ -2842,7 +2842,7 @@ antilabe in all files
 						<l part="F">ἐφ’ ἡμῖν οὗτος ἐκ προαστίου</l>
 						<l>χωρεῖ γεγηθὼς. . .</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βᾶτε κατ’ ἀντιθύρων ὅσον τάχιστα,</l>
 						<l n="1435">νῦν, τὰ πρὶν εὖ θέμενοι, τάδ’ ὡς πάλιν.</l>
@@ -2863,7 +2863,7 @@ antilabe in all files
 						<speaker>Ἠλέκτρα</speaker>
 						<l part="F">τἀνθάδ’ ἂν μέλοιτ’ ἐμοί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δῑ ὠτὸς ἂν παῦρά γ’ ὡς ἠπίως ἐννέπειν</l>
 						<l n="1440">πρὸς ἄνδρα τόνδε συμφέροι, λαθραῖον ὡς</l>
@@ -3054,7 +3054,7 @@ antilabe in all files
 					<milestone ed="p" n="1508" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ σπέρμ’ Ἀτρέως, ὡς πολλὰ παθὸν</l>
 						<l>δῑ ἐλευθερίας μόλις ἐξῆλθες</l>

--- a/tei/sophocles-ichneutae.xml
+++ b/tei/sophocles-ichneutae.xml
@@ -52,28 +52,25 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<personGrp xml:id="XorosSatyron">
+					<personGrp xml:id="choros_satyron">
 						<name>Χορὸς Σατύρων</name>
 					</personGrp>
-					<person xml:id="HmixA">
-						<persName>Ἡμιχ. α</persName>
-					</person>
-					<person xml:id="HmixB">
-						<persName>Ἡμιχ. β</persName>
-					</person>
-					<person xml:id="HmixorosA">
-						<persName>Ἡμιχορός α</persName>
-					</person>
-					<person xml:id="Silenos">
+					<personGrp xml:id="hemichoros_a">
+						<name>Ἡμιχορός α</name>
+					</personGrp>
+					<personGrp xml:id="hemichoros_b">
+						<name>Ἡμιχορός β</name>
+					</personGrp>
+					<person xml:id="silenos">
 						<persName>Σιληνός</persName>
 					</person>
-					<person xml:id="Kyllene">
+					<person xml:id="kyllene">
 						<persName>Κυλλήνη</persName>
 					</person>
-					<person xml:id="Xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
-					</person>
-					<person xml:id="Apollon">
+					</personGrp>
+					<person xml:id="apollon">
 						<persName>Ἀπόλλων</persName>
 					</person>
 				</listPerson>
@@ -134,7 +131,7 @@ new text
 		<div1>
 			<milestone ed="p" n="1" unit="card"/>
 			<milestone n="1" unit="column"/>
-			<sp who="#Apollon">
+			<sp who="#apollon">
 				<speaker>Ἀπόλλων</speaker>
 				<l> ]κιο[</l>
 				<l> ]πειτα[</l>
@@ -245,7 +242,7 @@ new text
 				<l>[τὸν φ]ῶρα τῶν Παιῶνος ὅστις ἂ[ν λάβῃ,</l>
 				<l>[τῷδ’ α]ὐτόχρημα μισθός ἐσθ’ ὁ κε[ίμενος.</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l n="45">[ὦ Φοῖβε,] σοῦ φώνημαθ’ ὡς ἐπέκλυον</l>
 				<l>[βοῶ]ντος ὀρθίοισι σὺν κηρύγμας[ι,</l>
@@ -275,7 +272,7 @@ new text
 					 ιμ]’ [ἂ]ν εἴπερ ἐκτε[λ]εῖς ἅπερ λέγεις
 				</l>
 			</sp>
-			<sp who="#Apollon">
+			<sp who="#apollon">
 				<speaker>Ἀπόλλων</speaker>
 				<l n="55">
 					[
@@ -283,15 +280,15 @@ new text
 					 ]ώσω· μοῦνον ἐμπ[έδου τ]άδε.
 				</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>τα[ς βοῦς ἀπάξω ς]οι· σὺ δ’ ἐμπέδου [δόσι]ν.</l>
 			</sp>
-			<sp who="#Apollon">
+			<sp who="#apollon">
 				<speaker>Ἀπόλλων</speaker>
 				<l>[ἕξει σφ’ ὁ γ’ εὑ]ρὼν ὅστι[ς] ἔ[ς]θ’· ἑτ[οῖμ]α δ[έ.</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>
 					[
@@ -305,7 +302,7 @@ new text
 					[
 				</l>
 			</sp>
-			<sp who="#Apollon">
+			<sp who="#apollon">
 				<speaker>Ἀπόλλων</speaker>
 				<l>
 					[
@@ -318,7 +315,7 @@ new text
 					<note anchored="yes" lang="en" place="inline" resp="ed">one line missing here</note>
 				</l>
 			</sp>
-			<sp who="#Apollon">
+			<sp who="#apollon">
 				<speaker>Ἀπόλλων</speaker>
 				<l>
 					<gap/>
@@ -327,7 +324,7 @@ new text
 					]
 				</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>
 					τί τοῦτο; πο[ι
@@ -335,7 +332,7 @@ new text
 					λέγ]εις;
 				</l>
 			</sp>
-			<sp who="#Apollon">
+			<sp who="#apollon">
 				<speaker>Ἀπόλλων</speaker>
 				<l>
 					ἐλεύθερος σὺ [πᾶν τε γένος ἔσται τέκν]ων.
@@ -343,7 +340,7 @@ new text
 					<milestone n="64" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#XorosSatyron">
+			<sp who="#choros_satyron">
 				<speaker>Χορὸς Σατύρων</speaker>
 				<l>
 					ἴθ’ ἄγε δ[
@@ -426,7 +423,7 @@ new text
 					<milestone n="79" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>θεὸς Τύχη [κ]αὶ δαῖμον ἰθυντήριε,</l>
 				<l n="80">τυχ[ε]ῖν με πράγους οὗ δράμημ’ ἐπείγεται,</l>
@@ -450,13 +447,13 @@ new text
 				</l>
 				<l>μήνυ[τρα</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ἰὼ ς[</l>
 				<l>ϋηο[</l>
 				<l n="90">δ’ οὐδ[</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>φησίν τις; ἢ[</l>
 				<l>ἔοικεν ἤδη κ[</l>
@@ -492,7 +489,7 @@ new text
 					<milestone n="100" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#HmixorosA">
+			<sp who="#hemichoros_a">
 				<speaker>Ἡμιχορός α</speaker>
 				<l n="100">θεὸς θεὸς θεὸς θεός· ἔα [ἔα·</l>
 				<l>
@@ -501,33 +498,33 @@ new text
 					τει.
 				</l>
 			</sp>
-			<sp who="#HmixB">
+			<sp who="#hemichoros_b">
 				<speaker>Ἡμιχ. β</speaker>
 				<l>ταῦτ’ ἔστ’ ἐκεῖνα· τῶν βοῶν τ[ὰ] σήματα.</l>
 			</sp>
-			<sp who="#HmixA">
+			<sp who="#hemichoros_a">
 				<speaker>Ἡμιχ. α</speaker>
 				<l>σίγ[α]· θεός τις τὴν ἀποι[κία]ν ἄγει.</l>
 			</sp>
-			<sp who="#HmixB">
+			<sp who="#hemichoros_b">
 				<speaker>Ἡμιχ. β</speaker>
 				<l>τί δρῶμεν, ὦ τᾶν; ἦ τὸ δέον [ἐξ]ήνομεν;</l>
 			</sp>
-			<sp who="#HmixA">
+			<sp who="#hemichoros_a">
 				<speaker>Ἡμιχ. α</speaker>
 				<l n="105" part="I">τί; τοῖς[ι] ταύτῃ πῶς δοκεῖ;</l>
 			</sp>
-			<sp who="#HmixB">
+			<sp who="#hemichoros_b">
 				<speaker>Ἡμιχ. β</speaker>
 				<l part="F">δοκεῖ πάνυ.</l>
 				<l>σαφῆ [γ]ὰρ αὔθ’ ἕκαστα σημαίνει τάδε.</l>
 			</sp>
-			<sp who="#HmixA">
+			<sp who="#hemichoros_a">
 				<speaker>Ἡμιχ. α</speaker>
 				<l>ἰδοὺ ἰδού·</l>
 				<l>καὶ τοὐπίσημον αὐτὸ τῶν ὁπλῶν πάλι[ν.</l>
 			</sp>
-			<sp who="#HmixB">
+			<sp who="#hemichoros_b">
 				<speaker>Ἡμιχ. β</speaker>
 				<l>ἄθρει μάλα.</l>
 				<l n="110">
@@ -536,7 +533,7 @@ new text
 					[τρού]μ[ε]νον.
 				</l>
 			</sp>
-			<sp who="#HmixA">
+			<sp who="#hemichoros_a">
 				<speaker>Ἡμιχ. α</speaker>
 				<l>
 					χ[ώ]ρει δρόμῳ καὶ τα[
@@ -555,13 +552,13 @@ new text
 				</l>
 				<l>ῥοίβδημ’ ἐάν τι τῶν [βοῶν δ]ῑ οὖς [λάβῃ</l>
 			</sp>
-			<sp who="#HmixB">
+			<sp who="#hemichoros_b">
 				<speaker>Ἡμιχ. β</speaker>
 				<l>οὐκ εἰσακούω πω [τορῶ]ς τοῦ φθ[έγ]ματος.</l>
 				<l n="115">ἀλλ’ αὐτὰ μὴν ἴχ[νη τε] χὠ στίβος τάδε</l>
 				<l>κείνων ἐναργῆ τῶν β[ο]ῶν μαθεῖν πάρα.</l>
 			</sp>
-			<sp who="#HmixA">
+			<sp who="#hemichoros_a">
 				<speaker>Ἡμιχ. α</speaker>
 				<l>ἔα μάλα·</l>
 				<l>παλινστραφῆ τοι ναὶ μὰ Δία τὰ βήματα</l>
@@ -575,7 +572,7 @@ new text
 					<milestone n="124" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>τίν’ αὖ τέχνην σὺ τήν[δ’ ἄρ’ ἐξ]ῆυρες, τίν’ αὖ,</l>
 				<l n="125">πρόσπαιον ὧδε κεκλιμ[ένον] κυνηγετεῖν</l>
@@ -585,26 +582,26 @@ new text
 				<l>[τ]ί ταῦτα; ποῦ γῆς ἐμάθετ’ ἐν πο[ί]ῳ τόπῳ;</l>
 				<l n="130">ς[η]μήνατ’, οὐ γὰρ ἴδρις εἰμὶ τοῦ τρόπου.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ὕ [ὗ] ὕ ὗ.</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>τ[ί τοῦτ’ ἰύζεις;] τίνα φοβῇ; τίν’ εἰσορᾷς;</l>
 				<l>τ[ί δεῖμ’ ὄπωπ]ας; τί ποτε βακχεύεις ἔχων;</l>
 				<l>α[γχοῦ τις ἤχε]ι κέρχνος·  ἱμείρει[ς] μαθεῖν</l>
 				<l n="135">τ[ίς ἦν;  τί σιγ]ᾶτ’, ὦ πρ[ὸ τοῦ λαλίστ]ατοι;</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ς[ίγα μὲν οὖν.]</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>τ[ίν’ ἔστ’ ἐκεῖθε]ν ἁπονος[φίζ]εις ἔχων;</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>
 					ἄ[κουε δή.
@@ -612,19 +609,19 @@ new text
 					<milestone n="6" unit="column"/>
 				</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>καλῶς ἀκούς[ω μηδεν]ὸς φωνὴν κλύων;</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l n="140">ἐμοὶ πιθοῦ.</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>ἐμ[ὸν] δίω[γμά γ’ οὐδα]μῶς ὀνήσετε.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ἄκουσον αὖ τ[ο]ῦ χρ[ήμα]τ[ο]ς χρόνον τινά,</l>
 				<l>[ο]ἵῳ ’κπ[λ]αγέντες ἐν[θάδ’] ἐξενίσμεθα</l>
@@ -634,7 +631,7 @@ new text
 					<milestone n="145" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l n="145">τί μοι ψ[ό]φον; φοβ[εῖσθε] κα[ὶ] δειμαίνετε,</l>
 				<l>μάλθης ἄναγνα σώ[μα]τ’ ἐκμεμαγμένα</l>
@@ -665,13 +662,13 @@ new text
 				<l>τὰς βοῦς ὅπῃ βεβᾶσι καὶ τὸν βουκόλο[ν,</l>
 				<l>κλαίοντες αὐτῇ δειλίᾳ ψοφή[ς]ετε.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>πάτερ, παρὼν αὐτός με συμποδηγέτε[ι,</l>
 				<l n="170">ἵν’ εὖ κατείδῃς εἴ τίς ἐστι δειλία·</l>
 				<l>γνώση[ι] γὰρ αὐτός, ἂν παρῇς, οὐδὲν λέγω[ν.</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>ἐγὼ πα[ρ]ὼν αὐτός σε προσβιβῶ λόγῳ,</l>
 				<l>κυνορτικὸν σύριγμα διακαλούμεν[ος.</l>
@@ -682,7 +679,7 @@ new text
 					<milestone n="176" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ὗ ὗ ὗ, ψ ψ, ἆ ἆ. λέγ’ ὅ τι πονεῖς.</l>
 				<l>τί μάτην ὑπέκλαγες, ὑπέκριγες</l>
@@ -766,19 +763,19 @@ new text
 				<l>πάτερ, τί σιγᾷς; μῶν ἀληθ[ὲς εἴπομεν;</l>
 				<l>οὐ[κ ε]ἰσακο[ύε]ις; ἦ κεκώφη[σαι, ψόφον;</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l n="205" part="I">σί[γα·] τί ἔστιν;</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l part="Y">οὐ μενῶ.</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l part="Y">μέν’, ε[ἰ] &lt;δύνᾳ.&gt;</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>οὐκ ἔστιν. ἀλλ’ αὐτὸς σὺ ταῦθ[’ ὅπῃ θέλεις]</l>
 				<l>ζήτει τε κἀξίχνευε καὶ πλού[τει λαβὼν</l>
@@ -795,13 +792,13 @@ new text
 					] χρόνον.
 				</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l n="210">ἀλλ’ οὔ τι μ[ή σοί] μ[’ ἐκλιπεῖν ἐφήσομαι]</l>
 				<l>οὐδ’ ἐξυπελθ[εῖ]ν τ[οῦ πόνου πρίν γ’ ἂν σα]φῶς</l>
 				<l>εἰδῶμεν ὅν[τιν’] ἔ[νδον ἥδ’ ἔχει στέγη.]</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ἶὼ γ[</l>
 				<l>
@@ -828,7 +825,7 @@ new text
 					<milestone n="221" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>θῆρες, τί [τό]νδε χλοερὸν ὑλώδη πάγον</l>
 				<l>ἔν[θ]ηρον ὡρμήθητε σὺν πολλῇ βοῇ;</l>
@@ -900,7 +897,7 @@ new text
 					<milestone n="243" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<note anchored="yes" place="inline" type="meter">str.</note>
 				<l>νύμφη βαθύζωνε π[αῦσαι χόλου ]</l>
@@ -916,7 +913,7 @@ new text
 					<milestone n="251" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>ταῦτ’ ἔστ’ ἐκείνων νῦν [ τρόπων πεπαίτερα,</l>
 				<l>καὶ τοῖσδε θηρῶν ἐκπύ[θοιο μᾶλλον ἂν</l>
@@ -926,14 +923,14 @@ new text
 				<l>ἀλλ’ ἥσυχος πρόφαινε καὶ μ[ή]νυ[έ μοι</l>
 				<l>ὅτου μάλιστα πράγματος χρείαν ἔχεις.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>τόπων ἄνασσα τῶν[δ]ε, Κυλλήνης σθένος,</l>
 				<l>ὅτου μὲν οὕνεκ’ ἦλθ[ο]ν, ὕστερον φράσω·</l>
 				<l n="260">τὸ φθέγμα δ’ ἡμῖν τοῦ[θ’] ὅπερ φωνεῖ φράσον</l>
 				<l>καὶ τίς ποτ’ αὐτῷ δι[α]χαράσσεται βροτῶν.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l> ὑμᾶς μὲν αὐτοὺς χρὴ τάδ’ εἰδέναι σαφῶς</l>
 				<l>ὡς εἰ φανεῖτε τὸν λ[ό]γον τὸν ἐξ ἐμοῦ,</l>
@@ -983,7 +980,7 @@ new text
 					<milestone n="290" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l n="290">
 					ἄφραστ[ο 
@@ -1028,55 +1025,55 @@ new text
 					<milestone n="298" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>μὴ νῦν ἀπίστει· πιστὰ γάρ σε προσγελᾷ θεᾶς ἔπη.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l n="300">καὶ πῶς πίθωμαι τοῦ θανόντος φθέγμα τοιοῦτον βρέμειν;</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>πιθοῦ· θανὼν γὰρ ἔσχε φωνήν, ζῶν δ’ ἄναυδος ἦν ὁ θήρ.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ποῖός τις ἦν εἶδος; πρ[ο]μήκης, ἢ ’πίκυρτος, ἢ βραχύς;</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>βραχύς, χυτρώδης, πο[ι]κίλῃ δορᾷ κατερρικνωμένος.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ὡς αἰέλουρος εἰκάσαι πέφυκεν ἢ τὼς πόρδαλις;</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l n="305">πλεῖστον με[τ]αξύ· γογγύλον γάρ ἐστι καὶ βραχυσκελές.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>οὐδ’ ὡς ἰχνευμ&lt;ων&gt; προσφερὲς πέφυκεν οὐδ’ ὡς καρκίν&lt;ος&gt;;</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>οὐδ’ αὖ τοιοῦτ[ό]ν ἐστιν· ἀλλ’ ἄλλον τιν’ ἐξευροῦ τρόπον.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ἀλλ’ ὡς κεράστ[η]ς κάνθαρος δῆτ’ ἐστὶν Αἰτναῖος φυήν;</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>νῦν ἐγγὺς ἔγν[ως] ᾧ μάλιστα προσφερὲς τὸ κνώδαλον.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l n="310">τ[ί δ’ αὖ τὸ ] φων[οῦ]ν ἐστιν αὐτοῦ, τοὐντὸς ἢ τοὔξω, φράσον.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>
 					 [
@@ -1086,15 +1083,15 @@ new text
 					φ]ορίνη σύγγονος τῶν ὀστράκων.
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>[ποῖον δὲ τοὔνομ’ ἐν]νέ[πει]ς;  πόρσυνον, εἴ τι πλέον ἔχεις.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>[τὸν θῆρα μὲν χέλυν, τὸ φωνο]ῦν δ’ αὖ λύραν ὁ παῖς καλεῖ.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>
 					[ 
@@ -1105,7 +1102,7 @@ new text
 					] τινι;
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>
 					[ 
@@ -1170,7 +1167,7 @@ new text
 					<milestone n="329" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>
 					ὀ&lt;ρθ&gt;οψάλακτός τις ὀμφὴ κατοιχνεῖ τόπου,      
@@ -1189,19 +1186,19 @@ new text
 					<milestone n="338" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>[τίς ἔχει πλά]νη σε; τίνα κλοπὴν ὠνείδις[ας;</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>[οὐ μὰ Δία σ’, ὦ πρές]βειρα χειμάζειν [ θέλω.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l n="340">[μῶν τὸν Διὸς παῖδ’ ὄ]ντα φ&lt;η&gt;λήτην κα[λεῖς;</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>
 					[
@@ -1210,7 +1207,7 @@ new text
 					 ]αν αὐτῇ τῇ κλο[πῇ.
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>
 					[
@@ -1219,7 +1216,7 @@ new text
 					ε]ἴ γε τἀληθῆ λέ[γεις.
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>
 					[       
@@ -1265,7 +1262,7 @@ new text
 					<milestone n="352" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>κυλλήνη</speaker>
 				<l>
 					[  
@@ -1306,7 +1303,7 @@ new text
 					<milestone n="371" unit="card"/>
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>
 					στρέφου λυγίζου τε μύθοις, ὁποι‐  
@@ -1327,62 +1324,62 @@ new text
 					<note anchored="yes" lang="en" place="inline" resp="ed.">ονε ορ μορε λινες μισσινγ</note>
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>[ὁ Ζ]εὺς γὰρ ]</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l n="380">[ὁ] παῖς κλο[π</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>[εἰ] τοι πονη[ρὰ δρᾷ, πονηρὸς ὢν κυρεῖ.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>[κ]ακῶς ἀκού[ειν οὐ πρέπει Διὸς γόνῳ.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>[ε]ἰ δ’ ἔστ’ ἀλη[θῆ, χρή με καὶ λέγειν τάδε.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>[ο]ὐ μὴ ταδ’ [εἴπῃς</l>
 				<l>
 					<note anchored="yes" lang="en" place="inline" resp="ed.">αβουτ 8 λινες οφ ωηιξη ωε ηαvε ονλψ τηε ινιτιαλ λεττερς</note>
 				</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>ποῦ καὶ βόες νέμουσι τ[</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>π[λ]είους δέ γ’ ἤδη νῦν [</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>τ[ί]ς, ὦ πόνηρ’, ἔχει; τί πλε[</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ὁ παῖς ὃς ἔνδον ἐστὶν ἐγκεκλη[ιμένος.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>[τὸ]ν παῖδα παῦσαι τοῦ Διὸς [ κακῶς λέγων.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l n="400">π[α]ύοιμ[’ ἄ]ν [, εἰ] τὰς βοῦς τις ἐ[ξελᾶν θέλοι.</l>
 			</sp>
-			<sp who="#Kyllene">
+			<sp who="#kyllene">
 				<speaker>Κυλλήνη</speaker>
 				<l>ἤδη με πνίγεις καὶ σὺ χα[ἰ βόες σέθεν.</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>
 					[
@@ -1400,24 +1397,24 @@ new text
 					<milestone n="17" unit="column"/>
 				</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ἰοὺ ἰοὺ [</l>
 				<l>ἥν τ’ ἔφη π[</l>
 				<l>οὗτος οὐ φ[</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>ω Λ[οξία</l>
 				<l>ιω δ[</l>
 			</sp>
-			<sp who="#Xoros">
+			<sp who="#choros">
 				<speaker>Χορός</speaker>
 				<l>ὦ Λοξία, δε[</l>
 				<l>καὶ παρη[</l>
 				<l>τῶν [β]οῶ[ν</l>
 			</sp>
-			<sp who="#Apollon">
+			<sp who="#apollon">
 				<speaker>Ἀπόλλων</speaker>
 				<l>
 					[
@@ -1435,7 +1432,7 @@ new text
 				<l>μισθς [</l>
 				<l>ἐλεύθερο[</l>
 			</sp>
-			<sp who="#Silenos">
+			<sp who="#silenos">
 				<speaker>Σιληνός</speaker>
 				<l>τὸν ἐγ[</l>
 			</sp>

--- a/tei/sophocles-oedipus-at-colonus.xml
+++ b/tei/sophocles-oedipus-at-colonus.xml
@@ -52,16 +52,16 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="theseys">
+					<person xml:id="theseus">
 						<persName>Θησεύς</persName>
 					</person>
-					<person xml:id="ksenos">
+					<person xml:id="xenos">
 						<persName>Ξένος</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<person xml:id="oidipoys">
+					<person xml:id="oidipous">
 						<persName>Οἰδίπους</persName>
 					</person>
 					<person xml:id="polyneikes">
@@ -73,7 +73,7 @@
 					<person xml:id="ismene">
 						<persName>Ἰσμήνη</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 					<person xml:id="antigone">
@@ -181,7 +181,7 @@ convert to TEI P3
 		<body n="OC">
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τέκνον τυφλοῦ γέροντος Ἀντιγόνη, τίνας</l>
 					<l>χώρους ἀφίγμεθ’ ἢ τίνων ἀνδρῶν πόλιν;</l>
@@ -207,7 +207,7 @@ convert to TEI P3
 					<l>οὗ κῶλα κάμψον τοῦδ’ ἐπ’ ἀξέστου πέτρου·</l>
 					<l n="20">μακρὰν γὰρ ὡς γέροντι προὐστάλης ὁδόν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>κάθιζέ νύν με καὶ φύλασσε τὸν τυφλόν.</l>
 				</sp>
@@ -215,7 +215,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>χρόνου μὲν οὕνεκ’ οὐ μαθεῖν με δεῖ τόδε.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἔχεις διδάξαι δή μ’ ὅποι καθέσταμεν;</l>
 				</sp>
@@ -223,7 +223,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>τὰς γοῦν Ἀθήνας οἶδα, τὸν δὲ χῶρον οὔ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="25">πᾶς γάρ τις ηὔδα τοῦτό γ’ ἡμὶν ἐμπόρων.</l>
 				</sp>
@@ -231,7 +231,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>ἀλλ’ ὅστις ὁ τόπος ἦ μάθω μολοῦσά ποι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ναί, τέκνον, εἴπερ ἐστί γ’ ἐξοικήσιμος.</l>
 				</sp>
@@ -240,7 +240,7 @@ convert to TEI P3
 					<l>ἀλλ’ ἐστὶ μὴν οἰκητός· οἴομαι δὲ δεῖν</l>
 					<l>οὐδέν·  πέλας γὰρ ἄνδρα τόνδε νῷν ὁρῶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="30">ἦ δεῦρο προσστείχοντα κἀξορμώμενον;</l>
 				</sp>
@@ -250,67 +250,67 @@ convert to TEI P3
 					<l>εὔκαιρόν ἐστιν, ἔννεφ’, ὡς ἀνὴρ ὅδε.</l>
 					<milestone ed="p" n="33" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ ξεῖν’, ἀκούων τῆσδε τῆς ὑπέρ τ’ ἐμοῦ</l>
 					<l>αὑτῆς θ’ ὁρώσης, οὕνεχ’ ἡμὶν αἴσιος</l>
 					<l n="35">σκοπὸς προσήκεις ὧν ἀδηλοῦμεν φράσαι—</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>πρὶν νῦν τὰ πλείον’ ἱστορεῖν, ἐκ τῆσδ’ ἕδρας</l>
 					<l>ἔξελθ’·  ἔχεις γὰρ χῶρον οὐχ ἁγνὸν πατεῖν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς δ’ ἔσθ’ ὁ χῶρος; τοῦ θεῶν νομίζεται;</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>ἄθικτος οὐδ’ οἰκητός·  αἱ γὰρ ἔμφοβοι</l>
 					<l n="40">θεαί σφ’ ἔχουσι, Γῆς τε καὶ Σκότου κόραι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίνων τὸ σεμνὸν ὄνομ’ ἂν εὐξαίμην κλύων;</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>τὰς πάνθ’ ὁρώσας Εὐμενίδας ὅ γ’ ἐνθάδ’ ἂν</l>
 					<l>εἴποι λεώς νιν·  ἄλλα δ’ ἀλλαχοῦ καλά.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ ἵλεῳ μὲν τὸν ἱκέτην δεξαίατο·</l>
 					<l n="45">ὡς οὐχ ἕδρας γῆς τῆσδ’ ἂν ἐξέλθοιμ’ ἔτι.</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l part="I">τί δ’ ἐστὶ τοῦτο;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">ξυμφορᾶς ξύνθημ’ ἐμῆς.</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>ἀλλ’ οὐδ’ ἐμοί τοι τοὐξανιστάναι πόλεως</l>
 					<l>δίχ’ ἐστὶ θάρσος, πρίν γ’ ἂν ἐνδείξω τί δρῶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πρός νυν θεῶν, ὦ ξεῖνε, μή μ’ ἀτιμάσῃς,</l>
 					<l n="50">τοιόνδ’ ἀλήτην, ὧν σε προστρέπω φράσαι.</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>σήμαινε, κοὐκ’ ἄτιμος ἔκ γ’ ἐμοῦ φανεῖ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς ἔσθ’ ὁ χῶρος δῆτ’, ἐν ᾧ βεβήκαμεν;</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>ὅσ’ οἶδα κἀγὼ πάντ’ ἐπιστήσει κλύων·</l>
 					<l>χῶρος μὲν ἱερὸς πᾶς ὅδ’ ἔστ’· ἔχει δέ νιν</l>
@@ -324,52 +324,52 @@ convert to TEI P3
 					<l>τοιαῦτά σοι ταῦτ’   ἐστίν, ὦ ξέν’, οὐ λόγοις</l>
 					<l>τιμώμεν’, ἀλλὰ   τῇ ξυνουσίᾳ πλέον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ γάρ τινες ναίουσι τούσδε τοὺς τόπους;</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l n="65">καὶ κάρτα, τοῦδε τοῦ θεοῦ γ’ ἐπώνυμοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἄρχει τις αὐτῶν ἢ ’πὶ τῷ πλήθει λόγος;</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>ἐκ τοῦ κατ’ ἄστυ βασιλέως τάδ’ ἄρχεται.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὗτος δὲ τίς λόγῳ τε καὶ σθένει κρατεῖ;</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>Θησεὺς καλεῖται, τοῦ πρὶν Αἰγέως τόκος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="70">ἆρ’ ἄν τις αὐτῷ πομπὸς ἐξ ὑμῶν μόλοι;</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>ὡς πρὸς τί λέξων ἢ καταρτύσων μολεῖν;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὡς ἂν προσαρκῶν σμικρὰ κερδάνῃ μέγα.</l>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l>καὶ τίς πρὸς ἀνδρὸς μὴ βλέποντος ἄρκεσις;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅσ’ ἂν λέγωμεν πάνθ’ ὁρῶντα λέξομεν.</l>
 					<milestone ed="p" n="75" unit="card"/>
 				</sp>
-				<sp who="#ksenos">
+				<sp who="#xenos">
 					<speaker>Ξένος</speaker>
 					<l n="75">οἶσθ’, ὦ ξέν’, ὡς νῦν μὴ σφαλῇς; ἐπείπερ εἰ</l>
 					<l>γενναῖος, ὡς ἰδόντι, πλὴν τοῦ δαίμονος,</l>
@@ -378,7 +378,7 @@ convert to TEI P3
 					<l>λέξω τάδ’ ἐλθών·  οἵδε γὰρ κρινοῦσί σοι</l>
 					<l n="80">εἰ χρή σε μίμνειν ἢ πορεύεσθαι πάλιν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ τέκνον, ἦ βέβηκεν ἡμὶν ὁ ξένος;</l>
 				</sp>
@@ -387,7 +387,7 @@ convert to TEI P3
 					<l>βέβηκεν, ὥστε πᾶν ἐν ἡσύχῳ, πάτερ,</l>
 					<l>ἔξεστι φωνεῖν, ὡς ἐμοῦ μόνης πέλας.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ πότνιαι δεινῶπες, εὖτε νῦν ἕδρας</l>
 					<l n="85">πρώτων ἐφ’ ὑμῶν τῆσδε γῆς ἔκαμψ’ ἐγώ,</l>
@@ -422,7 +422,7 @@ convert to TEI P3
 					<l>σίγα·  πορεύονται γὰρ οἵδε δή τινες</l>
 					<l>χρόνῳ παλαιοί, σῆς ἕδρας ἐπίσκοποι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>σιγήσομαί τε καὶ σύ μ’ ἐξ ὁδοῦ πόδα</l>
 					<l>κρύψον κατ’ ἄλσος, τῶνδ’ ἕως ἂν ἐκμάθω</l>
@@ -433,7 +433,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅρα.  τίς ἄρ’ ἦν;  ποῦ ναίει;</l>
 						<l>ποῦ κυρεῖ ἐκτόπιος συθεὶς ὁ πάντων</l>
@@ -454,25 +454,25 @@ convert to TEI P3
 						<l>δύναμαι τέμενος</l>
 						<l>γνῶναι ποῦ μοί ποτε ναίει.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὅδ’ ἐκεῖνος ἐγώ·  φωνῇ γὰρ ὁρῶ,</l>
 						<l>τὸ φατιζόμενον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="140">ἰὼ ἰώ,</l>
 						<l>δεινὸς μὲν ὁρᾶν, δεινὸς δὲ κλύειν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>μή μ’, ἱκετεύω, προσίδητ’ ἄνομον.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ζεῦ ἀλεξῆτορ, τίς ποθ’ ὁ πρέσβυς;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>οὐ πάνυ μοίρας εὐδαιμονίσαι</l>
 						<l n="145">πρώτης, ὦ τῆσδ’ ἔφοροι χώρας.</l>
@@ -483,7 +483,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐή, ἀλαῶν ὀμμάτων</l>
 						<l n="150">ἆρα καὶ ἦσθα φυτάλμιος; δυσαίων</l>
@@ -504,7 +504,7 @@ convert to TEI P3
 						<l>ἵνα πᾶσι νόμος,</l>
 						<l>φώνει·  πρόσθεν δ’ ἀπερύκου.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="170">θύγατερ, ποῖ τις φροντίδος ἔλθῃ;</l>
 					</sp>
@@ -513,7 +513,7 @@ convert to TEI P3
 						<l>ὦ πάτερ, ἀστοῖς ἴσα χρὴ μελετᾶν,</l>
 						<l>εἴκοντας ἃ δεῖ κἀκούοντας.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">πρόσθιγέ νύν μου.</l>
 					</sp>
@@ -521,7 +521,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="F">ψαύω καὶ δή.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὦ ξένε, μὴ δῆτ’ ἀδικηθῶ σοὶ</l>
 						<l n="175">πιστεύσας καὶ μεταναστάς.</l>
@@ -529,24 +529,24 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὔ τοι μήποτέ σ’  ἐκ τῶνδ’ ἑδράνων,</l>
 						<l>ὦ γέρον, ἄκοντά τις ἄξει.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">ἔτ’ οὖν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">ἔτι βαῖνε πόρσω.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="180" part="I">ἔτι;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">προβίβαζε,  κούρα,</l>
 						<l>πόρσω·  σὺ γὰρ ἀΐεις.</l>
@@ -559,7 +559,7 @@ convert to TEI P3
 							&gt;
 						</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>
 							&lt;
@@ -577,7 +577,7 @@ convert to TEI P3
 						<l n="182">ἕπεο μάν, ἕπε’ ὧδ’ ἀμαυρῷ</l>
 						<l>κώλῳ, πάτερ, ᾇ σ’ ἄγω.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>
 							&lt;
@@ -585,14 +585,14 @@ convert to TEI P3
 							&gt;
 						</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="184">τόλμα ξεῖνος ἐπὶ ξένης,</l>
 						<l n="185">ὦ τλάμων, ὅ τι καὶ πόλις</l>
 						<l>τέτροφεν ἄφιλον ἀποστυγεῖν</l>
 						<l>καὶ τὸ φίλον σέβεσθαι.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἄγε νυν σύ με, παῖ,</l>
 						<l>ἵν’ ἂν εὐσεβίας ἐπιβαίνοντες</l>
@@ -602,24 +602,24 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>αὐτοῦ·  μηκέτι τοῦδ’ αὐτοπέτρου</l>
 						<l>βήματος ἔξω πόδα κλίνῃς.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">οὕτως;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">ἅλις, ὡς ἀκούεις.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="195" part="I">ἦ ἑσθῶ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">λέχριός γ’ ἐπ’ ἄκρου</l>
 						<l>λᾶος βραχὺς ὀκλάσας.</l>
@@ -628,7 +628,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>πάτερ, ἐμὸν τόδ’·  ἐν ἁσυχαίᾳ</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἰώ μοί μοι.</l>
 					</sp>
@@ -638,11 +638,11 @@ convert to TEI P3
 						<l n="200">γεραὸν ἐς χέρα σῶμα σὸν</l>
 						<l>προκλίνας φιλίαν ἐμάν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὤμοι δύσφρονος ἄτας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ τλάμων, ὅτε νῦν χαλᾷς,</l>
 						<l>αὔδασον, τίς ἔφυς βροτῶν;</l>
@@ -652,41 +652,41 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὦ ξένοι,</l>
 						<l>ἀπόπτολις·  ἀλλὰ μὴ</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί τόδ’ ἀπεννέπεις, γέρον;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="210">μὴ μὴ μή μ’ ἀνέρῃ τίς εἰμι,</l>
 						<l>μηδ’ ἐξετάσῃς πέρα ματεύων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">τί τόδ’;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="M">αἰνὰ φύσις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">αὔδα.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>τέκνον, ὤμοι, τί γεγώνω;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="215">τίνος εἶ σπέρματος, ὦ ξένε, φώνει, πατρόθεν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὤμοι ἐγώ, τί πάθω, τέκνον ἐμόν;</l>
 					</sp>
@@ -694,67 +694,67 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>λέγ’, ἐπείπερ ἐπ’ ἔσχατα βαίνεις.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἀλλ’ ἐρῶ· οὐ γὰρ ἔχω κατακρυφάν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μακρὰ μέλλετον, ἀλλὰ τάχυνε.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="220" part="I">Λαΐου ἴστε τιν’;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">ὢ ἰοὺ ἰού.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">τό τε Λαβδακιδᾶν γένος;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">ὦ Ζεῦ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">ἄθλιον Οἰδιπόδαν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">σὺ γὰρ ὅδ’ εἶ;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>δέος ἴσχετε μηδὲν ὅσ’ αὐδῶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">ἰὼ ὢ ὤ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="M">δύσμορος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">ὢ ὤ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="225">θύγατερ, τί ποτ’  αὐτίκα κύρσει;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔξω πόρσω βαίνετε χώρας.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἃ δ’ ὑπέσχεο ποῖ καταθήσεις,</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐδενὶ μοιριδία τίσις ἔρχεται</l>
 						<l n="230">ἃν προπάθῃ τὸ τίνειν·  ἀπάτα δ’ ἀπά‐</l>
@@ -789,14 +789,14 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἴσθι, τέκνον Οἰδίπου, σέ τ’ ἐξ ἴσου</l>
 					<l n="255">οἰκτίρομεν καὶ τόνδε συμφορᾶς χάριν·</l>
 					<l>τὰ δ’ ἐκ θεῶν τρέμοντες οὐ σθένοιμεν ἂν</l>
 					<l>φωνεῖν πέρα τῶν πρὸς σὲ νῦν εἰρημένων.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τί δῆτα δόξης ἢ τί κληδόνος καλῆς</l>
 					<l>μάτην ῥεούσης ὠφέλημα γίγνεται,</l>
@@ -833,7 +833,7 @@ convert to TEI P3
 					<l n="290">τότ’  εἰσακούων πάντ’  ἐπιστήσει·  τὰ δὲ</l>
 					<l>μεταξὺ τούτου μηδαμῶς γίγνου κακός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ταρβεῖν μέν, ὦ γεραιέ, τἀνθυμήματα</l>
 					<l>πολλή ’στ’ ἀνάγκη τἀπὸ σοῦ· λόγοισι γὰρ</l>
@@ -841,29 +841,29 @@ convert to TEI P3
 					<l n="295">ἄνακτας ἀρκεῖ ταῦτά μοι διειδέναι.</l>
 					<milestone ed="p" n="296" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ ποῦ ’σθ’ ὁ κραίνων τῆσδε τῆς χώρας, ξένοι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πατρῷον ἄστυ γῆς ἔχει·  σκοπὸς δέ νιν,</l>
 					<l>ὃς κἀμὲ δεῦρ’ ἔπεμψεν, οἴχεται στελῶν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ καὶ δοκεῖτε τοῦ τυφλοῦ τιν’ ἐντροπὴν</l>
 					<l n="300">ἢ φροντίδ’, ἕξειν, αὐτὸν ὥστ’  ἐλθεῖν πέλας;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ κάρθ’, ὅταν  περ τοὔνομ’ αἴσθηται τὸ σόν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς δ’ ἔσθ’ ὁ κείνῳ τοῦτο τοὔπος ἀγγελῶν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>μακρὰ κέλευθος·  πολλὰ δ’ ἐμπόρων ἔπη</l>
 					<l>φιλεῖ πλανᾶσθαι, τῶν ἐκεῖνος ἀΐων,</l>
@@ -871,7 +871,7 @@ convert to TEI P3
 					<l>ὄνομα διήκει πάντας, ὥστε κεἰ βραδὺς</l>
 					<l>εὕδει, κλύων σοῦ δεῦρ’ ἀφίξεται ταχύς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ εὐτυχὴς ἵκοιτο τῇ θ’ αὑτοῦ πόλει</l>
 					<l>ἐμοί τε·  τίς γὰρ ἐσθλὸς οὐχ αὑτῷ φίλος;</l>
@@ -880,7 +880,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l n="310">ὦ Ζεῦ, τί λέξω;  ποῖ φρενῶν ἔλθω, πάτερ;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">τί δ’ ἔστι, τέκνον Ἀντιγόνη;</l>
 				</sp>
@@ -898,7 +898,7 @@ convert to TEI P3
 					<l n="320">σαίνει με προσστείχουσα·  σημαίνει δ’ ὅτι</l>
 					<l>μόνης τόδ’ ἐστὶ δῆλον Ἰσμήνης κάρα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">πῶς εἶπας, ὦ παῖ;</l>
 				</sp>
@@ -913,7 +913,7 @@ convert to TEI P3
 					<l n="325">ἥδιστα προσφωνήμαθ’, ὡς ὑμᾶς μόλις</l>
 					<l>εὑροῦσα λύπῃ δεύτερον μόλις βλέπω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὦ τέκνον, ἥκεις;</l>
 				</sp>
@@ -921,7 +921,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l part="F">ὦ πάτερ δύσμοιρ’ ὁρᾶν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">τέκνον, πέφηνας;</l>
 				</sp>
@@ -929,7 +929,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l part="F">οὐκ ἄνευ μόχθου γέ μοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">πρόσψαυσον, ὦ παῖ.</l>
 				</sp>
@@ -937,7 +937,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l part="F">θιγγάνω δυοῖν ὁμοῦ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="330" part="I">ὦ σπέρμ’ ὅμαιμον.</l>
 				</sp>
@@ -945,7 +945,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l part="F">ὦ δυσάθλιαι τροφαί.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ἦ τῆσδε κἀμοῦ;</l>
 				</sp>
@@ -953,7 +953,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l part="F">δυσμόρου τ’ ἐμοῦ τρίτης.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">τέκνον, τί δ’ ἦλθες;</l>
 				</sp>
@@ -961,7 +961,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l part="F">σῇ, πάτερ, προμηθίᾳ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">πότερα πόθοισι;</l>
 				</sp>
@@ -970,7 +970,7 @@ convert to TEI P3
 					<l part="F">καὶ λόγων γ’ αὐτάγγελος,</l>
 					<l>ξὺν ᾧπερ εἶχον οἰκετῶν πιστῷ μόνῳ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="335">οἱ δ’ αὐθόμαιμοι ποῦ νεανίαι πονεῖν;</l>
 				</sp>
@@ -979,7 +979,7 @@ convert to TEI P3
 					<l>εἴσ’ οὗπέρ εἰσι·  δεινὰ τἀν κείνοις τανῦν.</l>
 					<milestone ed="p" n="337" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ πάντ’ ἐκείνω τοῖς ἐν Αἰγύπτῳ νόμοις</l>
 					<l>φύσιν κατεικασθέντε καὶ βίου τροφάς·</l>
@@ -1034,7 +1034,7 @@ convert to TEI P3
 					<l>πόνους κατοικτιοῦσιν οὐκ ἔχω μαθεῖν.</l>
 					<milestone ed="p" n="385" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="385">ἤδη γὰρ ἔσχες ἐλπίδ’ ὡς ἐμοῦ θεοὺς</l>
 					<l>ὤραν τιν’ ἕξειν, ὥστε σωθῆναί ποτε;</l>
@@ -1043,7 +1043,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>ἔγωγε τοῖς νὺν γ’, ὦ πάτερ, μαντεύμασιν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποίοισι τούτοις; τί δὲ τεθέσπισται, τέκνον;</l>
 				</sp>
@@ -1052,7 +1052,7 @@ convert to TEI P3
 					<l>σὲ τοῖς ἐκεῖ ζητητὸν ἀνθρώποις ποτὲ</l>
 					<l n="390">θανόντ’ ἔσεσθαι ζῶντά τ’ εὐσοίας  χάριν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς δ’ ἂν τοιοῦδ’ ὑπ’ ἀνδρὸς εὖ πράξειεν ἄν;</l>
 				</sp>
@@ -1060,7 +1060,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>ἐν σοὶ τὰ κείνων  φασὶ γίγνεσθαι κράτη.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅτ’ οὐκέτ’ εἰμί, τηνικαῦτ’ ἄρ’ εἴμ’ ἀνήρ;</l>
 				</sp>
@@ -1068,7 +1068,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>νῦν γὰρ θεοί σ’ ὀρθοῦσι, πρόσθε δ’ ὤλλυσαν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="395">γέροντα δ’ ὀρθοῦν φλαῦρον ὃς νέος πέσῃ.</l>
 				</sp>
@@ -1077,7 +1077,7 @@ convert to TEI P3
 					<l>καὶ μὴν Κρέοντά γ’ ἴσθι σοι τούτων χάριν</l>
 					<l>ἥξοντα βαιοῦ κοὐχὶ μυρίου χρόνου.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅπως τί δράσῃ,  θύγατερ; ἑρμήνευέ μοι.</l>
 				</sp>
@@ -1086,7 +1086,7 @@ convert to TEI P3
 					<l>ὥς σ’ ἄγχι γῆς στήσωσι Καδμείας, ὅπως</l>
 					<l n="400">κρατῶσι μὲν σοῦ, γῆς δὲ μὴ ’μβαίνῃς ὅρων.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἡ δ’ ὠφέλησις τίς θύρασι κειμένου;</l>
 				</sp>
@@ -1094,7 +1094,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>κείνοις ὁ τύμβος δυστυχῶν ὁ σὸς βαρύς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>κἄνευ θεοῦ τις τοῦτό γ’ ἂν γνώμῃ μάθοι.</l>
 				</sp>
@@ -1103,7 +1103,7 @@ convert to TEI P3
 					<l>τούτου χάριν τοίνυν σε προσθέσθαι πέλας</l>
 					<l n="405">χώρας θέλουσι, μηδ’ ἵν’ ἂν σαυτοῦ κρατοῖς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ καὶ κατασκιῶσι Θηβαίᾳ κόνει;</l>
 				</sp>
@@ -1111,7 +1111,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>ἀλλ’ οὐκ ἐᾷ τοὔμφυλον αἷμά σ’, ὦ πάτερ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐκ ἆρ’ ἐμοῦ γε μὴ κρατήσωσίν ποτε.</l>
 				</sp>
@@ -1119,7 +1119,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>ἔσται ποτ’ ἆρα τοῦτο Καδμείοις βάρος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="410">ποίας φανείσης, ὦ τέκνον, συναλλαγῆς;</l>
 				</sp>
@@ -1127,7 +1127,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>τῆς σῆς ὑπ’ ὀργῆς, σοῖς ὅταν στῶσιν τάφοις.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἃ δ’ ἐννέπεις, κλύουσα τοῦ λέγεις, τέκνον;</l>
 				</sp>
@@ -1135,7 +1135,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>ἀνδρῶν θεωρῶν Δελφικῆς ἀφ’ ἑστίας.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ ταῦτ’ ἐφ’ ἡμῖν Φοῖβος εἰρηκὼς κυρεῖ;</l>
 				</sp>
@@ -1143,7 +1143,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l n="415">ὥς φασιν οἱ μολόντες εἰς Θήβης πέδον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>παίδων τις οὖν ἤκουσε τῶν ἐμῶν τάδε;</l>
 				</sp>
@@ -1151,7 +1151,7 @@ convert to TEI P3
 					<speaker>Ἰσμήνη</speaker>
 					<l>ἄμφω γ’ ὁμοίως, κἀξεπίστασθον καλῶς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>κᾆθ’ οἱ κάκιστοι τῶνδ’ ἀκούσαντες, πάρος</l>
 					<l>τοὐμοῦ πόθου προύθεντο τὴν τυραννίδα;</l>
@@ -1161,7 +1161,7 @@ convert to TEI P3
 					<l n="420">ἀλγῶ κλύουσα ταῦτ’  ἐγώ, φέρω δ’  ὅμως.</l>
 					<milestone ed="p" n="421" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ οἱ θεοί σφιν μήτε τὴν πεπρωμένην</l>
 					<l>ἔριν κατασβέσειαν, ἔν τ’ ἐμοὶ τέλος</l>
@@ -1205,86 +1205,86 @@ convert to TEI P3
 					<l n="460">σωτῆρ’ ἀρεῖσθε, τοῖς δ’ ἐμοῖς ἐχθροῖς πόνους.</l>
 					<milestone ed="p" n="461" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐπάξιος μέν, Οἰδίπους, κατοικτίσαι,</l>
 					<l>αὐτός τε παῖδές θ’ αἵδ’·  ἐπεὶ δὲ τῆσδε γῆς</l>
 					<l>σωτῆρα σαυτὸν τῷδ’ ἐπεμβάλλεις λόγῳ,</l>
 					<l>παραινέσαι σοι βούλομαι τὰ σύμφορα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="465">ὦ φίλταθ’, ὡς νῦν πᾶν τελοῦντι προξένει.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θοῦ νῦν καθαρμὸν τῶνδε δαιμόνων, ἐφ’ ἃς</l>
 					<l>τὸ πρῶτον ἵκου καὶ κατέστειψας πέδον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τρόποισι ποίοις; ὦ ξένοι, διδάσκετε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πρῶτον μὲν ἱερὰς ἐξ ἀειρύτου χοὰς</l>
 					<l n="470">κρήνης ἐνεγκοῦ,  δῑ ὁσίων χειρῶν θιγών.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅταν δὲ τοῦτο χεῦμ’ ἀκήρατον λάβω;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>κρατῆρές εἰσιν, ἀνδρὸς εὔχειρος τέχνη,</l>
 					<l>ὧν κρᾶτ’ ἔρεψον καὶ λαβὰς ἀμφιστόμους.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>θαλλοῖσιν ἢ κρόκαισιν, ἢ ποίῳ τρόπῳ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="475">οἰός  γε νεαρᾶς νεοπόκῳ μαλλῷ λαβών.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>εἶεν·  τὸ δ’ ἔνθεν ποῖ τελευτῆσαί με χρή;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>χοὰς χέασθαι στάντα πρὸς πρώτην ἕω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ τοῖσδε κρωσσοῖς οἷς λέγεις χέω τάδε;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τρισσάς γε πηγάς·  τὸν τελευταῖον δ’ ὅλον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="480">τοῦ τόνδε πλήσας θῶ; δίδασκε καὶ τόδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὕδατος, μελίσσης·  μηδὲ προσφέρειν μέθυ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅταν δὲ τούτων γῆ μελάμφυλλος τύχῃ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τρὶς ἐννέ’ αὐτῇ κλῶνας ἐξ ἀμφοῖν χεροῖν</l>
 					<l>τιθεὶς ἐλαίας τάσδ’ ἐπεύχεσθαι λιτάς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="485">τούτων ἀκοῦσαι βούλομαι·  μέγιστα γάρ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὥς σφας καλοῦμεν Εὐμενίδας, ἐξ εὐμενῶν</l>
 					<l>στέρνων δέχεσθαι τὸν ἱκέτην σωτήριον,</l>
@@ -1294,7 +1294,7 @@ convert to TEI P3
 					<l>δράσαντι θαρσῶν ἂν παρασταίην ἐγώ·</l>
 					<l>ἄλλως δὲ δειμαίνοιμ’ ἄν, ὦ ξέν’, ἀμφὶ σοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ παῖδε, κλύετον τῶνδε προσχώρων ξένων;</l>
 				</sp>
@@ -1302,7 +1302,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>ἠκούσαμέν τε χὤ  τι δεῖ πρόστασσε δρᾶν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="495">ἐμοὶ μὲν οὐχ ὁδωτά·  λείπομαι γὰρ ἐν</l>
 					<l>τῷ μὴ δύνασθαι μήδ’ ὁρᾶν, δυοῖν κακοῖν·</l>
@@ -1318,7 +1318,7 @@ convert to TEI P3
 					<l>ἀλλ’ εἶμ’ ἐγὼ τελοῦσα·  τὸν τόπον δ’ ἵνα</l>
 					<l>χρῆσταί μ’ ἐφευρεῖν, τοῦτο βούλομαι μαθεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="505">τοὐκεῖθεν ἄλσους, ὦ ξένη, τοῦδ’·  ἢν δέ του</l>
 					<l>σπάνιν τιν’ ἴσχῃς, ἔστ’ ἔποικος ὃς φράσει.</l>
@@ -1333,130 +1333,130 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="510">δεινὸν μὲν τὸ πάλαι κείμενον ἤδη κακόν, ὦ ξεῖν’, ἐπεγείρειν·</l>
 						<l>ὅμως δ’ ἔραμαι πυθέσθαι</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>τί τοῦτο;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τᾶς δειλαίας ἀπόρου φανείσας</l>
 						<l>ἀλγηδόνος, ᾇ ξυνέστας.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="515">μὴ πρὸς ξενίας ἀνοίξῃς</l>
 						<l>τᾶς σᾶς ἃ πέπονθ’ ἀναιδῆ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τό τοι πολὺ καὶ μηδαμὰ λῆγον</l>
 						<l>χρῄζω,  ξεῖν’, ὀρθὸν ἄκουσμ’ ἀκοῦσαι.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">ὤμοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="M">στέρξον, ἱκετεύω.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">φεῦ φεῦ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="520">πείθου·  κἀγὼ γὰρ ὅσον σὺ προσχρῄζεις.</l>
 						<milestone ed="p" n="521" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἤνεγκ’ οὖν κακότατ’, ὦ ξένοι, ἤνεγκ’ ἀέκων μέν,</l>
 						<l>θεὸς ἴστω,</l>
 						<l>τούτων δ’ αὐθαίρετον οὐδέν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’  ἐς τί;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="525">κακᾷ μ’ εὐνᾷ πόλις οὐδὲν ἴδριν</l>
 						<l>γάμων ἐνέδησεν ἄτᾳ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦ ματρόθεν, ὡς ἀκούω,</l>
 						<l>δυσώνυμα λέκτρ’ ἐπλήσω;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὤμοι θάνατος μὲν τάδ’ ἀκούειν,</l>
 						<l n="530">ὦ ξεῖν’·  αὗται δὲ δύ’ ἐξ ἐμοῦ μὲν</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πῶς φῄς;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>παῖδε, δύο δ’ ἄτα</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="532b">ὦ Ζεῦ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ματρὸς κοινᾶς ἀπέβλαστον ὠδῖνος.</l>
 						<milestone ed="p" n="534" unit="card"/>
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>σαί τ’ εἴσ’ ἄρ’  ἀπόγονοί τε καὶ </l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="535">κοιναί γε πατρὸς ἀδελφεαί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">ἰώ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">ἰὼ δῆτα μυρίων γ’ ἐπιστροφαὶ κακῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">ἔπαθες</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">ἔπαθον ἄλαστ’ ἔχειν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">ἔρεξας</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="M">οὐκ ἔρεξα.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="M">τί γάρ;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">ἐδεξάμην</l>
 						<l n="540">δῶρον, ὃ μήποτ’ ἐγὼ ταλακάρδιος</l>
@@ -1465,43 +1465,43 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δύστανε, τί γάρ; ἔθου φόνον</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>τί τοῦτο; τί δ’ ἐθέλεις μαθεῖν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">πατρός;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">παπαῖ. δευτέραν ἔπαισας, ἐπὶ νόσῳ νόσον,</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="545" part="I">ἔκανες</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">ἔκανον.  ἔχει δέ μοι</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">τί τοῦτο;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="M">πρὸς δίκας τι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="M">τί γάρ;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">ἐγὼ φράσω.</l>
 						<l>καὶ  γὰρ ἄν, οὓς ἐφόνευσ’, ἔμ’ ἀπώλεσαν·</l>
@@ -1511,12 +1511,12 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καὶ  μὴν ἄναξ ὅδ’ ἡμὶν Αἰγέως γόνος</l>
 					<l n="550">Θησεὺς κατ’  ὀμφὴν σὴν ἐφ’  ἁστάλη    πάρα.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>πολλῶν ἀκούων ἔν τε τῷ πάρος χρόνῳ</l>
 					<l>τὰς αἱματηρὰς ὀμμάτων διαφθορὰς</l>
@@ -1537,7 +1537,7 @@ convert to TEI P3
 					<l>ἔξοιδ’ ἀνὴρ ὢν χὤτι τῆς εἰς αὔριον</l>
 					<l>οὐδὲν πλέον μοι σοῦ μέτεστιν ἡμέρας.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>Θησεῦ, τὸ σὸν γενναῖον ἐν σμικρῷ λόγῳ</l>
 					<l n="570">παρῆκεν, ὥστε βραχέα μοι δεῖσθαι φράσαι.</l>
@@ -1546,122 +1546,122 @@ convert to TEI P3
 					<l>ὥστ’ ἐστί μοι τὸ λοιπὸν οὐδὲν ἄλλο πλὴν</l>
 					<l>εἰπεῖν ἃ χρῄζω, χὠ λόγος διοίχεται.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="575">τοῦτ’ αὐτὸ νῦν δίδασχ’, ὅπως ἂν ἐκμάθω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>δώσων ἱκάνω τοὐμὸν ἄθλιον δέμας</l>
 					<l>σοὶ δῶρον, οὐ σπουδαῖον εἰς ὄψιν· τὰ δὲ</l>
 					<l>κέρδη παρ’ αὐτοῦ κρείσσον’ ἢ μορφὴ καλή.</l>
 					<milestone ed="p" n="579" unit="card"/>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ποῖον δὲ κέρδος ἀξιοῖς ἥκειν φέρων;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="580">χρόνῳ μάθοις ἄν, οὐχὶ τῷ παρόντι που.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ποίῳ γὰρ ἡ σὴ προσφορὰ δηλώσεται;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅταν θάνω ’γὼ   καὶ σύ μου ταφεὺς γένῃ</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τὰ λοίσθῑ αἰτεῖ τοῦ βίου, τὰ δ’ ἐν μέσῳ</l>
 					<l>ἢ λῆστιν ἴσχεις ἢ δῑ οὐδενὸς ποεῖ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="585">ἐνταῦθα γάρ μοι κεῖνα συγκομίζεται.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἀλλ’ ἐν βραχεῖ δὴ τήνδε μ’ ἐξαιτεῖ χάριν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅρα γε μήν·  οὐ σμικρός, οὔχ, ἁγὼν ὅδε.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>πότερα τὰ τῶν σῶν ἐκγόνων κἀμοῦ  λέγεις;—</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>κεῖνοι κομίζειν κεῖσ’ ἄναξ, χρῄζουσί με.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="590">ἀλλ’  εἰ θέλοντά γ’  οὐδὲ σοὶ φεύγειν καλόν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ οὐδ’, ὅτ’ αὐτὸς ἤθελον, παρίεσαν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ὦ μῶρε, θυμὸς δ’ ἐν κακοῖς οὐ ξύμφορον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅταν μάθῃς μου, νουθέτει, τανῦν δ’ ἔα.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>δίδασκ’·  ἄνευ γνώμης γὰρ οὔ με χρὴ λέγειν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="595">πέπονθα, Θησεῦ, δεινὰ πρὸς κακοῖς κακά.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἦ τὴν παλαιὰν ξυμφορὰν γένους ἐρεῖς;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐ δῆτ’, ἐπεὶ πᾶς τοῦτό γ’ Ἑλλήνων θροεῖ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τί γὰρ τὸ μεῖζον ἢ κατ’ ἄνθρωπον νοσεῖς;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὕτως ἔχει μοι.  γῆς ἐμῆς ἀπηλάθην</l>
 					<l n="600">πρὸς τῶν ἐμαυτοῦ σπερμάτων·  ἔστιν δέ μοι</l>
 					<l>πάλιν κατελθεῖν μήποθ’, ὡς πατροκτόνῳ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>πῶς δῆτα σ’ ἂν πεμψαίαθ’, ὥστ’ οἰκεῖν δίχα;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τὸ θεῖον αὐτοὺς ἐξαναγκάσει στόμα.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ποῖον πάθος δείσαντας ἐκ χρηστηρίων;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="605">ὅτι σφ’ ἀνάγκη τῇδε πληγῆναι χθονί.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>καὶ πῶς γένοιτ’ ἂν τἀμὰ κἀκείνων πικρά;</l>
 					<milestone ed="p" n="607" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ φίλτατ’ Αἰγέως παῖ, μόνοις οὐ γίγνεται</l>
 					<l>θεοῖσι γῆρας οὐδὲ κατθανεῖν ποτε.</l>
@@ -1686,12 +1686,12 @@ convert to TEI P3
 					<l>ἀχρεῖον οἰκητῆρα δέξασθαι τόπων</l>
 					<l>τῶν ἐνθάδ’, εἴπερ μὴ θεοὶ ψεύσουσί με.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄναξ, πάλαι καὶ ταῦτα καὶ τοιαῦτ’ ἔπη</l>
 					<l n="630">γῇ τῇδ’ ὅδ’ ἁνὴρ ὡς τελῶν ἐφαίνετο.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τίς δῆτ’ ἂν ἀνδρὸς εὐμένειαν ἐκβάλοι</l>
 					<l>τοιοῦδ’, ὅτῳ πρῶτον μὲν ἡ δορύξενος</l>
@@ -1706,83 +1706,83 @@ convert to TEI P3
 					<l>κρίναντι χρῆσθαι·  τῇδε γὰρ ξυνοίσομαι.</l>
 					<milestone ed="p" n="642" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ Ζεῦ, διδοίης τοῖσι τοιούτοισιν εὖ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τί δῆτα χρῄζεις; ἦ δόμους στείχειν ἐμούς;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>εἴ μοι θέμις γ’ ἦν·  ἀλλ’ ὁ χῶρός ἐσθ’ ὅδε,</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="645">ἐν ᾧ τί πράξεις; οὐ γὰρ ἀντιστήσομαι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐν ᾧ κρατήσω τῶν ἔμ’ ἐκβεβληκότων.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>μέγ’ ἂν λέγοις δώρημα τῆς συνουσίας.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>εἰ σοί γ’ ἅπερ φὴ|ς ἐμμενεῖ τελοῦντί μοι.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>θάρσει τὸ τοῦδέ γ’ ἀνδρός·  οὔ σε μὴ προδῶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="650">οὔτοι σ’ ὑφ’ ὅρκου γ’ ὡς κακὸν πιστώσομαι.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὔκουν πέρα γ’ ἂν οὐδὲν ἢ λόγῳ φέροις.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">πῶς οὖν ποήσεις;</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">τοῦ μάλιστ’ ὄκνος σ’ ἔχει;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ἥξουσιν ἄνδρες</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">ἀλλὰ τοῖσδ’ ἔσται μέλον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὅρα με λείπων</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">μὴ δίδασχ’ ἃ χρή με δρᾶν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="655" part="I">ὀκνοῦντ’ ἀνάγκη.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">τοὐμὸν οὐκ ὀκνεῖ κέαρ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">οὐκ οἶσθ’ ἀπειλὰς</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">οἶδ’ ἐγώ σε μή τινα</l>
 					<l>ἐνθένδ’ ἀπάξοντ’ ἄνδρα πρὸς βίαν ἐμοῦ.</l>
@@ -1801,7 +1801,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εὐίππου, ξένε, τᾶσδε χώρας</l>
 						<l>ἵκου τὰ κράτιστα γᾶς ἔπαυλα,</l>
@@ -1820,7 +1820,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θάλλει δ’ οὐρανίας ὑπ’  ἄχνας</l>
 						<l>ὁ καλλίβοτρυς κατ’ ἦμαρ ἀεὶ</l>
@@ -1838,7 +1838,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χρυσάνιος Ἀφροδίτα.</l>
 						<l n="695">ἔστιν δ’ οἷον ἐγὼ γᾶς Ἀσίας οὐκ ἐπακούω</l>
@@ -1855,7 +1855,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἄλλον δ’ αἶνον ἔχω ματροπόλει τᾷδε κράτιστον</l>
 						<l n="710">δῶρον τοῦ μεγάλου δαίμονος, εἰπεῖν, χθονὸς αὔχημα μέγιστον,</l>
@@ -1877,7 +1877,7 @@ convert to TEI P3
 					<l n="720">ὦ πλεῖστ’  ἐπαίνοις εὐλογούμενον πέδον,</l>
 					<l>νῦν σὸν τὰ λαμπρὰ ταῦτα δὴ φαίνειν ἔπη.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">τί δ’ ἔστιν, ὦ παῖ, καινόν;</l>
 				</sp>
@@ -1886,12 +1886,12 @@ convert to TEI P3
 					<l part="F">ἆσσον ἔρχεται</l>
 					<l>Κρέων ὅδ’ ἡμῖν οὐκ ἄνευ πομπῶν, πάτερ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ φίλτατοι γέροντες, ἐξ ὑμῶν ἐμοὶ</l>
 					<l n="725">φαίνοιτ’ ἂν ἤδη τέρμα τῆς σωτηρίας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θάρσει, παρέσται·  καὶ γὰρ εἰ γέρων ἐγώ,</l>
 					<l>τὸ τῆσδε χώρας οὐ γεγήρακεν σθένος.</l>
@@ -1933,7 +1933,7 @@ convert to TEI P3
 					<l n="760">δίκῃ σέβοιτ’ ἄν, οὖσα σὴ πάλαι τροφός.</l>
 					<milestone ed="p" n="761" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ πάντα τολμῶν κἀπὸ παντὸς ἂν φέρων</l>
 					<l>λόγου δικαίου μηχάνημα ποικίλον,</l>
@@ -1981,7 +1981,7 @@ convert to TEI P3
 					<l n="800">πότερα νομίζεις δυστυχεῖν ἔμ’ ἐς τὰ σά,</l>
 					<l>ἤ σ’ εἰς τὰ σαυτοῦ μᾶλλον, ἐς τῷ νῦν λόγῳ;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐμοὶ μέν ἐσθ’ ἥδιστον, εἰ σὺ μήτ’ ἐμὲ</l>
 					<l>πείθειν οἷός τ’ εἶ μήτε τούσδε τοὺς πέλας.</l>
@@ -1991,7 +1991,7 @@ convert to TEI P3
 					<l>ὦ δύσμορ’, οὐδὲ τῷ χρόνῳ φύσας φανεῖ</l>
 					<l n="805">φρένας ποτ’ ἀλλὰ λῦμα τῷ γήρᾳ τρέφει;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>γλώσσῃ σὺ δεινός·  ἄνδρα δ’ οὐδέν’ οἶδ’ ἐγὼ</l>
 					<l>δίκαιον ὅστις ἐξ ἅπαντος εὖ λέγει.</l>
@@ -2000,7 +2000,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>χωρὶς τό τ’ εἰπεῖν πολλὰ καὶ τὰ καίρια.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὡς δὴ σὺ βραχέα, ταῦτα δ’ ἐν καιρῷ λέγεις.</l>
 				</sp>
@@ -2008,7 +2008,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="810">οὐ δῆθ’  ὅτῳ γε νοῦς ἴσος καὶ σοὶ πάρα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἄπελθ’, ἐρῶ γὰρ καὶ πρὸ τῶνδε, μηδέ με</l>
 					<l>φύλασσ’ ἐφορμῶν ἔνθα χρὴ ναίειν ἐμέ.</l>
@@ -2018,7 +2018,7 @@ convert to TEI P3
 					<l>μαρτύρομαι τούσδ’, οὐ σέ· πρὸς δὲ τοὺς φίλους</l>
 					<l>οἷ’ ἀνταμείβει ῥήματ’, ἤν σ’ ἕλω ποτέ</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="815">τίς δ’ ἄν με τῶνδε συμμάχων ἕλοι βίᾳ;</l>
 				</sp>
@@ -2026,7 +2026,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>ἦ μὴν σὺ κἄνευ τοῦδε λυπηθεὶς ἔσει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποίῳ σὺν ἔργῳ τοῦτ’ ἀπειλήσας ἔχεις;</l>
 				</sp>
@@ -2035,7 +2035,7 @@ convert to TEI P3
 					<l>παίδοιν δυοῖν σοι τὴν μὲν ἀρτίως ἐγὼ</l>
 					<l>ξυναρπάσας ἔπεμψα, τὴν δ’ ἄξω τάχα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">οἴμοι.</l>
 				</sp>
@@ -2043,7 +2043,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="820" part="F">τάχ’  ἕξεις μᾶλλον οἰμώζειν τάδε.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">τὴν παῖδ’ ἔχεις μου;</l>
 				</sp>
@@ -2051,12 +2051,12 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">τήνδε τ’ οὐ μακροῦ χρόνου.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἰὼ ξένοι, τί δράσετ’; ἦ προδώσετε,</l>
 					<l>κοὐκ ἐξελᾶτε τὸν ἀσεβῆ τῆσδε χθονός;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>χώρει, ξέν’, ἔξω θᾶσσον.  οὔτε γὰρ τὰ νῦν</l>
 					<l n="825">δίκαια πράσσεις οὔθ’ ἃ πρόσθεν εἴργασαι.</l>
@@ -2071,7 +2071,7 @@ convert to TEI P3
 					<l>οἴμοι τάλαινα, ποῖ φύγω; ποίαν λάβω</l>
 					<l part="I">θεῶν ἄρηξιν ἢ βροτῶν;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="F">τί δρᾷς, ξένε;</l>
 				</sp>
@@ -2079,11 +2079,11 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="830">οὐχ ἅψομαι τοῦδ’ ἀνδρός, ἀλλὰ τῆς ἐμῆς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὦ γῆς ἄνακτες.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="F">ὦ ξέν’, οὐ δίκαια δρᾷς.</l>
 				</sp>
@@ -2091,7 +2091,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">δίκαια.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="M">πῶς δίκαια;</l>
 				</sp>
@@ -2099,11 +2099,11 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">τοὺς ἐμοὺς ἄγω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἰὼ πόλις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="835">τί δρᾷς, ὦ ξέν’; οὐκ ἀφήσεις; τάχ’ εἰς βάσανον εἶ χερῶν.</l>
 				</sp>
@@ -2111,7 +2111,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">εἴργου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="F">σοῦ μὲν οὔ, τάδε γε μωμένου.</l>
 				</sp>
@@ -2119,11 +2119,11 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>πόλει μαχεῖ γάρ, εἴ τι πημανεῖς ἐμέ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">οὐκ ἠγόρευον ταῦτ’ ἐγώ;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="F">μέθες χεροῖν</l>
 					<l part="I">τὴν παῖδα θᾶσσον.</l>
@@ -2132,7 +2132,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">μὴ ’πίτασσ’ ἃ μὴ κρατεῖς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="840" part="I">χαλᾶν λέγω σοι.</l>
 				</sp>
@@ -2140,7 +2140,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">σοὶ  δ’ ἔγωγ’ ὁδοιπορεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πρόβαθ’ ὧδε, βᾶτε βᾶτ’, ἔντοποι·</l>
 					<l>πόλις ἐναίρεται, πόλις ἐμά, σθένει·  πρόβαθ’ ὧδέ μοι.</l>
@@ -2149,7 +2149,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>ἀφέλκομαι δύστηνος,  ὦ ξένοι ξένοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="845" part="I">ποῦ, τέκνον, εἴ μοι;</l>
 				</sp>
@@ -2157,7 +2157,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l part="F">πρὸς βίαν πορεύομαι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὄρεξον, ὦ παῖ, χεῖρας.</l>
 				</sp>
@@ -2169,7 +2169,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">οὐκ ἄξεθ’ ὑμεῖς;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">ὦ τάλας ἐγώ, τάλας.</l>
 					<milestone ed="p" n="848" unit="card"/>
@@ -2185,7 +2185,7 @@ convert to TEI P3
 					<l>δρᾷς οὔτε πρόσθεν εἰργάσω βίᾳ φίλων,</l>
 					<l n="855">ὀργῇ χάριν δούς, ἥ σ’ ἀεὶ λυμαίνεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">ἐπίσχες αὐτοῦ,  ξεῖνε.</l>
 				</sp>
@@ -2193,7 +2193,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">μὴ ψαύειν λέγω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὔτοι σ’ ἀφήσω, τῶνδέ γ’ ἐστερημένος.</l>
 				</sp>
@@ -2202,7 +2202,7 @@ convert to TEI P3
 					<l>καὶ μεῖζον ἆρα ῥύσιον πόλει τάχα</l>
 					<l>θήσεις·  ἐφάψομαι γὰρ οὐ ταύταιν μόναιν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="860" part="I">ἀλλ’ ἐς τί τρέψει;</l>
 				</sp>
@@ -2210,7 +2210,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">τόνδ’  ἀπάξομαι λαβών.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">δεινὸν λέγοις ἄν.</l>
 				</sp>
@@ -2218,11 +2218,11 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">τοῦτο νῦν πεπράξεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἢν μή σ’ ὁ κραίνων τῆσδε γῆς ἀπειργάθῃ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ φθέγμ’ ἀναιδές, ἦ σὺ γὰρ ψαύσεις ἐμοῦ;</l>
 				</sp>
@@ -2230,7 +2230,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">αὐδῶ σιωπᾶν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">μὴ γὰρ αἵδε δαίμονες</l>
 					<l n="865">θεῖέν μ’ ἄφωνον τῆσδε τῆς ἀρᾶς ἔτι,</l>
@@ -2244,7 +2244,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>ὁρᾶτε ταῦτα, τῆσδε γῆς ἐγχώριοι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὁρῶσι κἀμὲ καὶ σέ, καὶ φρονοῦσ’ ὅτι</l>
 					<l>ἔργοις πεπονθὼς ῥήμασίν σ’ ἀμύνομαι.</l>
@@ -2254,11 +2254,11 @@ convert to TEI P3
 					<l>οὔτοι καθέξω θυμόν, ἀλλ’ ἄξω βίᾳ</l>
 					<l n="875">κεἰ μοῦνός εἰμι τόνδε καὶ χρόνῳ βραδύς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἰὼ τάλας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅσον λῆμ’ ἔχων ἀφίκου, ξέν’, εἰ τάδε δοκεῖς τελεῖν.</l>
 				</sp>
@@ -2266,7 +2266,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">δοκῶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="F">τάνδ’ ἄρ’ οὐκέτι νεμῶ πόλιν.</l>
 				</sp>
@@ -2274,11 +2274,11 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="880">τοῖς τοι δικαίοις χὠ βραχὺς νικᾷ μέγαν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ἀκούεθ’ οἷα φθέγγεται;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="F">τά γ’ οὐ τελεῖ.</l>
 					<l part="I">[ἴστω μέγας Ζεύς.]</l>
@@ -2287,7 +2287,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">Ζεύς γ’ ἂν εἰδείη, σὺ δ’ οὔ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">ἆρ’ οὐχ ὕβρις τάδ’;</l>
 				</sp>
@@ -2295,42 +2295,42 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="F">ὕβρις, ἀλλ’ ἀνεκτέα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἰὼ πᾶς λεώς, ἰὼ γᾶς πρόμοι,</l>
 					<l n="885">μόλετε σὺν τάχει, μόλετ’, ἐπεὶ πέραν περῶσ’ οἵδε δή.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς ποθ’ ἡ βοή; τί τοὔργον; ἐκ τίνος φόβου ποτὲ</l>
 					<l>βουθυτοῦντά μ’ ἀμφὶ βωμὸν ἔσχετ’ ἐναλίῳ θεῷ</l>
 					<l>τοῦδ’ ἐπιστάτῃ Κολωνοῦ; λέξαθ’, ὡς εἰδῶ τὸ πᾶν,</l>
 					<l n="890">οὗ χάριν δεῦρ’ ᾖξα θᾶσσον ἢ καθ’  ἡδονὴν   ποδός.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ φίλτατ’, ἔγνων γὰρ τὸ προσφώνημά σου,</l>
 					<l>πέπονθα δεινὰ τοῦδ’ ὑπ’ ἀνδρὸς ἀρτίως.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τὰ ποῖα ταῦτα, τίς δ’ ὁ πημήνας; λέγε.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>Κρέων ὅδ’, ὃν δέδορκας, οἴχεται τέκνων</l>
 					<l n="895">ἀποσπάσας μου τὴν μόνην ξυνωρίδα.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="I">πῶς εἶπας;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">οἷά περ πέπονθ’ ἀκήκοας.</l>
 					<milestone ed="p" n="897" unit="card"/>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὔκουν τις ὡς τάχιστα προσπόλων μολὼν</l>
 					<l>πρὸς τούσδε βωμούς, πάντ’ ἀναγκάσει λεὼν</l>
@@ -2373,7 +2373,7 @@ convert to TEI P3
 					<l n="935">εἶναι βίᾳ τε κοὐχ ἑκών·  καὶ ταῦτά σοι</l>
 					<l>τῷ νῷ θ’ ὁμοίως κἀπὸ τῆς γλώσσης λέγω.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὁρᾷς ἵν’ ἥκεις, ὦ ξέν’; ὡς ἀφ’ ὧν μὲν εἶ</l>
 					<l>φαίνει δίκαιος, δρῶν δ’ ἐφευρίσκει κακά.</l>
@@ -2404,7 +2404,7 @@ convert to TEI P3
 					<l>καὶ τηλικόσδ’ ὤν, ἀντιδρᾶν πειράσομαι.</l>
 					<milestone ed="p" n="960" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="960">ὦ λῆμ’  ἀναιδές, τοῦ καθυβρίζειν δοκεῖς,</l>
 					<l>πότερον ἐμοῦ γέροντος ἢ σαυτοῦ, τόδε;</l>
@@ -2462,12 +2462,12 @@ convert to TEI P3
 					<l>οἵων ὑπ’ ἀνδρῶν ἥδε φρουρεῖται πόλις.</l>
 					<milestone ed="p" n="1014" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὁ ξεῖνος, ὦναξ, χρηστός·  αἱ δὲ συμφοραὶ</l>
 					<l n="1015">αὐτοῦ πανώλεις, ἄξιαι δ’ ἀμυναθεῖν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἅλις λόγων, ὡς οἱ μὲν ἐξειργασμένοι</l>
 					<l>σπεύδουσιν, ἡμεῖς δ’ οἱ παθόντες ἕσταμεν.</l>
@@ -2476,7 +2476,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>τί δῆτ’ ἀμαυρῷ φωτὶ προστάσσεις ποεῖν;</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ὁδοῦ κατάρχειν τῆς ἐκεῖ, πομπὸν δέ με</l>
 					<l n="1020">χωρεῖν, ἵν’, εἰ μὲν ἐν τόποισι τοῖσδ’ ἔχεις</l>
@@ -2501,14 +2501,14 @@ convert to TEI P3
 					<l>οὐδὲν σὺ μεμπτὸν ἐνθάδ’ ὢν ἐρεῖς ἐμοί·</l>
 					<l>οἴκοι δὲ χἠμεῖς εἰσόμεσθ’ ἃ χρὴ ποεῖν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>χωρῶν ἀπείλει νῦν·  σὺ δ’ ἡμίν, Οἰδίπους,</l>
 					<l>ἕκηλος αὐτοῦ μίμνε, πιστωθεὶς ὅτι,</l>
 					<l n="1040">ἢν μὴ θάνω ’γὼ πρόσθεν, οὐχὶ παύσομαι</l>
 					<l>πρὶν ἄν σε τῶν σῶν κύριον στήσω τέκνων.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὄναιο, Θησεῦ, τοῦ τε γενναίου χάριν</l>
 					<l>καὶ τῆς πρὸς ἡμᾶς ἐνδίκου προμηθίας.</l>
@@ -2517,7 +2517,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἴην ὅθι δαΐων</l>
 						<l n="1045">ἀνδρῶν τάχ’ ἐπιστροφαὶ</l>
@@ -2537,7 +2537,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἤ που τὸν ἐφεσπέρου</l>
 						<l n="1060">πέτρας νιφάδος πελῶσ’</l>
@@ -2557,7 +2557,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔρδουσ’ ἢ μέλλουσιν;  ὡς</l>
 						<l n="1075">προμνᾶταί τί μοι</l>
@@ -2572,7 +2572,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1085">ἰὼ θεῶν πάνταρχε, παντ‐</l>
 						<l>όπτα Ζεῦ, πόροις</l>
@@ -2591,7 +2591,7 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ποῦ ποῦ; τί φής; πῶς εἶπας;</l>
 				</sp>
@@ -2601,7 +2601,7 @@ convert to TEI P3
 					<l n="1100">τίς ἂν θεῶν σοι τόνδ’ ἄριστον ἄνδρ’ ἰδεῖν</l>
 					<l>δοίη, τὸν ἡμᾶς δεῦρο προσπέμψαντά σοι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὦ τέκνον, ἦ πάρεστον;</l>
 				</sp>
@@ -2610,7 +2610,7 @@ convert to TEI P3
 					<l part="F">αἵδε γὰρ χέρες</l>
 					<l>Θησέως ἔσωσαν φιλτάτων τ’ ὀπαόνων.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>προσέλθετ’ ὦ παῖ, πατρὶ καὶ τὸ μηδαμὰ</l>
 					<l n="1105">ἐλπισθὲν ἥξειν σῶμα βαστάσαι δότε.</l>
@@ -2619,7 +2619,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l>αἰτεῖς ἃ τεύξει· σὺν πόθῳ γὰρ ἡ χάρις.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ποῦ δῆτα, ποῦ ’στόν;</l>
 				</sp>
@@ -2627,7 +2627,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l part="F">αἵδ’ ὁμοῦ πελάζομεν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὦ φίλτατ’ ἔρνη.</l>
 				</sp>
@@ -2635,7 +2635,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l part="F">τῷ τεκόντι πᾶν φίλον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὦ σκῆπτρα φωτός.</l>
 				</sp>
@@ -2643,7 +2643,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l part="F">δυσμόρου γε δύσμορα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1110">ἔχω τὰ φίλτατ’, οὐδ’  ἔτ’  ἂν πανάθλιος</l>
 					<l>θανὼν ἂν εἴην σφῷν παρεστώσαιν ἐμοί.</l>
@@ -2658,7 +2658,7 @@ convert to TEI P3
 					<l>ὅδ’ ἔσθ’ ὁ σώσας·  τοῦδε χρὴ κλύειν, πάτερ,</l>
 					<l>οὗ κἄστι τοὔργον·  τοὐμὸν ὧδ’ ἔσται βραχύ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ ξεῖνε, μὴ θαύμαζε, πρὸς τὸ λιπαρὲς</l>
 					<l n="1120">τέκν’  εἰ φανέντ’  ἄελπτα μηκύνω λόγον.</l>
@@ -2682,7 +2682,7 @@ convert to TEI P3
 					<l>μέλου δικαίως, ὥσπερ ἐς τόδ’ ἡμέρας.</l>
 					<milestone ed="p" n="1139" unit="card"/>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὔτ’ εἴ τι μῆκος τῶν λόγων ἔθου πλέον,</l>
 					<l n="1140">τέκνοισι τερφθεὶς τοῖσδε, θαυμάσας ἔχω,</l>
@@ -2700,82 +2700,82 @@ convert to TEI P3
 					<l>σμικρὸς μὲν εἰπεῖν, ἄξιος δὲ θαυμάσαι·</l>
 					<l>πρᾶγος δ’ ἀτίζειν οὐδὲν ἄνθρωπον χρεών.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τί δ’ ἔστι, τέκνον Αἰγέως; δίδασκέ με</l>
 					<l n="1155">ὡς μὴ εἰδότ’ αὐτὸν μηδὲν ὧν σὺ πυνθάνει.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>φασίν τιν’ ἡμῖν ἄνδρα, σοὶ μὲν ἔμπολιν</l>
 					<l>οὐκ ὄντα, συγγενῆ δέ, προσπεσόντα πως</l>
 					<l>βωμῷ καθῆσθαι τῷ Ποσειδῶνος, παρ’ ᾧ</l>
 					<l>θύων ἔκυρον, ἡνίχ’ ὡρμώμην ἐγώ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1160">ποδαπόν;  τί προσχρῄζοντα τῷ θακήματι·</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>οὐκ οἶδα πλὴν ἕν·  σοῦ γάρ, ὡς λέγουσί μοι,</l>
 					<l>βραχύν τιν’ αἰτεῖ μῦθον οὐκ ὄγκου πλέων.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποῖόν τιν’; οὐ γὰρ ἥδ’ ἕδρα σμικροῦ λόγου.</l>
 					<l>σοὶ φασὶν αὐτὸν ἐς λόγους ἐλθεῖν μόνον</l>
 					<l n="1165">αἰτεῖν ἀπελθεῖν τ’ ἀσφαλῶς τῆς δεῦρ’ ὁδοῦ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς δῆτ’ ἂν εἴη τήνδ’ ὁ προσθακῶν ἕδραν;</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ὅρα κατ’ Ἄργος εἴ τις ὑμὶν ἐγγενὴς</l>
 					<l>ἔσθ’, ὅστις ἄν σου τοῦτο προσχρῄζοι τυχεῖν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὦ φίλτατε, σχὲς οὗπερ εἶ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">τί δ’ ἔστι σοι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1170" part="I">μή μου δεηθῇς.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">πράγματος ποίου;  λέγε.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἔξοιδ’ ἀκούων τῶνδ’ ὅς ἐσθ’ ὁ προστάτης.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>καὶ τίς ποτ’ ἐστὶν ὅν γ’ ἐγὼ ψέξαιμί τι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>παῖς οὑμός, ὦναξ, στυγνός, οὗ λόγων ἐγὼ</l>
 					<l>ἄλγιστ’ ἂν ἀνδρῶν ἐξανασχοίμην κλύων.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="1175">τί δ’; οὐκ ἀκούειν ἔστι καὶ μὴ δρᾶν ἃ μὴ</l>
 					<l>χρῄζεις; τί σοι τοῦτ’ ἐστὶ λυπηρὸν κλύειν;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἔχθιστον, ὦναξ, φθέγμα τοῦθ’ ἥκει πατρί·</l>
 					<l>καὶ μή μ’ ἀνάγκῃ προσβάλῃς τάδ’ εἰκαθεῖν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἀλλ’ εἰ τὸ θάκημ’ ἐξαναγκάζει, σκόπει</l>
 					<l n="1180">μή σοι πρόνοῑ ᾖ τοῦ θεοῦ φυλακτέα.</l>
@@ -2807,14 +2807,14 @@ convert to TEI P3
 					<l>δίκαια προσχρῄζουσιν, οὐδ’ αὐτὸν μὲν εὖ</l>
 					<l>πάσχειν, παθόντα δ’ οὐκ ἐπίστασθαι τίνειν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1205">τέκνον, βαρεῖαν ἡδονὴν νικᾶτέ με</l>
 					<l>λέγοντες·  ἔστω δ’ οὖν ὅπως ὑμῖν φίλον.</l>
 					<l>μόνον, ξέν’, εἴπερ κεῖνος ὧδ’ ἐλεύσεται,</l>
 					<l>μηδεὶς κρατείτω τῆς ἐμῆς ψυχῆς ποτε.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>ἅπαξ τὰ τοιαῦτ’, οὐχὶ δὶς χρῄζω κλύειν,</l>
 					<l>ὦ πρέσβυ.  κομπεῖν δ’ οὐχὶ βούλομαι·  σὺ δ’ ὢν</l>
@@ -2824,7 +2824,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅστις τοῦ πλέονος μέρους χρῄζει τοῦ μετρίου παρεὶς</l>
 						<l>ζώειν, σκαιοσύναν φυλάσσων</l>
@@ -2840,7 +2840,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1225">μὴ φῦναι τὸν ἅπαντα νικᾷ λόγον·  τὸ δ’, ἐπεὶ φανῇ,</l>
 						<l>βῆναι κεῖθεν ὅθεν περ ἥκει,</l>
@@ -2856,7 +2856,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐν ᾧ τλάμων ὅδ’, οὐκ ἐγὼ μόνος,</l>
 						<l n="1240">πάντοθεν βόρειος ὥς τις</l>
@@ -2879,11 +2879,11 @@ convert to TEI P3
 					<l n="1250">ἀνδρῶν γε μοῦνος, ὦ πάτερ, δῑ  ὄμματος</l>
 					<l>ἀστακτὶ λείβων δάκρυον ὧδ’ ὁδοιπορεῖ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">τίς οὗτος;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">ὅνπερ καὶ πάλαι κατείχομεν</l>
 					<l>γνώμῃ, πάρεστι δεῦρο Πολυνείκης ὅδε.</l>
@@ -2991,12 +2991,12 @@ convert to TEI P3
 					<l n="1345">κομπεῖν, ἄνευ σοῦ δ’ οὐδὲ σωθῆναι σθένω.</l>
 					<milestone ed="p" n="1346" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τὸν ἄνδρα τοῦ πέμψαντος οὕνεκ’, Οἰδίπους</l>
 					<l>εἰπὼν ὁποῖα ξύμφορ’ ἔκπεμψαι πάλιν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ εἰ μέν, ἄνδρες, τῆσδε δημοῦχοι χθονός</l>
 					<l>μὴ ’τύγχαν’ αὐτὸν δεῦρο προσπέμψας ἐμοὶ</l>
@@ -3049,7 +3049,7 @@ convert to TEI P3
 					<l>τοιαῦτ’ ἔνειμε παισὶ τοῖς αὑτοῦ γέρα.</l>
 					<milestone ed="p" n="1397" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>Πολύνεικες, οὔτε ταῖς παρελθούσαις ὁδοῖς</l>
 					<l>ξυνήδομαί σοι, νῦν τ’ ἴθ’ ὡς τάχος πάλιν.</l>
@@ -3175,7 +3175,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νέα τάδε νεόθεν ἦλθέ μοι</l>
 						<l>κακὰ βαρύποτμὰ παρ’ ἀλαοῦ ξένου,</l>
@@ -3185,7 +3185,7 @@ convert to TEI P3
 						<l n="1455">τὰ δὲ παρ’  ἦμαρ αὖθις αὔξων ἄνω.</l>
 						<l>ἔκτυπεν αἰθήρ, ὦ Ζεῦ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὦ τέκνα τέκνα, πῶς ἄν, εἴ τις ἔντοπος,</l>
 						<l>τὸν πάντ’ ἄριστον δεῦρο Θησέα πόροι;</l>
@@ -3194,7 +3194,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>πάτερ, τί δ’ ἐστὶ τἀξίωμ’ ἐφ’ ᾧ καλεῖς;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1460">Διὸς πτερωτὸς ἥδε μ’  αὐτίκ’  ἄξεται</l>
 						<l>βροντὴ πρὸς Ἅιδην·  ἀλλὰ πέμψαθ’ ὡς τάχος.</l>
@@ -3202,7 +3202,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μέγας, ἴδε, μάλ’ ὅδ’ ἐρείπεται</l>
 						<l>κτύπος ἄφατος διόβολος· ἐς δ’ ἄκραν</l>
@@ -3212,7 +3212,7 @@ convert to TEI P3
 						<l n="1470">ἀφορμᾷ ποτ’, οὐκ ἄνευ ξυμφορᾶς.</l>
 						<l>ὦ μέγας αἰθήρ, ὦ Ζεῦ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὦ παῖδες, ἥκει τῷδ’ ἐπ’ ἀνδρὶ θέσφατος</l>
 						<l>βίου τελευτὴ κοὐκέτ’ ἔστ’ ἀποστροφή.</l>
@@ -3221,7 +3221,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>πῶς οἶσθα; τῷ δὲ τοῦτο συμβαλὼν ἔχεις;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1475">καλῶς κάτοιδ’·  ἀλλ’ ὡς τάχιστά μοι μολὼν</l>
 						<l>ἄνακτα χώρας τῆσδέ τις πορευσάτω.</l>
@@ -3229,7 +3229,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔα ἔα, ἰδοὺ μάλ’  αὖθις ἀμφίσταται διαπρύσιος ὄτοβος.</l>
 						<l n="1480">ἵλαος, ὦ δαίμων, ἵλαος  εἴ τι γᾷ</l>
@@ -3237,7 +3237,7 @@ convert to TEI P3
 						<l>ἐναισίου δὲ σοῦ τύχοιμι, μηδ’ ἄλαστον ἄνδρ’ ἰδὼν</l>
 						<l>ἀκερδῆ χάριν μετάσχοιμί πως.  Ζεῦ ἄνα σοὶ φωνῶ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1486">ἆρ’ ἐγγὺς ἁνήρ; ἆρ’ ἔτ’ ἐμψύχου, τέκνα,</l>
 						<l>κιχήσεταί μου καὶ κατορθοῦντος φρένα;</l>
@@ -3246,7 +3246,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>τί δ’ ἂν θέλοις τὸ πιστὸν ἐμφῦναι φρενί;</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἀνθ’ ὧν ἔπασχον εὖ, τελεσφόρον χάριν</l>
 						<l n="1490">δοῦναί σφιν, ἥνπερ τυγχάνων ὑπεσχόμην.</l>
@@ -3254,7 +3254,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ ἰὼ παῖ, βᾶθι βᾶθ’, εἴτ’  ἄκρα,</l>
 						<l>περὶ γύαλ’ ἐναλίῳ Ποσειδωνίῳ θεῷ, τυγχάνεις</l>
@@ -3267,7 +3267,7 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="1500">τίς αὖ παρ’  ὑμῶν κοινὸς ἠχεῖται κτύπος,</l>
 					<l>σαφὴς μὲν ἀστῶν, ἐμφανὴς δὲ τοῦ ξένου;</l>
@@ -3275,44 +3275,44 @@ convert to TEI P3
 					<l>χάλαζ’ ἐπιρράξασα; πάντα γὰρ θεοῦ</l>
 					<l>τοιαῦτα χειμάζοντος εἰκάσαι πάρα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1505">ἄναξ, ποθοῦντι προυφάνης, καί σοι θεῶν</l>
 					<l>τύχην τις ἐσθλὴν τῆσδ’ ἔθηκε τῆς ὁδοῦ.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τί δ’ ἐστίν, ὦ παῖ Λαΐου, νέορτον αὖ;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ῥοπὴ βίου μοι·  καί σ’ ἅπερ ξυνῄνεσα</l>
 					<l>θέλω πόλιν τε τήνδε μὴ ψεύσας θανεῖν.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l n="1510">τῷ δ’  ἐκπέπεισαι τοῦ μόρου τεκμηρίῳ;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>αὐτοὶ θεοὶ κήρυκες ἀγγέλλουσί μοι,</l>
 					<l>ψεύδοντες οὐδὲν σῆμα τῶν προκειμένων.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>πῶς εἶπας, ὦ γεραιέ, δηλοῦσθαι τάδε;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>αἱ πολλὰ βρονταὶ διατελεῖς τὰ πολλά τε</l>
 					<l n="1515">στράψαντα χειρὸς τῆς ἀνικήτου βέλη.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>πείθεις με·  πολλὰ γάρ σε θεσπίζονθ’ ὁρῶ</l>
 					<l>κοὐ ψευδόφημα·  χὤ τι χρὴ ποιεῖν λέγε.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐγὼ διδάξω, τέκνον Αἰγέως, ἅ σοι</l>
 					<l>γήρως ἄλυπα τῇδε κείσεται πόλει.</l>
@@ -3357,7 +3357,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ θέμις ἐστί μοι τὰν ἀφανῆ θεὸν</l>
 						<l>καὶ σὲ λιταῖς σεβίζειν,</l>
@@ -3374,7 +3374,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ χθόνιαι θεαὶ σῶμά τ’ ἀνικάτου</l>
 						<l>θηρός, ὃν ἐν πύλαισι</l>
@@ -3392,27 +3392,27 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἄνδρες πολῖται, ξυντομωτάτως, μὲν ἂν</l>
 					<l n="1580">τύχοιμι λέξας Οἰδίπουν ὀλωλότα·</l>
 					<l>ἃ δ’ ἦν τὰ πραχθέντ’, οὔθ’ ὁ μῦθος ἐν βραχεῖ</l>
 					<l>φράσαι πάρεστιν οὔτε τἄργ’ ὅσ’ ἦν ἐκεῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">ὄλωλε γὰρ δύστηνος;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l part="F">ὡς λελοιπότα</l>
 					<l>κεῖνον τὸν ἀεὶ βίοτον ἐξεπίστασο.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1585">πῶς; ἆρα θείᾳ κἀπόνῳ τάλας τύχῃ;</l>
 				</sp>
-				<sp n="Ἀγγελος" who="#aggelos">
+				<sp n="Ἀγγελος" who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ταῦτ’ ἐστὶν ἤδη κἀποθαυμάσαι πρέπον.</l>
 					<l>ὡς μὲν γὰρ ἐνθένδ’ εἷρπε, καὶ σύ που παρὼν</l>
@@ -3497,11 +3497,11 @@ convert to TEI P3
 					<l n="1665">θαυμαστός.  εἰ δὲ μὴ δοκῶ φρονῶν λέγειν,</l>
 					<l>οὐκ ἂν παρείμην οἷσι μὴ δοκῶ φρονεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ποῦ δ’ αἵ τε παῖδες χοἰ προπέμψαντες φίλων;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>αἵδ’ οὐχ ἑκάς·  γόων γὰρ οὐκ ἀσήμονες</l>
 					<l>φθόγγοι σφε σημαίνουσι δεῦρ’ ὁρμωμένας.</l>
@@ -3520,7 +3520,7 @@ convert to TEI P3
 						<l n="1675">ἐν πυμάτῳ δ’ ἀλόγιστα παροίσομεν</l>
 						<l>ἰδόντε καὶ παθόντε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί δ’ ἔστιν;</l>
 					</sp>
@@ -3528,7 +3528,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l>ἔστιν μὲν εἰκάσαι, φίλοι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">βέβηκεν;</l>
 					</sp>
@@ -3550,7 +3550,7 @@ convert to TEI P3
 						<l>Ἀΐδας ἕλοι πατρὶ ξυνθανεῖν γεραιῷ</l>
 						<l n="1690">τάλαιναν, ὡς ἔμοιγ’ ὁ μέλλων βίος οὐ βιωτός.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ διδύμα τέκνων ἀρίστα,</l>
 						<l>τὸ φέρον ἐκ θεοῦ φέρειν,</l>
@@ -3569,7 +3569,7 @@ convert to TEI P3
 						<l>οὐδέ γ’ ἔνερθ’  ἀφίλητος ἐμοί ποτε</l>
 						<l n="1705">καὶ τᾷδε μὴ κυρήσῃς.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">ἔπραξεν;</l>
 					</sp>
@@ -3577,7 +3577,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="F">ἔπραξεν οἷον ἤθελεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">τὸ ποῖον;</l>
 					</sp>
@@ -3604,7 +3604,7 @@ convert to TEI P3
 						</l>
 						<l n="1719">ἐπαμμένει σέ τ’, ὦ φίλα, τὰς πατρὸς ὧδ’ ἐρήμας;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1720">ἀλλ’ ἐπεὶ ὀλβίως γ’ ἔλυσεν</l>
 						<l>τὸ τέλος, ὦ φίλαι, βίου,</l>
@@ -3675,7 +3675,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">φίλαι, τρέσητε μηδέν.</l>
 					</sp>
@@ -3683,7 +3683,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="F">ἀλλὰ ποῖ φύγω;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">καὶ πάρος ἀπέφυγε</l>
 					</sp>
@@ -3691,7 +3691,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="F">τί;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1740">τὰ σφῷν τὸ  μὴ πίτνειν κακῶς.</l>
 					</sp>
@@ -3699,7 +3699,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="I">φρονῶ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">τί δῆθ’ ὅπερ νοεῖς;</l>
 					</sp>
@@ -3708,7 +3708,7 @@ convert to TEI P3
 						<l>ὅπως μολούμεθ’ ἐς δόμους</l>
 						<l part="I">οὐκ ἔχω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">μηδέ γε μάτευε.</l>
 					</sp>
@@ -3716,7 +3716,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="I">μόγος ἔχει.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">καὶ πάρος ἐπεῖχε.</l>
 					</sp>
@@ -3724,7 +3724,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l n="1745">τοτὲ μὲν ἄπορα, τοτὲ δ’ ὕπερθεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μέγ’ ἄρα πέλαγος ἐλάχετόν τι.</l>
 					</sp>
@@ -3732,7 +3732,7 @@ convert to TEI P3
 						<speaker>Ἀντιγόνη</speaker>
 						<l part="I">ναὶ ναί.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">ξύμφημι καὐτός.</l>
 					</sp>
@@ -3746,7 +3746,7 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>παύετε θρήνων, παῖδες·  ἐν οἷς γὰρ</l>
 					<l>χάρις ἡ χθονία ξύν’ ἀπόκειται,</l>
@@ -3756,7 +3756,7 @@ convert to TEI P3
 					<speaker>Ἀντιγόνη</speaker>
 					<l n="1755">ὦ τέκνον Αἰγέως, προσπίτνομέν σοι.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l>τίνος, ὦ παῖδες, χρείας ἀνύσαι;</l>
 				</sp>
@@ -3765,7 +3765,7 @@ convert to TEI P3
 					<l>τύμβον θέλομεν προσιδεῖν αὐταὶ</l>
 					<l part="I">πατρὸς ἡμετέρου.</l>
 				</sp>
-				<sp who="#theseys">
+				<sp who="#theseus">
 					<speaker>Θησεύς</speaker>
 					<l part="F">ἀλλ’ οὐ θεμιτόν.</l>
 				</sp>
@@ -3774,7 +3774,7 @@ convert to TEI P3
 					<l>πῶς εἶπας, ἄναξ,     κοίραν’ Ἀθηνῶν;</l>
 				</sp>
 				<div2 met="anapests" type="close">
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l n="1765">ὦ παῖδες, ἀπεῖπεν ἐμοὶ κεῖνος</l>
 						<l>μήτε πελάζειν ἐς τούσδε τόπους</l>
@@ -3793,14 +3793,14 @@ convert to TEI P3
 						<l>διακωλύσωμεν ἰόντα φόνον</l>
 						<l>τοῖσιν ὁμαίμοις.</l>
 					</sp>
-					<sp who="#theseys">
+					<sp who="#theseus">
 						<speaker>Θησεύς</speaker>
 						<l>δράσω καὶ τάδε καὶ πάνθ’ ὁπόσ’ ἂν</l>
 						<l>μέλλω πράσσειν πρόσφορά θ’ ὑμῖν</l>
 						<l n="1775">καὶ τῷ κατὰ γῆς, ὃς νέον ἔρρει,</l>
 						<l>πρὸς χάριν·  οὐ δεῖ μ’ ἀποκάμνειν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ἀποπαύετε μηδ’ ἐπὶ πλείω</l>
 						<l>θρῆνον ἐγείρετε·</l>

--- a/tei/sophocles-oedipus-tyrannus.xml
+++ b/tei/sophocles-oedipus-tyrannus.xml
@@ -51,13 +51,13 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="eksaggelos">
+					<person xml:id="exangelos">
 						<persName>Ἐξάγγελος</persName>
 					</person>
-					<person xml:id="iereys">
+					<person xml:id="hiereus">
 						<persName>Ἱερεύς</persName>
 					</person>
-					<person xml:id="oidipoys">
+					<person xml:id="oidipous">
 						<persName>Οἰδίπους</persName>
 					</person>
 					<person xml:id="teiresias">
@@ -72,10 +72,10 @@
 					<person xml:id="kreon">
 						<persName>Κρέων</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
 				</listPerson>
@@ -177,7 +177,7 @@ convert to TEI P3
 		<body n="OT">
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ τέκνα, Κάδμου τοῦ πάλαι νέα τροφή,</l>
 					<l>τίνας ποθ’ ἕδρας τάσδε μοι θοάζετε</l>
@@ -194,7 +194,7 @@ convert to TEI P3
 					<l>εἴην τοιάνδε μὴ οὐ κατοικτίρων ἕδραν.</l>
 					<milestone ed="p" n="14" unit="card"/>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>ἀλλ’ ὦ κρατύνων Οἰδίπους χώρας ἐμῆς,</l>
 					<l n="15">ὁρᾷς μὲν ἡμᾶς ἡλίκοι προσήμεθα</l>
@@ -242,7 +242,7 @@ convert to TEI P3
 					<l>ἔρημος ἀνδρῶν μὴ ξυνοικούντων ἔσω.</l>
 					<milestone ed="p" n="58" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ παῖδες οἰκτροί, γνωτὰ κοὐκ ἄγνωτά μοι</l>
 					<l>προσήλθεθ’ ἱμείροντες·  εὖ γὰρ οἶδ’ ὅτι</l>
@@ -266,22 +266,22 @@ convert to TEI P3
 					<l>μὴ δρῶν ἂν εἴην πάνθ’ ὅσ’ ἂν δηλοῖ θεός.</l>
 					<milestone ed="p" n="78" unit="card"/>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>ἀλλ’ εἰς καλὸν σύ τ’ εἶπας οἵδε τ’ ἀρτίως</l>
 					<l>Κρέοντα προσστείχοντα σημαίνουσί μοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="80">ὦναξ Ἄπολλον, εἰ γὰρ ἐν τύχῃ γέ τῳ</l>
 					<l>σωτῆρι βαίη λαμπρὸς ὥσπερ ὄμματι</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>ἀλλ’ εἰκάσαι μέν, ἡδύς·  οὐ γὰρ ἂν κάρα</l>
 					<l>πολυστεφὴς ὧδ’ εἷρπε παγκάρπου δάφνης.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τάχ’ εἰσόμεσθα·  ξύμμετρος γὰρ ὡς κλύειν.</l>
 					<l n="85">ἄναξ, ἐμὸν κήδευμα, παῖ Μενοικέως,</l>
@@ -292,7 +292,7 @@ convert to TEI P3
 					<l>ἐσθλήν·  λέγω γὰρ καὶ τὰ δύσφορ’, εἰ τύχοι</l>
 					<l>κατ’ ὀρθὸν ἐξελθόντα, πάντ’ ἂν εὐτυχεῖν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἔστιν δὲ ποῖον τοὔπος; οὔτε γὰρ θρασὺς</l>
 					<l n="90">οὔτ’ οὖν προδείσας εἰμὶ τῷ γε νῦν λόγῳ.</l>
@@ -302,7 +302,7 @@ convert to TEI P3
 					<l>εἰ τῶνδε χρῄζεις πλησιαζόντων κλύειν,</l>
 					<l>ἕτοιμος εἰπεῖν, εἴτε καὶ στείχειν ἔσω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐς πάντας αὔδα·  τῶνδε γὰρ πλέον φέρω</l>
 					<l>τὸ πένθος ἢ καὶ τῆς ἐμῆς ψυχῆς πέρι.</l>
@@ -314,7 +314,7 @@ convert to TEI P3
 					<l>μίασμα χώρας, ὡς τεθραμμένον χθονὶ</l>
 					<l>ἐν τῇδ’, ἐλαύνειν μηδ’ ἀνήκεστον τρέφειν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποίῳ καθαρμῷ; τίς ὁ τρόπος τῆς ξυμφορᾶς;</l>
 				</sp>
@@ -324,7 +324,7 @@ convert to TEI P3
 					<l>λύοντας, ὡς τόδ’ αἷμα χειμάζον πόλιν.</l>
 					<milestone ed="p" n="102" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποίου γὰρ ἀνδρὸς τήνδε μηνύει τύχην;</l>
 				</sp>
@@ -333,7 +333,7 @@ convert to TEI P3
 					<l>ἦν ἡμίν, ὦναξ, Λάϊός ποθ’ ἡγεμὼν</l>
 					<l>γῆς τῆσδε, πρὶν σὲ τήνδ’ ἀπευθύνειν πόλιν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="105">ἔξοιδ’ ἀκούων·  οὐ γὰρ εἰσεῖδόν γέ πω.</l>
 				</sp>
@@ -342,7 +342,7 @@ convert to TEI P3
 					<l>τούτου θανόντος νῦν ἐπιστέλλει σαφῶς</l>
 					<l>τοὺς αὐτοέντας χειρὶ τιμωρεῖν τινας.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οἳ δ’ εἰσὶ ποῦ γῆς; ποῦ τόδ’ εὑρεθήσεται</l>
 					<l>ἴχνος παλαιᾶς δυστέκμαρτον αἰτίας;</l>
@@ -352,7 +352,7 @@ convert to TEI P3
 					<l n="110">ἐν τῇδ’ ἔφασκε γῇ·  τὸ δὲ ζητούμενον</l>
 					<l>ἁλωτόν, ἐκφεύγειν δὲ τἀμελούμενον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πότερα δ’ ἐν οἴκοις ἢ ’ν ἀγροῖς ὁ Λάϊος</l>
 					<l>ἢ γῆς ἐπ’ ἄλλης τῷδε συμπίπτει φόνῳ;</l>
@@ -362,7 +362,7 @@ convert to TEI P3
 					<l>θεωρός, ὡς ἔφασκεν, ἐκδημῶν, πάλιν</l>
 					<l n="115">πρὸς οἶκον οὐκέθ’   ἵκεθ’, ὡς ἀπεστάλη.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐδ’ ἄγγελός τις οὐδὲ συμπράκτωρ ὁδοῦ</l>
 					<l>κατεῖδ’, ὅτου τις ἐκμαθὼν ἐχρήσατ’ ἄν;</l>
@@ -372,7 +372,7 @@ convert to TEI P3
 					<l>θνῄσκουσι γάρ, πλὴν εἷς τις, ὃς φόβῳ, φυγὼν</l>
 					<l>ὧν εἶδε πλὴν ἓν οὐδὲν εἶχ’ εἰδὼς φράσαι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="120">τὸ ποῖον;  ἓν γὰρ πόλλ’  ἂν ἐξεύροι μαθεῖν,</l>
 					<l>ἀρχὴν βραχεῖαν εἰ λάβοιμεν ἐλπίδος.</l>
@@ -382,7 +382,7 @@ convert to TEI P3
 					<l>λῃστὰς ἔφασκε συντυχόντας οὐ μιᾷ</l>
 					<l>ῥώμῃ κτανεῖν νιν, ἀλλὰ σὺν πλήθει χερῶν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πῶς οὖν ὁ λῃστής, εἴ τι μὴ ξὺν ἀργύρῳ</l>
 					<l n="125">ἐπράσσετ’ ἐνθένδ’, ἐς τόδ’ ἂν τόλμης ἔβη;</l>
@@ -392,7 +392,7 @@ convert to TEI P3
 					<l>δοκοῦντα ταῦτ’  ἦν· Λαΐου δ’ ὀλωλότος</l>
 					<l>οὐδεὶς ἀρωγὸς ἐν κακοῖς ἐγίγνετο.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>κακὸν δὲ ποῖον ἐμποδών, τυραννίδος</l>
 					<l>οὕτω πεσούσης,   εἶργε τοῦτ’ ἐξειδέναι;</l>
@@ -403,7 +403,7 @@ convert to TEI P3
 					<l>μεθέντας ἡμᾶς τἀφανῆ προσήγετο.</l>
 					<milestone ed="p" n="132" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ ἐξ ὑπαρχῆς αὖθις αὔτ’ ἐγὼ φανῶ·</l>
 					<l>ἐπαξίως γὰρ Φοῖβος, ἀξίως δὲ σὺ</l>
@@ -421,7 +421,7 @@ convert to TEI P3
 					<l n="145">ὡς πᾶν ἐμοῦ δράσοντος·  ἢ γὰρ εὐτυχεῖς</l>
 					<l>σὺν τῷ θεῷ φανούμεθ’ ἢ πεπτωκότες.</l>
 				</sp>
-				<sp who="#iereys">
+				<sp who="#hiereus">
 					<speaker>Ἱερεύς</speaker>
 					<l>ὦ παῖδες, ἱστώμεσθα·  τῶνδε γὰρ χάριν</l>
 					<l>καὶ δεῦρ’ ἔβημεν ὧν ὅδ’ ἐξαγγέλλεται.</l>
@@ -432,7 +432,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ Διὸς ἁδυεπὲς φάτι, τίς ποτε τᾶς πολυχρύσου</l>
 						<l>Πυθῶνος ἀγλαὰς ἔβας</l>
@@ -445,7 +445,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="160">πρῶτα σὲ κεκλόμενος, θύγατερ Διός, ἄμβροτ’ Ἀθάνα</l>
 						<l>γαιάοχόν τ’ ἀδελφεὰν</l>
@@ -459,7 +459,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πόποι, ἀνάριθμα γὰρ φέρω</l>
 						<l n="170">πήματα·  νοσεῖ δέ μοι πρόπας στόλος, οὐδ’ ἔνι φροντίδος ἔγχος</l>
@@ -473,7 +473,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὧν πόλις ἀνάριθμος ὄλλυται·</l>
 						<l n="180">νηλέα δὲ γένεθλα πρὸς πέδῳ θαναταφόρα κεῖται ἀνοίκτως·</l>
@@ -487,7 +487,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="190">Ἄρεά τε τὸν μαλερόν, ὃς νῦν ἄχαλκος ἀσπίδων</l>
 						<l>φλέγει με περιβόατον, ἀντιάζω</l>
@@ -504,7 +504,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Λύκεῑ ἄναξ, τά τε σὰ χρυσοστρόφων ἀπ’ ἀγκυλᾶν</l>
 						<l>βέλεα θέλοιμ’ ἂν ἀδάματ’ ἐνδατεῖσθαι</l>
@@ -524,7 +524,7 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp n="Οἰδίπους" who="#oidipoys">
+				<sp n="Οἰδίπους" who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>αἰτεῖς·  ἃ δ’ αἰτεῖς, τἄμ’ ἐὰν θέλῃς ἔπη</l>
 					<l>κλύων δέχεσθαι τῇ νόσῳ θ’ ὑπηρετεῖν,</l>
@@ -589,71 +589,71 @@ convert to TEI P3
 					<l n="275">χοἰ πάντες εὖ ξυνεῖεν εἰσαεὶ θεοί.</l>
 				</sp>
 				<milestone ed="p" n="276" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὥσπερ μ’ ἀραῖον ἔλαβες, ὧδ’, ἄναξ, ἐρῶ.</l>
 					<l>οὔτ’ ἔκτανον γὰρ οὔτε τὸν κτανόντ’ ἔχω</l>
 					<l>δεῖξαι.  τὸ δὲ ζήτημα τοῦ πέμψαντος ἦν</l>
 					<l>Φοίβου τόδ’ εἰπεῖν, ὅστις εἴργασταί ποτε.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="280">δίκαῑ ἔλεξας·  ἀλλ’ ἀναγκάσαι θεοὺς</l>
 					<l>ἃν μὴ θέλωσιν οὐδ’ ἂν εἷς δύναιτ’ ἀνήρ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τὰ δεύτερ’ ἐκ τῶνδ’ ἂν λέγοιμ’ ἁμοὶ δοκεῖ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>εἰ καὶ τρίτ’ ἐστί,  μὴ παρῇς τὸ μὴ οὐ φράσαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄνακτ’ ἄνακτι ταὔθ’ ὁρῶντ’ ἐπίσταμαι</l>
 					<l n="285">μάλιστα Φοίβῳ Τειρεσίαν, παρ’ οὗ τις ἂν</l>
 					<l>σκοπῶν τάδ’, ὦναξ, ἐκμάθοι σαφέστατα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ οὐκ ἐν ἀργοῖς οὐδὲ τοῦτ’ ἐπραξάμην.</l>
 					<l>ἔπεμψα γὰρ Κρέοντος εἰπόντος διπλοῦς</l>
 					<l>πομπούς·  πάλαι δὲ μὴ παρῶν θαυμάζεται.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="290">καὶ μὴν τά γ’  ἄλλα κωφὰ καὶ παλαί’ ἔπη.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τὰ ποῖα ταῦτα; πάντα γὰρ σκοπῶ λόγον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>θανεῖν ἐλέχθη πρός τινων ὁδοιπόρων.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἤκουσα κἀγώ.  τὸν δ’ ἰδόντ’ οὐδεὶς ὁρᾷ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εἴ τι μὲν δὴ δείματός γ’ ἔχει μέρος,</l>
 					<l n="295">τὰς σὰς ἀκούων οὐ μενεῖ τοιάσδ’ ἀράς,</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ᾧ μή ’στι δρῶντι τάρβος, οὐδ’ ἔπος φοβεῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ οὑξελέγξων αὐτὸν ἔστιν·  οἵδε γὰρ</l>
 					<l>τὸν θεῖον ἤδη μάντιν ὧδ’ ἄγουσιν, ᾧ</l>
 					<l>τἀληθὲς ἐμπέφυκεν ἀνθρώπων μόνῳ.</l>
 					<milestone ed="p" n="300" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="300">ὦ πάντα νωμῶν Τειρεσία, διδακτά τε</l>
 					<l>ἄρρητά τ’, οὐράνιά τε καὶ χθονοστιβῆ,</l>
@@ -678,7 +678,7 @@ convert to TEI P3
 					<l>λύῃ φρονοῦντι·  ταῦτα γὰρ καλῶς ἐγὼ</l>
 					<l>εἰδὼς διώλεσ’·  οὐ γὰρ ἂν δεῦρ’ ἱκόμην.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τί δ’ ἔστιν; ὡς ἄθυμος εἰσελήλυθας.</l>
 				</sp>
@@ -687,7 +687,7 @@ convert to TEI P3
 					<l n="320">ἄφες μ’  ἐς οἴκους·  ῥᾷστα γὰρ τὸ σόν τε σὺ</l>
 					<l>κἀγὼ διοίσω τοὐμόν, ἢν ἐμοὶ πίθῃ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὔτ’ ἔννομ’ εἶπας οὔτε προσφιλῆ πόλει</l>
 					<l>τῇδ’, ἥ σ’ ἔθρεψε, τήνδ’ ἀποστερῶν φάτιν.</l>
@@ -697,7 +697,7 @@ convert to TEI P3
 					<l>ὁρῶ γὰρ οὐδὲ σοὶ τὸ σὸν φώνημ’ ἰὸν</l>
 					<l n="325">πρὸς καιρόν·  ὡς οὖν μηδ’ ἐγὼ ταὐτὸν πάθω—</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>μὴ πρὸς θεῶν φρονῶν γ’ ἀποστραφῇς, ἐπεὶ</l>
 					<l>πάντες σε προσκυνοῦμεν οἵδ’ ἱκτήριοι.</l>
@@ -708,7 +708,7 @@ convert to TEI P3
 					<l>τἄμ’, ὡς ἂν εἴπω μὴ τὰ σ’, ἐκφήνω κακά.</l>
 					<milestone ed="p" n="330" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="330">τί φής;  ξυνειδὼς οὐ φράσεις, ἀλλ’ ἐννοεῖς</l>
 					<l>ἡμᾶς προδοῦναι καὶ καταφθεῖραι πόλιν;</l>
@@ -718,7 +718,7 @@ convert to TEI P3
 					<l>ἐγὼ οὔτ’ ἐμαυτὸν οὔτε σ’ ἀλγυνῶ.  τί ταῦτ’</l>
 					<l>ἄλλως ἐλέγχεις; οὐ γὰρ ἂν πύθοιό μου.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐκ, ὦ κακῶν κάκιστε, καὶ γὰρ ἂν πέτρου</l>
 					<l n="335">φύσιν σύ γ’ ὀργάνειας, ἐξερεῖς ποτε,</l>
@@ -729,7 +729,7 @@ convert to TEI P3
 					<l>ὀργὴν ἐμέμψω τὴν ἐμήν, τὴν σὴν δ’ ὁμοῦ</l>
 					<l>ναίουσαν οὐ κατεῖδες, ἀλλ’ ἐμὲ ψέγεις.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς γὰρ τοιαῦτ’ ἂν οὐκ ἂν ὀργίζοιτ’ ἔπη</l>
 					<l n="340">κλύων, ἃ νῦν σὺ τήνδ’ ἀτιμάζεις πόλιν;</l>
@@ -738,7 +738,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>ἥξει γὰρ αὐτά, κἂν ἐγὼ σιγῇ στέγω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐκοῦν ἅ γ’ ἥξει καὶ σὲ χρὴ λέγειν ἐμοί.</l>
 				</sp>
@@ -747,7 +747,7 @@ convert to TEI P3
 					<l>οὐκ ἂν πέρα φράσαιμι.  πρὸς τάδ’, εἰ θέλεις,</l>
 					<l>θυμοῦ δῑ ὀργῆς ἥτις ἀγριωτάτη.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="345">καὶ μὴν παρήσω γ’ οὐδέν, ὡς ὀργῆς ἔχω,</l>
 					<l>ἅπερ ξυνίημ’·  ἴσθι γὰρ δοκῶν ἐμοὶ</l>
@@ -763,7 +763,7 @@ convert to TEI P3
 					<l>ὡς ὄντι γῆς τῆσδ’ ἀνοσίῳ μιάστορι.</l>
 					<milestone ed="p" n="354" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὕτως ἀναιδῶς ἐξεκίνησας τόδε</l>
 					<l n="355">τὸ ῥῆμα; καὶ ποῦ τοῦτο φεύξεσθαι δοκεῖς;</l>
@@ -772,7 +772,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>πέφευγα·  τἀληθὲς γὰρ ἰσχῦον τρέφω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πρὸς τοῦ διδαχθείς; οὐ γὰρ ἔκ γε τῆς τέχνης.</l>
 				</sp>
@@ -780,7 +780,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>πρὸς σοῦ·  σὺ γάρ μ’ ἄκοντα προυτρέψω λέγειν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποῖον λόγον; λέγ’ αὖθις, ὡς μᾶλλον μάθω.</l>
 				</sp>
@@ -788,7 +788,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l n="360">οὐχὶ ξυνῆκας πρόσθεν;  ἢ  ’κπειρᾷ λέγων;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐχ ὥστε γ’ εἰπεῖν γνωστόν·  ἀλλ’ αὖθις φράσον.</l>
 				</sp>
@@ -796,7 +796,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>φονέα σε φημὶ τἀνδρὸς οὗ ζητεῖς κυρεῖν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ οὔ τι χαίρων  δίς γε πημονὰς ἐρεῖς.</l>
 				</sp>
@@ -804,7 +804,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>εἴπω τι δῆτα κἄλλ’, ἵν’ ὀργίζῃ πλέον;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="365">ὅσον γε χρῄζεις·  ὡς μάτην εἰρήσεται.</l>
 				</sp>
@@ -813,7 +813,7 @@ convert to TEI P3
 					<l>λεληθέναι σε φημὶ σὺν τοῖς φιλτάτοις</l>
 					<l>αἴσχισθ’ ὁμιλοῦντ’, οὐδ’ ὁρᾶν ἵν’ εἶ κακοῦ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ καὶ γεγηθὼς ταῦτ’ ἀεὶ λέξειν δοκεῖς;</l>
 				</sp>
@@ -821,7 +821,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>εἴπερ τί γ’ ἐστὶ τῆς ἀληθείας σθένος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="370">ἀλλ’ ἔστι, πλὴν σοί·  σοὶ δὲ τοῦτ’ οὐκ ἔστ’ ἐπεὶ</l>
 					<l>τυφλὸς τά τ’ ὦτα τόν τε νοῦν τά τ’ ὄμματ’ εἶ.</l>
@@ -831,7 +831,7 @@ convert to TEI P3
 					<l>σὺ δ’ ἄθλιός γε ταῦτ’ ὀνειδίζων, ἃ σοὶ</l>
 					<l>οὐδεὶς ὃς οὐχὶ τῶνδ’ ὀνειδιεῖ τάχα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>μιᾶς τρέφει πρὸς νυκτός, ὥστε μήτ’ ἐμὲ</l>
 					<l n="375">μήτ’ ἄλλον, ὅστις φῶς ὁρᾷ, βλάψαι ποτ’ ἄν.</l>
@@ -841,7 +841,7 @@ convert to TEI P3
 					<l>οὐ γάρ σε μοῖρα πρός γ’ ἐμοῦ πεσεῖν, ἐπεὶ</l>
 					<l>ἱκανὸς Ἀπόλλων, ᾧ τάδ’ ἐκπρᾶξαι μέλει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>Κρέοντος ἢ σοῦ ταῦτα τἀξευρήματα;</l>
 				</sp>
@@ -850,7 +850,7 @@ convert to TEI P3
 					<l>Κρέων δέ σοι πῆμ’ οὐδέν, ἀλλ’ αὐτὸς σὺ σοί.</l>
 					<milestone ed="p" n="380" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="380">ὦ πλοῦτε καὶ τυραννὶ καὶ τέχνη τέχνης</l>
 					<l>ὑπερφέρουσα τῷ πολυζήλῳ βίῳ,</l>
@@ -877,7 +877,7 @@ convert to TEI P3
 					<l>ἀγηλατήσειν·  εἰ δὲ μὴ ’δόκεις γέρων</l>
 					<l>εἶναι, παθὼν ἔγνως ἂν οἷά περ φρονεῖς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμῖν μὲν εἰκάζουσι καὶ τὰ τοῦδ’ ἔπη</l>
 					<l n="405">ὀργῇ λελέχθαι καὶ τά σ’, Οἰδίπους, δοκεῖ,</l>
@@ -910,7 +910,7 @@ convert to TEI P3
 					<l>κάκιον ὅστις ἐκτριβήσεταί ποτε.</l>
 					<milestone ed="p" n="429" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ ταῦτα δῆτ’ ἀνεκτὰ πρὸς τούτου κλύειν;</l>
 					<l n="430">οὐκ εἰς ὄλεθρον;   οὐχὶ θᾶσσον;  οὐ πάλιν</l>
@@ -920,7 +920,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>οὐδ’ ἱκόμην ἔγωγ’  ἄν, εἰ σὺ μὴ ’κάλεις.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐ γάρ τί σ’ ᾔδη μῶρα φωνήσοντ’, ἐπεὶ</l>
 					<l>σχολῇ σ’ ἂν οἴκους τοὺς ἐμοὺς ἐστειλάμην.</l>
@@ -930,7 +930,7 @@ convert to TEI P3
 					<l n="435">ἡμεῖς τοιοίδ’ ἔφυμεν, ὡς μὲν σοὶ δοκεῖ,</l>
 					<l>μῶροι, γονεῦσι δ’, οἵ σ’ ἔφυσαν, ἔμφρονες.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποίοισι; μεῖνον, τίς δέ μ’ ἐκφύει βροτῶν;</l>
 				</sp>
@@ -938,7 +938,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>ἥδ’ ἡμέρα φύσει σε καὶ διαφθερεῖ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὡς πάντ’ ἄγαν αἰνικτὰ κἀσαφῆ λέγεις.</l>
 				</sp>
@@ -946,7 +946,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l n="440">οὔκουν σὺ ταῦτ’  ἄριστος εὑρίσκειν ἔφυς;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τοιαῦτ’ ὀνείδιζ’, οἷς ἔμ’ εὑρήσεις μέγαν.</l>
 				</sp>
@@ -954,7 +954,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>αὕτη γε μέντοι σ’ ἡ τύχη διώλεσεν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ εἰ πόλιν τήνδ’ ἐξέσωσ’, οὔ μοι μέλει.</l>
 				</sp>
@@ -962,7 +962,7 @@ convert to TEI P3
 					<speaker>Τειρεσίας</speaker>
 					<l>ἄπειμι τοίνυν·  καὶ σύ, παῖ, κόμιζέ με.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="445">κομιζέτω δῆθ’·  ὡς παρὼν σύ γ’ ἐμποδὼν</l>
 					<l>ὀχλεῖς, συθείς τ’ ἂν οὐκ ἂν ἀλγύνοις πλέον.</l>
@@ -991,7 +991,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς ὅντιν’ ἁ θεσπιέπεια Δελφὶς εἶπε πέτρα</l>
 						<l n="465">ἄρρητ’ ἀρρήτων τελέσαντα φοινίαισι χερσίν;</l>
@@ -1006,7 +1006,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔλαμψε γὰρ τοῦ νιφόεντος ἀρτίως φανεῖσα</l>
 						<l>φάμα Παρνασοῦ τὸν ἄδηλον ἄνδρα πάντ’ ἰχνεύειν.</l>
@@ -1021,7 +1021,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δεινὰ μὲν οὖν, δεινὰ ταράσσει σοφὸς οἰωνοθέτας</l>
 						<l n="485">οὔτε δοκοῦντ’ οὔτ’ ἀποφάσκονθ’·  ὅ τι λέξω δ’ ἀπορῶ.</l>
@@ -1035,7 +1035,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλ’ ὁ μὲν οὖν Ζεὺς ὅ τ’ Ἀπόλλων ξυνετοὶ καὶ τὰ βροτῶν</l>
 						<l n="500">εἰδότες·  ἀνδρῶν δ’ ὅτι μάντις πλέον ἢ ’γὼ φέρεται,</l>
@@ -1063,7 +1063,7 @@ convert to TEI P3
 					<l>ἀλλ’ ἐς μέγιστον, εἰ κακὸς μὲν ἐν πόλει,</l>
 					<l>κακὸς δὲ πρὸς σοῦ καὶ φίλων κεκλήσομαι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἦλθε μὲν δὴ τοῦτο τοὔνειδος τάχ’ ἂν</l>
 					<l>ὀργῇ βιασθὲν μᾶλλον ἢ γνώμῃ φρενῶν.</l>
@@ -1073,7 +1073,7 @@ convert to TEI P3
 					<l n="525">τοὔπος δ’ ἐφάνθη, ταῖς ἐμαῖς γνώμαις ὅτι</l>
 					<l>πεισθεὶς ὁ μάντις τοὺς λόγους ψευδεῖς λέγοι;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ηὐδᾶτο μὲν τάδ’, οἶδα δ’ οὐ γνώμῃ τίνι.</l>
 				</sp>
@@ -1082,12 +1082,12 @@ convert to TEI P3
 					<l>ἐξ ὀμμάτων δ’ ὀρθῶν τε κἀξ ὀρθῆς φρενὸς</l>
 					<l>κατηγορεῖτο τοὐπίκλημα τοῦτό μου;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="530">οὐκ οἶδ’·  ἃ γὰρ δρῶσ’, οἱ κρατοῦντες οὐχ ὁρῶ.</l>
 					<l>αὐτὸς δ’ ὅδ’ ἤδη δωμάτων ἔξω περᾷ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὗτος σύ, πῶς δεῦρ’ ἦλθες; ἦ τοσόνδ’ ἔχεις</l>
 					<l>τόλμης πρόσωπον ὥστε τὰς ἐμὰς στέγας</l>
@@ -1107,7 +1107,7 @@ convert to TEI P3
 					<l>οἶσθ’ ὡς πόησον; ἀντὶ τῶν εἰρημένων</l>
 					<l>ἴσ’ ἀντάκουσον, κᾆτα κρῖν’ αὐτὸς μαθών.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="545">λέγειν σὺ δεινός,  μανθάνειν δ’ ἐγὼ κακὸς</l>
 					<l>σοῦ· δυσμενῆ γὰρ καὶ βαρύν σ’ ηὕρηκ’ ἐμοί.</l>
@@ -1116,7 +1116,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>τοῦτ’ αὐτὸ νῦν μου πρῶτ’ ἄκουσον ὡς ἐρῶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τοῦτ’ αὐτὸ μή μοι φράζ’, ὅπως οὐκ εἶ κακός.</l>
 				</sp>
@@ -1125,7 +1125,7 @@ convert to TEI P3
 					<l>εἴ τοι νομίζεις κτῆμα τὴν αὐθαδίαν</l>
 					<l n="550">εἶναί τι τοῦ νοῦ  χωρίς, οὐκ ὀρθῶς φρονεῖς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>εἴ τοι νομίζεις ἄνδρα συγγενῆ κακῶς</l>
 					<l>δρῶν οὐχ ὑφέξειν  τὴν δίκην, οὐκ εὖ φρονεῖς.</l>
@@ -1135,7 +1135,7 @@ convert to TEI P3
 					<l>ξύμφημί σοι ταῦτ’ ἔνδικ’ εἰρῆσθαι·  τὸ δὲ</l>
 					<l>πάθημ’ ὁποῖον φὴς παθεῖν, δίδασκέ με.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="555">ἔπειθες ἢ οὐκ ἔπειθες, ὡς χρείη μ’ ἐπὶ</l>
 					<l>τὸν σεμνόμαντιν ἄνδρα πέμψασθαί τινα;</l>
@@ -1144,7 +1144,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>καὶ νῦν ἔθ’ αὑτός εἰμι τῷ βουλεύματι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πόσον τιν’ ἤδη δῆθ’ ὁ Λάϊος χρόνον</l>
 				</sp>
@@ -1152,7 +1152,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>δέδρακε ποῖον ἔργον; οὐ γὰρ ἐννοῶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="560">ἄφαντος ἔρρει θανασίμῳ χειρώματι;</l>
 				</sp>
@@ -1160,7 +1160,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>μακροὶ παλαιοί τ’    ἂν μετρηθεῖεν χρόνοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τότ’ οὖν ὁ μάντις οὗτος ἦν ἐν τῇ τέχνῃ;</l>
 				</sp>
@@ -1168,7 +1168,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>σοφός γ’ ὁμοίως   κἀξ ἴσου τιμώμενος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐμνήσατ’ οὖν ἐμοῦ τι τῷ τότ’ ἐν χρόνῳ;</l>
 				</sp>
@@ -1176,7 +1176,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="565">οὔκουν ἐμοῦ γ’   ἑστῶτος οὐδαμοῦ πέλας.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ οὐκ ἔρευναν τοῦ κτανόντος ἔσχετε;</l>
 				</sp>
@@ -1184,7 +1184,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>παρέσχομεν, πῶς    δ’ οὐχί; κοὐκ ἠκούσαμεν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πῶς οὖν τόθ’ οὗτος ὁ σοφὸς οὐκ ηὔδα τάδε;</l>
 				</sp>
@@ -1192,7 +1192,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>οὐκ οἶδ’·  ἐφ’ οἷς γὰρ μὴ φρονῶ σιγᾶν φιλῶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="570">τοσόνδε γ’ οἶσθα καὶ λέγοις ἂν εὖ φρονῶν.</l>
 				</sp>
@@ -1200,7 +1200,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>ποῖον τόδ’; εἰ γὰρ οἶδά γ’, οὐκ ἀρνήσομαι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὁθούνεκ’, εἰ μὴ σοὶ ξυνῆλθε, τάσδ’ ἐμὰς</l>
 					<l>οὐκ ἄν ποτ’ εἶπε Λαΐου διαφθοράς.</l>
@@ -1210,7 +1210,7 @@ convert to TEI P3
 					<l>εἰ μὲν λέγει τάδ’, αὐτὸς οἶσθ’·  ἐγὼ δὲ σοῦ</l>
 					<l n="575">μαθεῖν δικαιῶ ταὔθ’ ἅπερ κἀμοῦ σὺ νῦν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐκμάνθαν’·  οὐ γὰρ δὴ φονεὺς ἁλώσομαι.</l>
 				</sp>
@@ -1218,7 +1218,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>τί δῆτ’; ἀδελφὴν τὴν ἐμὴν γήμας ἔχεις;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἄρνησις οὐκ ἔνεστιν ὧν ἀνιστορεῖς.</l>
 				</sp>
@@ -1226,7 +1226,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>ἄρχεις δ’ ἐκείνῃ ταὐτὰ γῆς ἴσον νέμων;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="580">ἃν ᾖ θέλουσα πάντ’  ἐμοῦ κομίζεται.</l>
 				</sp>
@@ -1234,7 +1234,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>οὔκουν ἰσοῦμαι  σφῷν ἐγὼ δυοῖν τρίτος;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐνταῦθα γὰρ δὴ καὶ κακὸς φαίνει φίλος.</l>
 					<milestone ed="p" n="583" unit="card"/>
@@ -1276,12 +1276,12 @@ convert to TEI P3
 					<l n="615">κακὸν δὲ κἂν ἐν ἡμέρᾳ γνοίης μιᾷ.</l>
 					<milestone ed="p" n="616" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>καλῶς ἔλεξεν εὐλαβουμένῳ πεσεῖν,</l>
 					<l>ἄναξ·  φρονεῖν γὰρ οἱ ταχεῖς οὐκ ἀσφαλεῖς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὅταν ταχύς τις οὑπιβουλεύων λάθρᾳ</l>
 					<l>χωρῇ, ταχὺν δεῖ κἀμὲ βουλεύειν πάλιν·</l>
@@ -1292,7 +1292,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l>τί δῆτα χρῄζεις; ἦ με γῆς ἔξω βαλεῖν;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἥκιστα·  θνῄσκειν, οὐ φυγεῖν σε βούλομαι.</l>
 					<l>ὡς ἂν προδείξῃς οἷόν ἐστι τὸ φθονεῖν.</l>
@@ -1301,7 +1301,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="625">ὡς οὐχ ὑπείξων οὐδὲ πιστεύσων λέγεις;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>
 						&lt;
@@ -1313,7 +1313,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">οὐ γὰρ φρονοῦντά  σ’ εὖ βλέπω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">τὸ γοῦν ἐμόν.</l>
 				</sp>
@@ -1321,7 +1321,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">ἀλλ’ ἐξ ἴσου δεῖ κἀμόν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">ἀλλ’ ἔφυς κακός.</l>
 				</sp>
@@ -1329,7 +1329,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">εἰ δὲ ξυνίης μηδέν;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">ἀρκτέον γ’ ὅμως.</l>
 				</sp>
@@ -1337,7 +1337,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l part="I">οὔτοι κακῶς γ’   ἄρχοντος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="F">ὦ πόλις πόλις.</l>
 				</sp>
@@ -1345,7 +1345,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="630">κἀμοὶ πόλεως μέτεστιν, οὐχί σοι μόνῳ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>παύσασθ’, ἄνακτες·  καιρίαν δ’ ὑμῖν ὁρῶ</l>
 					<l>τήνδ’ ἐκ δόμων στείχουσαν Ἰοκάστην, μεθ’ ἧς</l>
@@ -1366,7 +1366,7 @@ convert to TEI P3
 					<l n="640">δρᾶσαι δικαιοῖ δυοῖν ἀποκρίνας κακοῖν</l>
 					<l>ἢ γῆς ἀπῶσαι πατρίδος ἢ κτεῖναι λαβών.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ξύμφημι·  δρῶντα γάρ νιν, ὦ γύναι, κακῶς</l>
 					<l>εἴληφα τοὐμὸν σῶμα σὺν τέχνῃ κακῇ.</l>
@@ -1386,36 +1386,36 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πιθοῦ θελήσας φρονήσας τ’, ἄναξ, λίσσομαι.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="650">τί σοι θέλεις δῆτ’ εἰκάθω;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν οὔτε πρὶν νήπιον νῦν τ’ ἐν ὅρκῳ μέγαν καταίδεσαι.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="655" part="I">οἶσθ’ οὖν ἃ χρῄζεις;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="M">οἶδα.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="F">φράζε δὴ τί φής.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τὸν ἐναγῆ φίλον μήποτ’ ἐν αἰτίᾳ</l>
 						<l>σὺν ἀφανεῖ λόγῳ  σ’ ἄτιμον βαλεῖν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>εὖ νυν ἐπίστω, ταῦθ’ ὅταν ζητῇς, ἐμοὶ</l>
 						<l>ζητῶν ὄλεθρον ἢ φυγὴν ἐκ τῆσδε γῆς.</l>
@@ -1423,7 +1423,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="660">οὐ τὸν πάντων θεῶν θεὸν πρόμον</l>
 						<l>Ἅλιον·  ἐπεὶ ἄθεος ἄφιλος ὅ τι πύματον</l>
@@ -1432,7 +1432,7 @@ convert to TEI P3
 						<l>τρύχει ψυχάν, τάδ’ εἰ κακοῖς κακὰ</l>
 						<l>προσάψει τοῖς πάλαι τὰ πρὸς σφῷν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὁ δ’ οὖν ἴτω, κεἰ χρή με παντελῶς θανεῖν</l>
 						<l n="670">ἢ γῆς ἄτιμον τῆσδ’  ἀπωσθῆναι βίᾳ.</l>
@@ -1445,7 +1445,7 @@ convert to TEI P3
 						<l>θυμοῦ περάσῃς·  αἱ δὲ τοιαῦται φύσεις</l>
 						<l n="675">αὑταῖς δικαίως εἰσὶν ἄλγισται φέρειν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">οὔκουν μ’ ἐάσεις κἀκτὸς εἶ;</l>
 					</sp>
@@ -1457,7 +1457,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>γύναι, τί μέλλεις κομίζειν δόμων τόνδ’ ἔσω;</l>
 					</sp>
@@ -1465,7 +1465,7 @@ convert to TEI P3
 						<speaker>Ἰοκάστη</speaker>
 						<l n="680">μαθοῦσά γ’ ἥτις ἡ τύχη.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δόκησις ἀγνὼς λόγων ἦλθε, δάπτει δὲ καὶ τὸ μὴ</l>
 						<l>’νδικον.</l>
@@ -1474,7 +1474,7 @@ convert to TEI P3
 						<speaker>Ἰοκάστη</speaker>
 						<l part="I">ἀμφοῖν ἀπ’ αὐτοῖν;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="M">ναίχι.</l>
 					</sp>
@@ -1482,19 +1482,19 @@ convert to TEI P3
 						<speaker>Ἰοκάστη</speaker>
 						<l part="F">καὶ τίς ἦν λόγος;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="685">ἅλις ἔμοιγ’, ἅλις, γᾶς προπονουμένας,</l>
 						<l>φαίνεται ἔνθ’ ἔληξεν αὐτοῦ μένειν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὁρᾷς ἵν’ ἥκεις, ἀγαθὸς ὢν γνώμην ἀνήρ,</l>
 						<l>τοὐμὸν παριεὶς καὶ καταμβλύνων κέαρ;</l>
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="690">ὦναξ, εἶπον μὲν οὐχ ἅπαξ μόνον,</l>
 						<l>ἴσθι δὲ παραφρόνιμον, ἄπορον ἐπὶ φρόνιμα</l>
@@ -1512,7 +1512,7 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="700">ἐρῶ·  σὲ γὰρ τῶνδ’  ἐς πλέον, γύναι, σέβω·</l>
 					<l>Κρέοντος, οἷά μοι βεβουλευκὼς ἔχει.</l>
@@ -1521,7 +1521,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>λέγ’, εἰ σαφῶς τὸ νεῖκος ἐγκαλῶν ἐρεῖς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>φονέα με φησὶ Λαΐου καθεστάναι.</l>
 				</sp>
@@ -1529,7 +1529,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>αὐτὸς ξυνειδὼς ἢ μαθὼν ἄλλου πάρα;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="705">μάντιν μὲν οὖν κακοῦργον εἰσπέμψας, ἐπεὶ</l>
 					<l>τό γ’ εἰς ἑαυτὸν πᾶν ἐλευθεροῖ στόμα.</l>
@@ -1557,7 +1557,7 @@ convert to TEI P3
 					<l n="725">χρείαν ἐρευνᾷ, ῥᾳδίως αὐτὸς φανεῖ.</l>
 					<milestone ed="p" n="726" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οἷόν μ’ ἀκούσαντ’ ἀρτίως ἔχει, γύναι,</l>
 					<l>ψυχῆς πλάνημα κἀνακίνησις φρενῶν.</l>
@@ -1566,7 +1566,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>ποίας μερίμνης τοῦθ’ ὑποστραφεὶς λέγεις;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἔδοξ’ ἀκοῦσαι σοῦ τόδ’, ὡς ὁ Λάϊος</l>
 					<l n="730">κατασφαγείη πρὸς τριπλαῖς ἁμαξιτοῖς.</l>
@@ -1575,7 +1575,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>ηὐδᾶτο γὰρ ταῦτ’ οὐδέ πω λήξαντ’ ἔχει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ ποῦ ’σθ’ ὁ χῶρος οὗτος οὗ τόδ’ ἦν πάθος;</l>
 				</sp>
@@ -1584,7 +1584,7 @@ convert to TEI P3
 					<l>Φωκὶς μὲν ἡ γῆ κλῄζεται, σχιστὴ δ’ ὁδὸς</l>
 					<l>ἐς ταὐτὸ Δελφῶν κἀπὸ Δαυλίας ἄγει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="735">καὶ τίς χρόνος τοῖσδ’ ἐστὶν οὑξεληλυθώς;</l>
 				</sp>
@@ -1593,7 +1593,7 @@ convert to TEI P3
 					<l>σχεδόν τι πρόσθεν ἢ σὺ τῆσδ’ ἔχων χθονὸς</l>
 					<l>ἀρχὴν ἐφαίνου, τοῦτ’ ἐκηρύχθη πόλει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ Ζεῦ, τί μου δρᾶσαι βεβούλευσαι πέρι;</l>
 				</sp>
@@ -1601,7 +1601,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>τί δ’ ἐστί σοι τοῦτ’, Οἰδίπους, ἐνθύμιον;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="740">μήπω μ’ ἐρώτα·  τὸν δὲ Λάϊον φύσιν</l>
 					<l>τίν’ ἦλθε φράζε, τίνα δ’ ἀκμὴν ἥβης ἔχων.</l>
@@ -1611,7 +1611,7 @@ convert to TEI P3
 					<l>μέγας, χνοάζων ἄρτι λευκανθὲς κάρα,</l>
 					<l>μορφῆς δὲ τῆς σῆς οὐκ ἀπεστάτει πολύ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οἴμοι τάλας·  ἔοικ’ ἐμαυτὸν εἰς ἀρὰς</l>
 					<l n="745">δεινὰς προβάλλων     ἀρτίως οὐκ εἰδέναι.</l>
@@ -1620,7 +1620,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>πῶς φῄς; ὀκνῶ τοι πρός σ’ ἀποσκοποῦσ’, ἄναξ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>δεινῶς ἀθυμῶ μὴ βλέπων ὁ μάντις ᾖ·</l>
 					<l>δείξεις δὲ μᾶλλον,   ἢν ἓν ἐξείπῃς ἔτι.</l>
@@ -1630,7 +1630,7 @@ convert to TEI P3
 					<l>καὶ μὴν ὀκνῶ μέν, ἃ δ’ ἂν ἔρῃ μαθοῦσ’ ἐρῶ.</l>
 					<milestone ed="p" n="750" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="750">πότερον  ἐχώρει βαιὸς ἢ πολλοὺς ἔχων</l>
 					<l>ἄνδρας λοχίτας, οἷ’ ἀνὴρ ἀρχηγέτης;</l>
@@ -1640,7 +1640,7 @@ convert to TEI P3
 					<l>πέντ’  ἦσαν οἱ ξύμπαντες, ἐν δ’  αὐτοῖσιν ἦν     .</l>
 					<l>κῆρυξ·  ἀπήνη δ’ ἦγε Λάϊον μία.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>αἰαῖ, τάδ’ ἤδη διαφανῆ.  τίς ἦν ποτε</l>
 					<l n="755">ὁ τούσδε λέξας τοὺς λόγους ὑμῖν, γύναι;</l>
@@ -1649,7 +1649,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>οἰκεύς τις, ὅσπερ ἵκετ’ ἐκσωθεὶς μόνος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ κἀν δόμοισι τυγχάνει τανῦν παρών;</l>
 				</sp>
@@ -1663,7 +1663,7 @@ convert to TEI P3
 					<l>κἄπεμψ’ ἐγώ νιν· ἄξιος γὰρ οἷ’ ἀνὴρ</l>
 					<l>δοῦλος φέρειν ἦν τῆσδε καὶ μείζω χάριν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="765">πῶς ἂν μόλοι δῆθ’ ἡμὶν ἐν τάχει πάλιν;</l>
 				</sp>
@@ -1671,7 +1671,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>πάρεστιν·  ἀλλὰ  πρὸς τί τοῦτ’ ἐφίεσαι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>δέδοικ’ ἐμαυτόν, ὦ γύναι, μὴ πόλλ’ ἄγαν</l>
 					<l>εἰρημέν’ ᾖ μοι δῑ ἅ νιν εἰσιδεῖν θέλω.</l>
@@ -1682,7 +1682,7 @@ convert to TEI P3
 					<l n="770">κἀγὼ τά γ’ ἐν σοὶ δυσφόρως ἔχοντ’, ἄναξ.</l>
 					<milestone ed="p" n="771" unit="card"/>
 				</sp>
-				<sp n="Οἰδίπους" who="#oidipoys">
+				<sp n="Οἰδίπους" who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>κοὐ μὴ στερηθῇς γ’, ἐς τοσοῦτον ἐλπίδων</l>
 					<l>ἐμοῦ βεβῶτος.  τῷ γὰρ ἂν καὶ μείζονι</l>
@@ -1750,12 +1750,12 @@ convert to TEI P3
 					<l>κηλῖδ’ ἐμαυτῷ συμφορᾶς ἀφιγμένην.</l>
 				</sp>
 				<milestone ed="p" n="834" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἡμῖν μέν, ὦναξ, ταῦτ’ ὀκνήρ’·  ἕως δ’ ἂν οὖν</l>
 					<l n="835">πρὸς τοῦ παρόντος ἐκμάθῃς, ἔχ’ ἐλπίδα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ μὴν τοσοῦτόν γ’ ἐστί μοι τῆς ἐλπίδος,</l>
 					<l>τὸν ἄνδρα τὸν βοτῆρα προσμεῖναι μόνον.</l>
@@ -1764,7 +1764,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>πεφασμένου δὲ τίς ποθ’ ἡ προθυμία;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἐγὼ διδάξω σ’·  ἢν γὰρ εὑρεθῇ λέγων</l>
 					<l n="840">σοὶ ταὔτ’, ἔγωγ’ ἂν ἐκπεφευγοίην πάθος.</l>
@@ -1773,7 +1773,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>ποῖον δέ μου περισσὸν ἤκουσας λόγον;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>λῃστὰς ἔφασκες αὐτὸν ἄνδρας ἐννέπειν</l>
 					<l>ὥς νιν κατακτείνειαν.  εἰ μὲν οὖν ἔτι</l>
@@ -1796,7 +1796,7 @@ convert to TEI P3
 					<l>ὥστ’ οὐχὶ μαντείας γ’ ἂν οὔτε τῇδ’ ἐγὼ</l>
 					<l>βλέψαιμ’ ἂν εἵνεκ’ οὔτε τῇδ’ ἂν ὕστερον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καλῶς νομίζεις· ἀλλ’ ὅμως τὸν ἐργάτην</l>
 					<l n="860">πέμψον τινὰ στελοῦντα μηδὲ τοῦτ’ ἀφῇς.</l>
@@ -1810,7 +1810,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἴ μοι ξυνείη φέροντι</l>
 						<l>μοῖρα τὰν εὔσεπτον ἁγνείαν λόγων</l>
@@ -1825,7 +1825,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὕβρις φυτεύει τύραννον·</l>
 						<l>ὕβρις, εἰ πολλῶν ὑπερπλησθῇ μάταν,</l>
@@ -1840,7 +1840,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ δέ τις ὑπέροπτα χερσὶν ἢ λόγῳ πορεύεται,</l>
 						<l n="885">δίκας ἀφόβητος οὐδὲ δαιμόνων ἕδη σέβων,</l>
@@ -1857,7 +1857,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐκέτι τὸν ἄθικτον εἶμι γᾶς ἐπ’ ὀμφαλὸν σέβων,</l>
 						<l n="900">οὐδ’ ἐς τὸν Ἀβαῖσι ναὸν οὐδὲ τὰν Ὀλυμπίαν,</l>
@@ -1891,18 +1891,18 @@ convert to TEI P3
 					<l>ὡς νῦν ὀκνοῦμεν πάντες ἐκπεπληγμένον</l>
 					<l>κεῖνον βλέποντες ὡς κυβερνήτην νεώς.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἆρ’ ἂν παρ’ ὑμῶν, ὦ ξένοι, μάθοιμ’ ὅπου</l>
 					<l n="925">τὰ τοῦ τυράννου δώματ’ ἐστὶν Οἰδίπου;</l>
 					<l>μάλιστα δ’ αὐτὸν εἴπατ’, εἰ κάτισθ’ ὅπου.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>στέγαι μὲν αἵδε, καὐτὸς ἔνδον, ὦ ξένε·</l>
 					<l>γυνὴ δὲ μήτηρ ἥδε τῶν κείνου τέκνων.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἀλλ’ ὀλβία τε καὶ ξὺν ὀλβίοις ἀεὶ</l>
 					<l n="930">γένοιτ’, ἐκείνου γ’  οὖσα παντελὴς δάμαρ.</l>
@@ -1913,7 +1913,7 @@ convert to TEI P3
 					<l>τῆς εὐεπείας εἵνεκ’·  ἀλλὰ φράζ’ ὅτου</l>
 					<l>χρῄζων ἀφῖξαι χὤ τι σημῆναι θέλων.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἀγαθὰ δόμοις τε  καὶ πόσει τῷ σῷ, γύναι.</l>
 				</sp>
@@ -1921,7 +1921,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l n="935">τὰ ποῖα ταῦτα;   παρὰ τίνος δ’ ἀφιγμένος;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐκ τῆς Κορίνθου·  τὸ δ’ ἔπος οὑξερῶ τάχα,</l>
 					<l>ἥδοιο μέν, πῶς δ’ οὐκ ἄν, ἀσχάλλοις δ’ ἴσως.</l>
@@ -1930,7 +1930,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>τί δ’ ἔστι; ποίαν δύναμιν ὧδ’ ἔχει διπλῆν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τύραννον αὐτὸν οὑπιχώριοι χθονὸς</l>
 					<l n="940">τῆς Ἰσθμίας στήσουσιν, ὡς ηὐδᾶτ’  ἐκεῖ.</l>
@@ -1939,7 +1939,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>τί δ’; οὐχ ὁ πρέσβυς Πόλυβος ἐγκρατὴς ἔτι;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐ δῆτ’, ἐπεί νιν θάνατος ἐν τάφοις ἔχει.</l>
 				</sp>
@@ -1947,7 +1947,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>πῶς εἶπας; ἦ τέθνηκε Πόλυβος, ὦ γέρον;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>εἰ μὴ λέγω τἀληθές, ἀξιῶ θανεῖν.</l>
 				</sp>
@@ -1960,7 +1960,7 @@ convert to TEI P3
 					<l>πρὸς τῆς τύχης ὄλωλεν οὐδὲ τοῦδ’ ὕπο.</l>
 					<milestone ed="p" n="950" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="950">ὦ φίλτατον γυναικὸς  Ἰοκάστης κάρα,</l>
 					<l>τί μ’ ἐξεπέμψω δεῦρο τῶνδε δωμάτων;</l>
@@ -1970,7 +1970,7 @@ convert to TEI P3
 					<l>ἄκουε τἀνδρὸς τοῦδε, καὶ σκόπει κλύων</l>
 					<l>τὰ σέμν’ ἵν’ ἥκει τοῦ θεοῦ μαντεύματα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὗτος δὲ τίς ποτ’ ἐστὶ καὶ τί μοι λέγει;</l>
 				</sp>
@@ -1979,32 +1979,32 @@ convert to TEI P3
 					<l n="955">ἐκ τῆς Κορίνθου, πατέρα τὸν σὸν ἀγγελῶν</l>
 					<l>ὡς οὐκέτ’ ὄντα Πόλυβον, ἀλλ’ ὀλωλότα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τί φῄς, ξέν’; αὐτός μοι σὺ σημάντωρ γενοῦ.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>εἰ τοῦτο πρῶτον δεῖ μ’ ἀπαγγεῖλαι σαφῶς,</l>
 					<l>εὖ ἴσθ’ ἐκεῖνον θανάσιμον βεβηκότα.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="960">πότερα δόλοισιν ἢ νόσου ξυναλλαγῇ;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>σμικρὰ παλαιὰ σώματ’ εὐνάζει ῥοπή.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>νόσοις ὁ τλήμων, ὡς ἔοικεν, ἔφθιτο.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>καὶ τῷ μακρῷ γε συμμετρούμενος χρόνῳ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>φεῦ φεῦ, τί δῆτ’ ἄν, ὦ γύναι, σκοποῖτό τι</l>
 					<l n="965">τὴν Πυθόμαντιν ἑστίαν ἢ τοὺς ἄνω</l>
@@ -2020,7 +2020,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>οὔκουν ἐγώ σοι ταῦτα προύλεγον πάλαι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ηὔδας·  ἐγὼ δὲ τῷ φόβῳ παρηγόμην.</l>
 				</sp>
@@ -2028,7 +2028,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l n="975">μὴ νῦν ἔτ’ αὐτῶν μηδὲν ἐς θυμὸν βάλῃς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ πῶς τὸ μητρὸς οὐκ ὀκνεῖν λέχος με δεῖ;</l>
 					<milestone ed="p" n="977" unit="card"/>
@@ -2043,7 +2043,7 @@ convert to TEI P3
 					<l>μητρὶ ξυνηυνάσθησαν.  ἀλλὰ ταῦθ’ ὅτῳ</l>
 					<l>παρ’ οὐδέν ἐστι, ῥᾷστα τὸν βίον φέρει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καλῶς ἅπαντα ταῦτ’ ἂν ἐξείρητό σοι,</l>
 					<l n="985">εἰ μὴ ’κύρει ζῶσ’ ἡ τεκοῦσα·  νῦν δ’ ἐπεὶ</l>
@@ -2053,31 +2053,31 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>καὶ μὴν μέγας γ’ ὀφθαλμὸς οἱ πατρὸς τάφοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>μέγας, ξυνίημ’·   ἀλλὰ τῆς ζώσης φόβος.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ποίας δὲ καὶ γυναικὸς ἐκφοβεῖσθ’ ὕπερ;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="990">Μερόπης, γεραιέ, Πόλυβος ἧς ᾤκει μέτα.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τί δ’ ἔστ’ ἐκείνης ὑμὶν ἐς φόβον φέρον;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>θεήλατον μάντευμα δεινόν, ὦ ξένε.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἦ ῥητόν; ἢ οὐχὶ θεμιτὸν ἄλλον εἰδέναι;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>μάλιστά γ’·  εἶπε γάρ με Λοξίας ποτὲ</l>
 					<l n="995">χρῆναι μιγῆναι μητρὶ τἠμαυτοῦ τό τε</l>
@@ -2087,204 +2087,204 @@ convert to TEI P3
 					<l>τὰ τῶν τεκόντων ὄμμαθ’ ἥδιστον βλέπειν.</l>
 					<milestone ed="p" n="1000" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1000">ἦ γὰρ τάδ’ ὀκνῶν κεῖθεν ἦσθ’ ἀπόπτολις;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πατρός τε χρῄζων μὴ φονεὺς εἶναι, γέρον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τί δῆτ’ ἐγὼ οὐχὶ τοῦδε τοῦ φόβου σ’, ἄναξ,</l>
 					<l>ἐπείπερ εὔνους ἦλθον, ἐξελυσάμην;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ μὴν χάριν γ’ ἂν ἀξίαν λάβοις ἐμοῦ.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1005">καὶ μὴν μάλιστα τοῦτ’ ἀφικόμην, ὅπως</l>
 					<l>σοῦ πρὸς δόμους ἐλθόντος εὖ πράξαιμί τι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ οὔποτ’ εἶμι   τοῖς φυτεύσασίν γ’ ὅμοῦ.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὦ παῖ, καλῶς εἶ     δῆλος οὐκ εἰδὼς τί δρᾷς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πῶς, ὦ γεραιέ;  πρὸς θεῶν δίδασκέ με.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1010">εἰ τῶνδε φεύγεις οὕνεκ’ εἰς οἴκους μολεῖν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ταρβῶν γε μή μοι Φοῖβος ἐξέλθῃ σαφής.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἦ μὴ μίασμα τῶν φυτευσάντων λάβῃς;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τοῦτ’ αὐτό, πρέσβυ, τοῦτό μ’ εἰσαεὶ φοβεῖ.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἆρ’ οἶσθα δῆτα πρὸς δίκης οὐδὲν τρέμων;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1015">πῶς δ’ οὐχί, παῖς γ’ εἰ τῶνδε γεννητῶν ἔφυν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὁθούνεκ’ ἦν σοι Πόλυβος οὐδὲν ἐν γένει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πῶς εἶπας; οὐ     γὰρ Πόλυβος ἐξέφυσέ με;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐ μᾶλλον οὐδὲν τοῦδε τἀνδρός, ἀλλ’ ἴσον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ πῶς ὁ φύσας ἐξ ἴσου τῷ μηδενί;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1020">ἀλλ’ οὔ σ’ ἐγείνατ’  οὔτ’ ἐκεῖνος οὔτ’  ἐγώ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ ἀντὶ τοῦ δὴ παῖδά μ’ ὠνομάζετο;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>δῶρόν ποτ’, ἴσθι, τῶν ἐμῶν χειρῶν λαβών.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>κᾆθ’ ὧδ’ ἀπ’ ἄλλης χειρὸς ἔστερξεν μέγα;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἡ γὰρ πρὶν αὐτὸν ἐξέπεισ’ ἀπαιδία.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1025">σὺ  δ’ ἐμπολήσας  ἢ τυχών μ’ αὐτῷ δίδως;</l>
 					<milestone ed="p" n="1026" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>εὑρὼν ναπαίαις ἐν Κιθαιρῶνος πτυχαῖς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὡδοιπόρεις δὲ     πρὸς τί τούσδε τοὺς τόπους;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐνταῦθ’ ὀρείοις ποιμνίοις ἐπεστάτουν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ποιμὴν γὰρ ἦσθα κἀπὶ θητείᾳ πλάνης;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1030">σοῦ τ’, ὦ τέκνον, σωτήρ γε τῷ τότ’ ἐν χρόνῳ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τί δ’ ἄλγος ἴσχοντ’ ἀγκάλαις με λαμβάνεις;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ποδῶν ἂν ἄρθρα μαρτυρήσειεν τὰ σά·</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οἴμοι, τί τοῦτ’    ἀρχαῖον ἐννέπεις κακόν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>λύω σ’ ἔχοντα  διατόρους ποδοῖν ἀκμάς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1035">δεινόν γ’ ὄνειδος σπαργάνων ἀνειλόμην.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὥστ’ ὠνομάσθης ἐκ τύχης ταύτης ὃς εἶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὦ πρὸς θεῶν, πρὸς μητρὸς ἢ πατρός; φράσον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐκ οἶδ’· ὁ δοὺς δὲ ταῦτ’ ἐμοῦ λῷον φρονεῖ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ γὰρ παρ’ ἄλλου μ’ ἔλαβες οὐδ’ αὐτὸς τυχών;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1040">οὔκ, ἀλλὰ ποιμὴν ἄλλος ἐκδίδωσί μοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίς οὗτος; ἦ κάτοισθα δηλῶσαι λόγῳ;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τῶν Λαΐου δήπου τις ὠνομάζετο.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ τοῦ τυράννου τῆσδε γῆς πάλαι ποτέ;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>μάλιστα·  τούτου τἀνδρὸς οὗτος ἦν βοτήρ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1045">ἦ κἄστ’ ἔτι ζῶν οὗτος, ὥστ’ ἰδεῖν ἐμέ;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὑμεῖς γ’ ἄριστ’  εἰδεῖτ’ ἂν οὑπιχώριοι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἔστιν τις ὑμῶν τῶν παρεστώτων πέλας,</l>
 					<l>ὅστις κάτοιδε τὸν βοτῆρ’ ὃν ἐννέπει,</l>
 					<l>εἴτ’ οὖν ἐπ’ ἀγρῶν εἴτε κἀνθάδ’ εἰσιδών;</l>
 					<l n="1050">σημήναθ’, ὡς ὁ καιρὸς ηὑρῆσθαι τάδε.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οἶμαι μὲν οὐδέν’ ἄλλον ἢ τὸν ἐξ ἀγρῶν,</l>
 					<l>ὃν κἀμάτευες πρόσθεν εἰσιδεῖν·  ἀτὰρ</l>
 					<l>ἥδ’ ἂν τάδ’ οὐχ ἥκιστ’ ἂν Ἰοκάστη λέγοι.</l>
 					<milestone ed="p" n="1054" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>γύναι, νοεῖς ἐκεῖνον, ὅντιν’ ἀρτίως</l>
 					<l n="1055">μολεῖν ἐφιέμεσθα; τόνδ’ οὗτος λέγει;</l>
@@ -2294,7 +2294,7 @@ convert to TEI P3
 					<l>τί δ’ ὅντιν’ εἶπε; μηδὲν ἐντραπῇς·  τὰ δὲ</l>
 					<l>ῥηθέντα βούλου μηδὲ μεμνῆσθαι μάτην.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐκ ἂν γένοιτο τοῦθ’ ὅπως ἐγὼ λαβὼν</l>
 					<l>σημεῖα τοιαῦτ’ οὐ φανῶ τοὐμὸν γένος.</l>
@@ -2304,7 +2304,7 @@ convert to TEI P3
 					<l n="1060">μὴ πρὸς θεῶν, εἴπερ τι τοῦ σαυτοῦ βίου</l>
 					<l>κήδει, ματεύσῃς τοῦθ’·  ἅλις νοσοῦσ’ ἐγώ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>θάρσει·  σὺ μὲν γὰρ οὐδ’ ἐὰν τρίτης ἐγὼ</l>
 					<l>μητρὸς φανῶ τρίδουλος, ἐκφανεῖ κακή.</l>
@@ -2313,7 +2313,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>ὅμως πιθοῦ μοι, λίσσομαι·  μὴ δρᾶ τάδε.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1065">οὐκ ἂν πιθοίμην μὴ οὐ τάδ’ ἐκμαθεῖν σαφῶς.</l>
 				</sp>
@@ -2321,7 +2321,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>καὶ μὴν φρονοῦσά γ’ εὖ τὰ λῷστά σοι λέγω.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τὰ λῷστα τοίνυν ταῦτά μ’ ἀλγύνει πάλαι.</l>
 				</sp>
@@ -2329,7 +2329,7 @@ convert to TEI P3
 					<speaker>Ἰοκάστη</speaker>
 					<l>ὦ δύσποτμ’, εἴθε μήποτε γνοίης ὃς εἶ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἄξει τις ἐλθὼν δεῦρο τὸν βοτῆρά μοι;</l>
 					<l n="1070">ταύτην δ’ ἐᾶτε πλουσίῳ χαίρειν γένει.</l>
@@ -2339,13 +2339,13 @@ convert to TEI P3
 					<l>ἰοὺ ἰού, δύστηνε·  τοῦτο γάρ σ’ ἔχω</l>
 					<l>μόνον προσειπεῖν, ἄλλο δ’ οὔποθ’ ὕστερον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί ποτε βέβηκεν, Οἰδίπους, ὑπ’ ἀγρίας</l>
 					<l>ᾄξασα λύπης ἡ γυνή; δέδοιχ’ ὅπως</l>
 					<l n="1075">μὴ ’κ τῆς σιωπῆς τῆσδ’ ἀναρρήξει κακά.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὁποῖα χρῄζει ῥηγνύτω·  τοὐμὸν δ’ ἐγώ,</l>
 					<l>κεἰ σμικρόν ἐστι, σπέρμ’ ἰδεῖν βουλήσομαι.</l>
@@ -2362,7 +2362,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἴπερ ἐγὼ μάντις εἰμὶ καὶ κατὰ γνώμαν ἴδρις,</l>
 						<l>οὐ τὸν Ὄλυμπον ἀπείρων, ὦ Κιθαιρών,</l>
@@ -2375,7 +2375,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τίς σε, τέκνον, τίς σ’ ἔτικτε τᾶν μακραιώνων ἄρα</l>
 						<l n="1100">Πανὸς ὀρεσσιβάτα πατρὸς πελασθεῖσ’;</l>
@@ -2389,7 +2389,7 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1110">εἰ χρή τι κἀμὲ μὴ συναλλάξαντά πω,</l>
 					<l>πρέσβεις, σταθμᾶσθαι, τὸν βοτῆρ’ ὁρᾶν δοκῶ,</l>
@@ -2399,21 +2399,21 @@ convert to TEI P3
 					<l n="1115">ἔγνωκ’ ἐμαυτοῦ·  τῇ δ’ ἐπιστήμῃ σύ μου</l>
 					<l>προύχοις τάχ’ ἄν που, τὸν βοτῆρ’ ἰδὼν πάρος.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔγνωκα γάρ, σάφ’ ἴσθι·  Λαΐου γὰρ ἦν</l>
 					<l>εἴπερ τις ἄλλος πιστὸς ὡς νομεὺς ἀνήρ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>σὲ πρῶτ’ ἐρωτῶ, τὸν Κορίνθιον ξένον,</l>
 					<l n="1120" part="I">ἦ τόνδε φράζεις;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l part="F">τοῦτον, ὅνπερ εἰσορᾷς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὗτος σύ, πρέσβυ, δεῦρό μοι φώνει βλέπων</l>
 					<l>ὅσ’ ἄν σ’ ἐρωτῶ.  Λαΐου ποτ’ ἦσθα σύ;</l>
@@ -2422,7 +2422,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>ἦ δοῦλος οὐκ ὠνητός, ἀλλ’ οἴκοι τραφείς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἔργον μεριμνῶν ποῖον ἢ βίον τινά;</l>
 				</sp>
@@ -2430,7 +2430,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l n="1125">ποίμναις τὰ πλεῖστα τοῦ βίου συνειπόμην.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>χώροις μάλιστα      πρὸς τίσι ξύναυλος ὤν;</l>
 				</sp>
@@ -2438,7 +2438,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>ἦν μὲν Κιθαιρών, ἦν δὲ πρόσχωρος τόπος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τὸν ἄνδρα τόνδ’ οὖν οἶσθα τῇδέ που μαθών;</l>
 				</sp>
@@ -2446,7 +2446,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>τί χρῆμα δρῶντα; ποῖον ἄνδρα καὶ λέγεις;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1130">τόνδ’ ὃς πάρεστιν·  ἢ ξυναλλάξας τί πω;</l>
 				</sp>
@@ -2454,7 +2454,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>οὐχ ὥστε γ’ εἰπεῖν ἐν τάχει μνήμης ἄπο.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>κοὐδέν γε θαῦμα, δέσποτ’·  ἀλλ’ ἐγὼ σαφῶς</l>
 					<l>ἀγνῶτ’ ἀναμνήσω νιν.  εὖ γὰρ οἶδ’ ὅτι</l>
@@ -2471,7 +2471,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>λέγεις ἀληθῆ, καίπερ ἐκ μακροῦ χρόνου.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>φέρ’ εἰπὲ νῦν, τότ’ οἶσθα παῖδά μοί τινα</l>
 					<l>δούς, ὡς ἐμαυτῷ θρέμμα θρεψαίμην ἐγώ;</l>
@@ -2480,7 +2480,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>τί δ’ ἔστι; πρὸς   τί τοῦτο τοὔπος ἱστορεῖς;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="1145">ὅδ’ ἐστίν, ὦ τᾶν, κεῖνος ὃς τότ’ ἦν νέος.</l>
 				</sp>
@@ -2488,7 +2488,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>οὐκ εἰς ὄλεθρον; οὐ σιωπήσας ἔσει;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἆ, μὴ κόλαζε, πρέσβυ, τόνδ’, ἐπεὶ τὰ σὰ</l>
 					<l>δεῖται κολαστοῦ μᾶλλον ἢ τὰ τοῦδ’ ἔπη.</l>
@@ -2497,7 +2497,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>τί δ’, ὦ φέριστε δεσποτῶν, ἁμαρτάνω;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1150">οὐκ ἐννέπων τὸν παῖδ’  ὃν οὗτος ἱστορεῖ.</l>
 				</sp>
@@ -2505,7 +2505,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>λέγει γὰρ εἰδὼς  οὐδέν, ἀλλ’ ἄλλως πονεῖ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>σὺ πρὸς χάριν μὲν οὐκ ἐρεῖς, κλαίων δ’ ἐρεῖς.</l>
 				</sp>
@@ -2513,7 +2513,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>μὴ δῆτα, πρὸς θεῶν, τὸν γέροντά μ’ αἰκίσῃ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὐχ ὡς τάχος τις    τοῦδ’ ἀποστρέψει χέρας;</l>
 				</sp>
@@ -2521,7 +2521,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l n="1155">δύστηνος, ἀντὶ τοῦ; τί προσχρῄζων μαθεῖν;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τὸν παῖδ’ ἔδωκας τῷδ’  ὃν οὗτος ἱστορεῖ;</l>
 				</sp>
@@ -2529,7 +2529,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>ἔδωκ’·  ὀλέσθαι δ’ ὤφελον τῇδ’ ἡμέρᾳ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ εἰς τόδ’ ἥξεις μὴ λέγων γε τοὔνδικον.</l>
 				</sp>
@@ -2537,7 +2537,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>πολλῷ γε μᾶλλον, ἢν φράσω, διόλλυμαι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1160">ἁνὴρ ὅδ’, ὡς ἔοικεν, ἐς τριβὰς ἐλᾷ.</l>
 				</sp>
@@ -2545,7 +2545,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>οὐ δῆτ’ ἔγωγ’,   ἀλλ’ εἶπον, ὡς δοίην, πάλαι.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πόθεν λαβών; οἰκεῖον ἢ ’ξ ἄλλου τινός;</l>
 				</sp>
@@ -2553,7 +2553,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>ἐμὸν μὲν οὐκ ἔγωγ’, ἐδεξάμην δέ του.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>τίνος πολιτῶν τῶνδε κἀκ ποίας στέγης;</l>
 				</sp>
@@ -2561,7 +2561,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l n="1165">μὴ πρὸς θεῶν, μή, δέσποθ’, ἱστόρει πλέον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὄλωλας, εἴ σε ταῦτ’ ἐρήσομαι πάλιν.</l>
 				</sp>
@@ -2569,7 +2569,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>τῶν Λαΐου τοίνυν τις ἦν γεννημάτων.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἦ δοῦλος ἢ κείνου τις ἐγγενὴς γεγώς;</l>
 				</sp>
@@ -2577,7 +2577,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l>οἴμοι, πρὸς αὐτῷ γ’ εἰμὶ τῷ δεινῷ λέγειν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1170">κἄγωγ’  ἀκούειν·  ἀλλ’  ὅμως ἀκουστέον.</l>
 					<milestone ed="p" n="1171" unit="card"/>
@@ -2587,7 +2587,7 @@ convert to TEI P3
 					<l>κείνου γέ τοι δὴ παῖς ἐκλῄζεθ’·  ἡ δ’ ἔσω</l>
 					<l>κάλλιστ’ ἂν εἴποι σὴ γυνὴ τάδ’ ὡς ἔχει.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ἦ γὰρ δίδωσιν ἥδε σοι;</l>
 				</sp>
@@ -2595,7 +2595,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l part="F">μάλιστ’, ἄναξ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ὡς πρὸς τί χρείας;</l>
 				</sp>
@@ -2603,7 +2603,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l part="F">ὡς ἀναλώσαιμί νιν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1175" part="I">τεκοῦσα τλήμων;</l>
 				</sp>
@@ -2611,7 +2611,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l part="F">θεσφάτων γ’ ὄκνῳ κακῶν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l part="I">ποίων;</l>
 				</sp>
@@ -2619,7 +2619,7 @@ convert to TEI P3
 					<speaker>Θεράπων</speaker>
 					<l part="F">κτενεῖν νιν τοὺς τεκόντας ἦν λόγος.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πῶς δῆτ’ ἀφῆκας τῷ γέροντι τῷδε σύ;</l>
 				</sp>
@@ -2630,7 +2630,7 @@ convert to TEI P3
 					<l n="1180">κάκ’  εἰς μέγιστ’  ἔσωσεν.  εἰ γὰρ οὗτος εἶ</l>
 					<l>ὅν φησιν οὗτος, ἴσθι δύσποτμος γεγώς.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἰοὺ ἰού·  τὰ πάντ’ ἂν ἐξήκοι σαφῆ.</l>
 					<l>ὦ φῶς, τελευταῖόν σε προσβλέψαιμι νῦν,</l>
@@ -2641,7 +2641,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἰὼ γενεαὶ βροτῶν,</l>
 						<l>ὡς ὑμᾶς ἴσα καὶ τὸ μηδὲν ζώσας ἐναριθμῶ.</l>
@@ -2656,7 +2656,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὅστις καθ’  ὑπερβολὰν</l>
 						<l>τοξεύσας ἐκράτησε τοῦ πάντ’ εὐδαίμονος ὄλβου,</l>
@@ -2671,7 +2671,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τανῦν δ’ ἀκούειν τίς ἀθλιώτερος;</l>
 						<l n="1205">τίς ἄταις ἀγρίαις, τίς ἐν πόνοις</l>
@@ -2686,7 +2686,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐφηῦρέ σ’ ἄκονθ’ ὁ πάνθ’ ὁρῶν χρόνος,</l>
 						<l>δικάζει τ’ ἄγαμον γάμον πάλαι</l>
@@ -2703,7 +2703,7 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#eksaggelos">
+				<sp who="#exangelos">
 					<speaker>Ἐξάγγελος</speaker>
 					<l>ὦ γῆς μέγιστα τῆσδ’ ἀεὶ τιμώμενοι,</l>
 					<l>οἷ’, ἔργ’ ἀκούσεσθ’, οἷα δ’ εἰσόψεσθ’, ὅσον δ’</l>
@@ -2715,22 +2715,22 @@ convert to TEI P3
 					<l n="1230">ἑκόντα κοὐκ ἄκοντα.  τῶν δὲ πημονῶν</l>
 					<l>μάλιστα λυποῦσ’ αἳ φανῶσ’ αὐθαίρετοι.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>λείπει μὲν οὐδ’ ἃ πρόσθεν εἴδομεν τὸ μὴ οὐ</l>
 					<l>βαρύστον’ εἶναι·  πρὸς δ’ ἐκείνοισιν τί φῄς;</l>
 				</sp>
-				<sp who="#eksaggelos">
+				<sp who="#exangelos">
 					<speaker>Ἐξάγγελος</speaker>
 					<l>ὁ μὲν τάχιστος τῶν λόγων εἰπεῖν τε καὶ</l>
 					<l n="1235">μαθεῖν, τέθνηκε θεῖον Ἰοκάστης κάρα.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ δυστάλαινα, πρὸς τίνος ποτ’ αἰτίας;</l>
 					<milestone ed="p" n="1237" unit="card"/>
 				</sp>
-				<sp who="#eksaggelos">
+				<sp who="#exangelos">
 					<speaker>Ἐξάγγελος</speaker>
 					<l>αὐτὴ πρὸς αὑτῆς.  τῶν δὲ πραχθέντων τὰ μὲν</l>
 					<l>ἄλγιστ’ ἄπεστιν·  ἡ γὰρ ὄψις οὐ πάρα.</l>
@@ -2783,11 +2783,11 @@ convert to TEI P3
 					<l>ὅσ’ ἐστὶ πάντων ὀνόματ’, οὐδέν ἐστ’ ἀπόν.</l>
 					<milestone ed="p" n="1285" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1285">νῦν δ’ ἔσθ’ ὁ τλήμων ἐν τίνι σχολῇ κακοῦ;</l>
 				</sp>
-				<sp who="#eksaggelos">
+				<sp who="#exangelos">
 					<speaker>Ἐξάγγελος</speaker>
 					<l>βοᾷ διοίγειν κλῇθρα καὶ δηλοῦν τινα</l>
 					<l>τοῖς πᾶσι Καδμείοισι τὸν πατροκτόνον,</l>
@@ -2802,7 +2802,7 @@ convert to TEI P3
 					<milestone ed="p" n="1297" unit="card"/>
 				</sp>
 				<div2 type="anapests">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ δεινὸν ἰδεῖν πάθος ἀνθρώποις,</l>
 						<l>ὦ δεινότατον πάντων ὅσ’ ἐγὼ</l>
@@ -2816,14 +2816,14 @@ convert to TEI P3
 						<l n="1305">πολλὰ δ’ ἀθρῆσαι·</l>
 						<l>τοίαν φρίκην παρέχεις μοι.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>αἰαῖ αἰαῖ, δύστανος ἐγώ,</l>
 						<l>ποῖ γᾶς φέρομαι τλάμων; πᾷ μοι</l>
 						<l n="1310">φθογγὰ διαπωτᾶται φοράδην;</l>
 						<l>ἰὼ δαῖμον, ἵν’ ἐξήλλου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐς δεινὸν οὐδ’ ἀκουστὸν οὐδ’ ἐπόψιμον.</l>
 						<milestone ed="p" n="1313" unit="card"/>
@@ -2832,7 +2832,7 @@ convert to TEI P3
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἰὼ σκότου</l>
 						<l>νέφος ἐμὸν ἀπότροπον, ἐπιπλόμενον ἄφατον,</l>
@@ -2843,7 +2843,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ θαῦμά γ’ οὐδὲν ἐν τοσοῖσδε πήμασιν</l>
 						<l n="1320">διπλᾶ  σε πενθεῖν καὶ διπλᾶ φορεῖν κακά.</l>
@@ -2851,7 +2851,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ἰὼ φίλος,</l>
 						<l>σὺ μὲν ἐμὸς ἐπίπολος ἔτι μόνιμος·  ἔτι γὰρ</l>
@@ -2862,7 +2862,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ δεινὰ δράσας, πῶς ἔτλης τοιαῦτα σὰς</l>
 						<l>ὄψεις μαρᾶναι; τίς σ’ ἐπῆρε δαιμόνων;</l>
@@ -2870,7 +2870,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>Ἀπόλλων τάδ’ ἦν, Ἀπόλλων, φίλοι,</l>
 						<l n="1330">ὁ κακὰ κακὰ τελῶν ἐμὰ τάδ’ ἐμὰ πάθεα.</l>
@@ -2878,11 +2878,11 @@ convert to TEI P3
 						<l>τί γὰρ ἔδει μ’ ὁρᾶν,</l>
 						<l n="1335">ὅτῳ γ’ ὁρῶντι μηδὲν ἦν ἰδεῖν γλυκύ;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἦν τᾷδ’ ὅπωσπερ καὶ σύ φῄς.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>τί δῆτ’ ἐμοὶ βλεπτὸν ἢ</l>
 						<l>στερκτὸν ἢ προσήγορον</l>
@@ -2892,7 +2892,7 @@ convert to TEI P3
 						<l>τὸν καταρατότατον, ἔτι δὲ καὶ θεοῖς</l>
 						<l n="1345">ἐχθρότατον βροτῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>δείλαιε τοῦ νοῦ τῆς τε συμφορᾶς ἴσον,</l>
 						<l>ὡς σ’ ἠθέλησα μηδέ γ’ ἂν γνῶναί ποτε.</l>
@@ -2900,7 +2900,7 @@ convert to TEI P3
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>ὄλοιθ’  ὅστις ἦν, ὃς ἀγρίας πέδας</l>
 						<l n="1350">μονάδ’ ἐπιποδίας ἔλυσ’ μ’ ἀπό τε φόνου</l>
@@ -2908,11 +2908,11 @@ convert to TEI P3
 						<l>τότε γὰρ ἂν θανὼν</l>
 						<l n="1355">οὐκ ἦ φίλοισιν οὐδ’ ἐμοὶ τοσόνδ’ ἄχος.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>θέλοντι κἀμοὶ τοῦτ’ ἂν ἦν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l>οὔκουν πατρός γ’  ἂν φονεὺς</l>
 						<l>ἦλθον οὐδὲ νυμφίος</l>
@@ -2926,12 +2926,12 @@ convert to TEI P3
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐκ οἶδ’ ὅπως σε φῶ βεβουλεῦσθαι καλῶς·</l>
 					<l>κρείσσων γὰρ ἦσθα μηκέτ’ ὢν ἢ ζῶν τυφλός.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ὡς μὲν τάδ’ οὐχ ὧδ’ ἔστ’ ἄριστ’ εἰργασμένα,</l>
 					<l n="1370">μή μ’ ἐκδίδασκε, μηδὲ συμβούλεῡ ἔτι.</l>
@@ -2982,13 +2982,13 @@ convert to TEI P3
 					<l n="1415">οὐδεὶς οἷός τε πλὴν ἐμοῦ φέρειν βροτῶν.</l>
 					<milestone ed="p" n="1416" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ὧν ἐπαιτεῖς εἰς δέον πάρεσθ’ ὅδε</l>
 					<l>Κρέων τὸ πράσσειν καὶ τὸ βουλεύειν, ἐπεὶ</l>
 					<l>χώρας λέλειπται μοῦνος ἀντὶ σοῦ φύλαξ.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οἴμοι, τί δῆτα λέξομεν πρὸς τόνδ’ ἔπος;</l>
 					<l n="1420">τίς μοι φανεῖται πίστις ἔνδικος;  τὰ γὰρ</l>
@@ -3007,7 +3007,7 @@ convert to TEI P3
 					<l n="1430">τοῖς ἐν γένει γὰρ τἀγγενῆ μάλισθ’ ὁρᾶν</l>
 					<l>μόνοις τ’ ἀκούειν εὐσεβῶς ἔχει κακά.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>πρὸς θεῶν, ἐπείπερ ἐλπίδος μ’ ἀπέσπασας,</l>
 					<l>ἄριστος ἐλθὼν πρὸς κάκιστον ἄνδρ’ ἐμέ,</l>
@@ -3017,7 +3017,7 @@ convert to TEI P3
 					<speaker>Κρέων</speaker>
 					<l n="1435">καὶ τοῦ με χρείας ὧδε λιπαρεῖς τυχεῖν;</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ῥῖψόν με γῆς ἐκ τῆσδ’ ὅσον τάχισθ’, ὅπου</l>
 					<l>θνητῶν φανοῦμαι μηδενὸς προσήγορος.</l>
@@ -3027,7 +3027,7 @@ convert to TEI P3
 					<l>ἔδρασ’ ἂν εὖ τοῦτ’ ἴσθ’ ἄν, εἰ μὴ τοῦ θεοῦ</l>
 					<l>πρώτιστ’ ἔχρῃζον ἐκμαθεῖν τί πρακτέαν.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l n="1440">ἀλλ’ ἥ γ’ ἐκείνου πᾶσ’ ἐδηλώθη φάτις,</l>
 					<l>τὸν πατροφόντην, τὸν ἀσεβῆ μ’ ἀπολλύναι.</l>
@@ -3037,7 +3037,7 @@ convert to TEI P3
 					<l>οὕτως ἐλέχθη ταῦθ’·  ὅμως δ’ ἵν’ ἕσταμεν</l>
 					<l>χρείας, ἄμεινον ἐκμαθεῖν τι δραστέον.</l>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>οὕτως ἄρ’ ἀνδρὸς ἀθλίου πεύσεσθ’ ὕπερ;</l>
 				</sp>
@@ -3046,7 +3046,7 @@ convert to TEI P3
 					<l n="1445">καὶ γὰρ σὺ νῦν τἂν τῷ θεῷ πίστιν φέροις.</l>
 					<milestone ed="p" n="1446" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>καὶ σοί γ’ ἐπισκήπτω τε καὶ προστέψομαι,</l>
 					<l>τῆς μὲν κατ’ οἴκους αὐτὸς ὃν θέλεις τάφον</l>
@@ -3085,7 +3085,7 @@ convert to TEI P3
 					<l>γνοὺς τὴν παροῦσαν τέρψιν, ἥ σ’ εἶχεν πάλαι.</l>
 					<milestone ed="p" n="1478" unit="card"/>
 				</sp>
-				<sp who="#oidipoys">
+				<sp who="#oidipous">
 					<speaker>Οἰδίπους</speaker>
 					<l>ἀλλ’ εὐτυχοίης, καί σε τῆσδε τῆσδε τῆς ὁδοῦ</l>
 					<l>δαίμων ἄμεινον ἢ ’μὲ φρουρήσας τύχοι.</l>
@@ -3130,7 +3130,7 @@ convert to TEI P3
 					<milestone ed="p" n="1516" unit="card"/>
 				</sp>
 				<div2 met="trochaic" type="close">
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">πειστέον, κεἰ μηδὲν ἡδύ.</l>
 					</sp>
@@ -3138,7 +3138,7 @@ convert to TEI P3
 						<speaker>Κρέων</speaker>
 						<l part="F">πάντα γὰρ καιρῷ καλά.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">οἶσθ’ ἐφ’ οἷς οὖν εἶμι;</l>
 					</sp>
@@ -3146,7 +3146,7 @@ convert to TEI P3
 						<speaker>Κρέων</speaker>
 						<l part="F">λέξεις, καὶ τότ’ εἴσομαι κλύων.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">γῆς μ’ ὅπως πέμψεις ἄποικον.</l>
 					</sp>
@@ -3154,7 +3154,7 @@ convert to TEI P3
 						<speaker>Κρέων</speaker>
 						<l part="F">τοῦ θεοῦ μ’ αἰτεῖς δόσιν.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">ἀλλὰ θεοῖς γ’ ἔχθιστος ἥκω.</l>
 					</sp>
@@ -3162,7 +3162,7 @@ convert to TEI P3
 						<speaker>Κρέων</speaker>
 						<l part="F">τοιγαροῦν τεύξει τάχα.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l n="1520" part="I">φὴ|ς τάδ’ οὖν;</l>
 					</sp>
@@ -3170,7 +3170,7 @@ convert to TEI P3
 						<speaker>Κρέων</speaker>
 						<l part="F">ἃ μὴ φρονῶ γὰρ οὐ φιλῶ λέγειν μάτην.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">ἄπαγέ νύν μ’ ἐντεῦθεν ἤδη.</l>
 					</sp>
@@ -3178,7 +3178,7 @@ convert to TEI P3
 						<speaker>Κρέων</speaker>
 						<l part="F">στεῖχέ νυν, τέκνων δ’ ἀφοῦ.</l>
 					</sp>
-					<sp who="#oidipoys">
+					<sp who="#oidipous">
 						<speaker>Οἰδίπους</speaker>
 						<l part="I">μηδαμῶς ταύτας γ’ ἕλῃ μου.</l>
 					</sp>
@@ -3187,7 +3187,7 @@ convert to TEI P3
 						<l part="F">πάντα μὴ βούλου κρατεῖν·</l>
 						<l>καὶ γὰρ ἁκράτησας οὔ σοι τῷ βίῳ ξυνέσπετο.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ πάτρας Θήβης ἔνοικοι, λεύσσετ’, Οἰδίπους ὅδε,</l>
 						<l n="1525">ὃς τὰ κλείν’ αἰνίγματ’ ᾔδει καὶ κράτιστος ἦν ἀνήρ,</l>

--- a/tei/sophocles-philoctetes.xml
+++ b/tei/sophocles-philoctetes.xml
@@ -52,22 +52,22 @@
 		<profileDesc>
 			<particDesc>
 				<listPerson>
-					<person xml:id="filoktetes">
+					<person xml:id="philoktetes">
 						<persName>Φιλοκτήτης</persName>
 					</person>
-					<person xml:id="erakles">
+					<person xml:id="herakles">
 						<persName>Ἡρακλῆς</persName>
 					</person>
 					<person xml:id="emporos">
 						<persName>Ἔμπορος</persName>
 					</person>
-					<person xml:id="odysseys">
+					<person xml:id="odysseus">
 						<persName>Ὀδυσσεύς</persName>
 					</person>
 					<person xml:id="neoptolemos">
 						<persName>Νεοπτόλεμος</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 				</listPerson>
@@ -168,7 +168,7 @@ antilabe in all files
 		<body n="Phil.">
 			<div1 type="episode">
 				<milestone ed="p" n="1" unit="card"/>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἀκτὴ μὲν ἥδε τῆς περιρρύτου χθονὸς</l>
 					<l>Λήμνου, βροτοῖς ἄστιπτος οὐδ’ οἰκουμένη,</l>
@@ -202,7 +202,7 @@ antilabe in all files
 					<l>ἄναξ Ὀδυσσεῦ, τοὔργον οὐ μακρὰν λέγεις·</l>
 					<l>δοκῶ γὰρ οἷον εἶπας ἄντρον εἰσορᾶν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἄνωθεν ἢ κάτωθεν; οὐ γὰρ ἐννοῶ.</l>
 				</sp>
@@ -210,7 +210,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>τόδ’ ἐξύπερθε· καὶ στίβου γ’ οὐδεὶς κτύπος.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="30">ὅρα καθ’ ὕπνον μὴ καταυλισθεὶς κυρεῖ.</l>
 				</sp>
@@ -218,7 +218,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ὁρῶ κενὴν οἴκησιν ἀνθρώπων δίχα.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὐδ’ ἔνδον οἰκοποιός ἐστί τις τροφή;</l>
 				</sp>
@@ -226,7 +226,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>στιπτή γε φυλλὰς ὡς ἐναυλίζοντί τῳ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τὰ δ’ ἄλλ’ ἔρημα, κοὐδέν ἐσθ’ ὑπόστεγον;</l>
 				</sp>
@@ -235,7 +235,7 @@ antilabe in all files
 					<l n="35">αὐτόξυλόν γ’ ἔκπωμα, φλαυρουργοῦ τινος</l>
 					<l>τεχνήματ’ ἀνδρός, καὶ πυρεῖ’ ὁμοῦ τάδε.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>κείνου τὸ θησαύρισμα σημαίνεις τόδε.</l>
 				</sp>
@@ -244,7 +244,7 @@ antilabe in all files
 					<l>ἰοὺ ἰού·  καὶ ταῦτά γ’ ἄλλα θάλπεται</l>
 					<l>ῥάκη, βαρείας του νοσηλείας πλέα.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="40">ἁνὴρ κατοικεῖ τούσδε τοὺς τόπους σαφῶς,</l>
 					<l>κἄστ’ οὐχ ἑκάς που· πῶς γὰρ ἂν νοσῶν ἀνὴρ</l>
@@ -260,7 +260,7 @@ antilabe in all files
 					<l>ἀλλ’ ἔρχεταί τε καὶ φυλάξεται στίβος.</l>
 					<l>σὺ δ’, εἴ τι χρῄζεις, φράζε δευτέρῳ λόγῳ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="50">Ἀχιλλέως παῖ, δεῖ σ’ ἐφ’ οἷς ἐλήλυθας</l>
 					<l>γενναῖον εἶναι, μὴ μόνον τῷ σώματι,</l>
@@ -272,7 +272,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="I">τί δῆτ’ ἄνωγας;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="F">τὴν Φιλοκτήτου σε δεῖ</l>
 					<l n="55">ψυχὴν ὅπως δόλοισιν  ἐκκλέψεις λέγων.</l>
@@ -321,7 +321,7 @@ antilabe in all files
 					<l>προδότης καλεῖσθαι· βούλομαι δ’, ἄναξ, καλῶς</l>
 					<l n="95">δρῶν ἐξαμαρτεῖν μᾶλλον ἢ νικᾶν κακῶς.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἐσθλοῦ πατρὸς παῖ, καὐτὸς ὢν νέος ποτὲ</l>
 					<l>γλῶσσαν μὲν ἀργόν, χεῖρα δ’ εἶχον ἐργάτιν·</l>
@@ -332,7 +332,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="100">τί μ’ οὖν ἄνωγας ἄλλο πλὴν ψευδῆ λέγειν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>λέγω σ’ ἐγὼ δόλῳ Φιλοκτήτην λαβεῖν.</l>
 				</sp>
@@ -340,7 +340,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>τί δ’ ἐν δόλῳ δεῖ μᾶλλον ἢ πείσαντ’ ἄγειν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὐ μὴ πίθηται·  πρὸς βίαν δ’ οὐκ ἂν λάβοις.</l>
 				</sp>
@@ -348,7 +348,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὕτως ἔχει τι δεινὸν ἰσχύος θράσος;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="105">ἰούς γ’ ἀφύκτους καὶ προπέμποντας φόνον.</l>
 				</sp>
@@ -356,7 +356,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὐκ ἆρ’ ἐκείνῳ γ’ οὐδὲ προσμῖξαι θρασύ;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὔ, μὴ δόλῳ λαβόντα γ’, ὡς ἐγὼ λέγω.</l>
 				</sp>
@@ -364,7 +364,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὐκ αἰσχρὸν ἡγεῖ δῆτα τὸ ψευδῆ λέγειν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὔκ, εἰ τὸ σωθῆναί γε τὸ ψεῦδος φέρει.</l>
 				</sp>
@@ -372,7 +372,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="110">πῶς οὖν βλέπων τις ταῦτα τολμήσει λακεῖν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ὅταν τι δρᾷς εἰς κέρδος, οὐκ ὀκνεῖν πρέπει.</l>
 				</sp>
@@ -380,7 +380,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>κέρδος δ’ ἐμοὶ τί τοῦτον ἐς Τροίαν μολεῖν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>αἱρεῖ τὰ τόξα ταῦτα τὴν Τροίαν μόνα.</l>
 				</sp>
@@ -388,7 +388,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὐκ ἆρ’ ὁ πέρσων, ὡς ἐφάσκετ’, εἴμ’ ἐγώ;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="115">οὔτ’ ἂν σὺ κείνων χωρὶς οὔτ’ ἐκεῖνα σοῦ.</l>
 				</sp>
@@ -396,7 +396,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>θηρατέ’ οὖν γίγνοιτ’ ἄν, εἴπερ ὧδ’ ἔχει.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ὡς τοῦτό γ’ ἔρξας δύο φέρει δωρήματα.</l>
 				</sp>
@@ -404,7 +404,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ποίω; μαθὼν γὰρ οὐκ ἂν ἀρνοίμην τὸ δρᾶν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>σοφός τ’ ἂν αὑτὸς κἀγαθὸς κεκλῇ’ ἅμα.</l>
 				</sp>
@@ -412,7 +412,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="120">ἴτω· ποήσω, πᾶσαν αἰσχύνην ἀφείς.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἦ μνημονεύεις οὖν ἅ σοι παρῄνεσα;</l>
 				</sp>
@@ -421,7 +421,7 @@ antilabe in all files
 					<l>σάφ’ ἴσθ’, ἐπείπερ εἰσάπαξ συνῄνεσα.</l>
 					<milestone ed="p" n="123" unit="card"/>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>σὺ μὲν μένων νυν κεῖνον ἐνθάδ’ ἐκδέχου,</l>
 					<l>ἐγὼ δ’ ἄπειμι, μὴ κατοπτευθῶ παρών,</l>
@@ -440,7 +440,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="135">τί χρὴ τί χρή με, δέσποτ’, ἐν ξένᾳ ξένον</l>
 						<l>στέγειν ἢ τί λέγειν πρὸς ἄνδρ’ ὑπόπταν;</l>
@@ -467,7 +467,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="150">μέλον πάλαι μέλημά μοι λέγεις, ἄναξ,</l>
 						<l>φρουρεῖν ὄμμ’ ἐπὶ σῷ μάλιστα καιρῷ·</l>
@@ -487,7 +487,7 @@ antilabe in all files
 						<l>οἶκον μὲν ὁρᾷς τόνδ’ ἀμφίθυρον</l>
 						<l n="160">πετρίνης κοίτης.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποῦ γὰρ ὁ τλήμων αὐτὸς ἄπεστιν;</l>
 					</sp>
@@ -504,7 +504,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἰκτίρω νιν ἔγωγ’, ὅπως,</l>
 						<l n="170">μή του κηδομένου βροτῶν</l>
@@ -520,7 +520,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="180">οὗτος πρωτογόνων ἴσως</l>
 						<l>οἴκων οὐδενὸς ὕστερος,</l>
@@ -552,7 +552,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="3" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">εὔστομ’ ἔχε, παῖ.</l>
 					</sp>
@@ -560,7 +560,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l part="M">τί τόδε;</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">προυφάνη κτύπος,</l>
 						<l>φωτὸς σύντροφος ὡς τειρομένου του,</l>
@@ -573,7 +573,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="3" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="210" part="I">ἀλλ’ ἔχε, τέκνον,</l>
 					</sp>
@@ -581,7 +581,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l part="M">λέγ’ ὅ τι.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">φροντίδας νέας.</l>
 						<l>ὡς οὐκ ἔξεδρος, ἀλλ’ ἔντοπος ἁνήρ,</l>
@@ -594,7 +594,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἰὼ ξένοι,</l>
 					<l n="220">τίνες ποτ’ ἐς γῆν τήνδε κἀκ ποίας πάτρας</l>
@@ -615,7 +615,7 @@ antilabe in all files
 					<l>ἀλλ’, ὦ ξέν’, ἴσθι τοῦτο πρῶτον, οὕνεκα</l>
 					<l>Ἕλληνές ἐσμεν· τοῦτο γὰρ βούλει μαθεῖν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ φίλτατον φώνημα· φεῦ τὸ καὶ λαβεῖν</l>
 					<l n="235">πρόσφθεγμα τοιοῦδ’ ἀνδρὸς ἐν χρόνῳ μακρῷ.</l>
@@ -629,7 +629,7 @@ antilabe in all files
 					<l n="240">Σκύρου·  πλέω δ’ ἐς οἶκον· αὐδῶμαι δὲ παῖς</l>
 					<l>Ἀχιλλέως, Νεοπτόλεμος.  οἶσθα δὴ τὸ πᾶν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ φιλτάτου παῖ πατρός, ὦ φίλης χθονός,</l>
 					<l>ὦ τοῦ γέροντος θρέμμα Λυκομήδους, τίνι</l>
@@ -639,7 +639,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="245">ἐξ Ἰλίου τοι δὴ τανῦν γε ναυστολῶ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>πῶς εἶπας; οὐ γὰρ δὴ σύ γ’ ἦσθα ναυβάτης</l>
 					<l>ἡμῖν κατ’ ἀρχὴν τοῦ πρὸς Ἴλιον στόλου.</l>
@@ -648,7 +648,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἦ γὰρ μετέσχες καὶ σὺ τοῦδε τοῦ πόνου;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ τέκνον, οὐ γὰρ οἶσθά μ’ ὅντιν’ εἰσορᾷς;</l>
 				</sp>
@@ -656,7 +656,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="250">πῶς γὰρ κάτοιδ’ ὅν γ’ εἶδον οὐδεπώποτε;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὐδ’ ὄνομ’ ἄρ’  οὐδὲ τῶν ἐμῶν κακῶν κλέος</l>
 					<l>ᾔσθου ποτ’ οὐδέν, οἷς ἐγὼ διωλλύμην;</l>
@@ -666,7 +666,7 @@ antilabe in all files
 					<l>ὡς μηδὲν εἰδότ’ ἴσθι μ’ ὧν ἀνιστορεῖς.</l>
 					<milestone ed="p" n="255" unit="card"/>
 				</sp>
-				<sp n="Φιλοκτήτης" who="#filoktetes">
+				<sp n="Φιλοκτήτης" who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="255">ὦ πόλλ’ ἐγὼ μοχθηρός, ὦ πικρὸς θεοῖς,</l>
 					<l>οὗ μηδὲ κληδὼν ὧδ’ ἔχοντος οἴκαδε</l>
@@ -734,7 +734,7 @@ antilabe in all files
 					<l>δοῖέν ποτ’ αὐτοῖς ἀντίποιν’ ἐμοῦ παθεῖν.</l>
 				</sp>
 				<milestone ed="p" n="317" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἔοικα κἀγὼ τοῖς ἀφιγμένοις ἴσα</l>
 					<l>ξένοις ἐποικτίρειν σε, Ποίαντος τέκνον.</l>
@@ -745,7 +745,7 @@ antilabe in all files
 					<l n="320">ὡς εἴσ’ ἀληθεῖς οἶδα, συντυχὼν κακῶν</l>
 					<l>ἀνδρῶν Ἀτρειδῶν τῆς τ’ Ὀδυσσέως βίας.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἦ γάρ τι καὶ σὺ τοῖς πανωλέθροις ἔχεις</l>
 					<l>ἔγκλημ’ Ἀτρείδαις, ὥστε θυμοῦσθαι παθών;</l>
@@ -756,7 +756,7 @@ antilabe in all files
 					<l n="325">ἵν’ αἱ Μυκῆναι γνοῖεν ἡ Σπάρτη θ’ ὅτι</l>
 					<l>χἠ Σκῦρος ἀνδρῶν ἀλκίμων μήτηρ ἔφυ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>εὖ γ’, ὦ τέκνον· τίνος γὰρ ὧδε τὸν μέγαν</l>
 					<l>χόλον κατ’ αὐτῶν ἐγκαλῶν ἐλήλυθας;</l>
@@ -767,7 +767,7 @@ antilabe in all files
 					<l n="330">ἅγωγ’ ὑπ’ αὐτῶν ἐξελωβήθην μολών.</l>
 					<l>ἐπεὶ γὰρ ἔσχε μοῖρ’ Ἀχιλλέα θανεῖν,</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οἴμοι· φράσῃς μοι μὴ πέρα, πρὶν ἂν μάθω</l>
 					<l>πρῶτον τόδ’, ἦ τέθνηχ’ ὁ Πηλέως γόνος;</l>
@@ -777,7 +777,7 @@ antilabe in all files
 					<l>τέθνηκεν, ἀνδρὸς οὐδενός, θεοῦ δ’ ὕπο,</l>
 					<l n="335">τοξευτός, ὡς λέγουσιν, ἐκ Φοίβου δαμείς.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀλλ’ εὐγενὴς μὲν ὁ κτανών τε χὠ θανών·</l>
 					<l>ἀμηχανῶ δὲ πότερον, ὦ τέκνον, τὸ σὸν</l>
@@ -788,7 +788,7 @@ antilabe in all files
 					<l>οἶμαι μὲν ἀρκεῖν σοί γε καὶ τὰ σ’, ὦ τάλας,</l>
 					<l n="340">ἀλγήμαθ’, ὥστε μὴ τὰ τῶν πέλας στένειν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὀρθῶς ἔλεξας· τοιγαροῦν τὸ σὸν φράσον</l>
 					<l>αὖθις πάλιν μοι πρᾶγμ’, ὅτῳ σ’ ἐνύβρισαν.</l>
@@ -849,7 +849,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὀρεστέρα παμβῶτι Γᾶ, μᾶτερ αὐτοῦ Διός,</l>
 						<l>ἃ τὸν μέγαν Πακτωλὸν εὔχρυσον νέμεις,</l>
@@ -864,7 +864,7 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἔχοντες, ὡς ἔοικε, σύμβολον σαφὲς</l>
 					<l>λύπης πρὸς ἡμᾶς, ὦ ξένοι, πεπλεύκατε,</l>
@@ -881,7 +881,7 @@ antilabe in all files
 					<l>οὐκ ἦν ἔτι ζῶν, ὦ ξέν’· οὐ γὰρ ἄν ποτε</l>
 					<l>ζῶντός γ’ ἐκείνου ταῦτ’ ἐσυλήθην ἐγώ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>πῶς εἶπας; ἀλλ’ ἦ χοὖτος οἴχεται θανών;</l>
 				</sp>
@@ -889,7 +889,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="415">ὡς μηκέτ’ ὄντα κεῖνον ἐν φάει νόει.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οἴμοι τάλας.  ἀλλ’ οὐχ ὁ Τυδέως γόνος</l>
 					<l>οὐδ’ οὑμπολητὸς Σισύφου Λαερτίῳ,</l>
@@ -900,7 +900,7 @@ antilabe in all files
 					<l>οὐ δῆτ’· ἐπίστω τοῦτό γ’· ἀλλὰ καὶ μέγα</l>
 					<l n="420">θάλλοντές εἰσι νῦν ἐν Ἀργείων στρατῷ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>τί δ’; οὐ παλαιὸς  κἀγαθὸς φίλος τ’ ἐμός,</l>
 					<l>Νέστωρ ὁ Πύλιος, ἔστιν; οὗτος γὰρ τά γε</l>
@@ -911,7 +911,7 @@ antilabe in all files
 					<l>κεῖνός γε πράσσει νῦν κακῶς, ἐπεὶ θανὼν</l>
 					<l n="425">Ἀντίλοχος αὐτῷ φροῦδος, ὃς παρῆν, γόνος.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οἴμοι, δύ’ αὖ τώδ’ ἄνδρ’ ἔλεξας, οἷν ἐγὼ</l>
 					<l>ἥκιστ’ ἂν ἠθέλησ’ ὀλωλότοιν κλύειν.</l>
@@ -924,7 +924,7 @@ antilabe in all files
 					<l>σοφὸς παλαιστὴς κεῖνος· ἀλλὰ χαἰ σοφαὶ</l>
 					<l>γνῶμαι, Φιλοκτῆτ’, ἐμποδίζονται θαμά.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>φέρ’ εἰπὲ πρὸς θεῶν, ποῦ γὰρ ἦν ἐνταῦθά σοι</l>
 					<l>Πάτροκλος, ὃς σοῦ πατρὸς ἦν τὰ φίλτατα;</l>
@@ -935,7 +935,7 @@ antilabe in all files
 					<l>τοῦτ’ ἐκδιδάξω·  πόλεμος οὐδέν’ ἄνδρ’ ἑκὼν</l>
 					<l>αἱρεῖ πονηρόν, ἀλλὰ τοὺς χρηστοὺς ἀεί.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ξυμμαρτυρῶ σοι· καὶ κατ’ αὐτὸ τοῦτό γε</l>
 					<l>ἀναξίου μὲν φωτὸς ἐξερήσομαι,</l>
@@ -946,7 +946,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ποίου δὲ τούτου πλήν γ’ Ὀδυσσέως ἐρεῖς;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὐ τοῦτον εἶπον, ἀλλὰ Θερσίτης τις ἦν,</l>
 					<l>ὃς οὐκ ἂν εἵλετ’ εἰσάπαξ εἰπεῖν, ὅπου</l>
@@ -956,7 +956,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="445">οὐκ εἶδον αὐτόν, ᾐσθόμην δ’ ἔτ’ ὄντα νιν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἔμελλ’· ἐπεὶ οὐδέν πω κακόν γ’ ἀπώλετο,</l>
 					<l>ἀλλ’ εὖ περιστέλλουσιν αὐτὰ δαίμονες,</l>
@@ -982,7 +982,7 @@ antilabe in all files
 					<l>ἡμεῖς δ’ ἴωμεν, ὡς ὁπηνίκ’ ἂν θεὸς</l>
 					<l n="465">πλοῦν ἡμὶν εἴκῃ, τηνικαῦθ’ ὁρμώμεθα.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">ἤδη, τέκνον, στέλλεσθε;</l>
 				</sp>
@@ -992,7 +992,7 @@ antilabe in all files
 					<l>πλοῦν μὴ ’ξ ἀπόπτου μᾶλλον ἢ ’γγύθεν σκοπεῖν.</l>
 					<milestone ed="p" n="468" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>πρός νύν σε πατρὸς πρός τε μητρός, ὦ τέκνον,</l>
 					<l>πρός τ’ εἴ τί σοι κατ’ οἶκόν ἐστι προσφιλές,</l>
@@ -1038,7 +1038,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οἴκτιρ’, ἄναξ· πολλῶν ἔλεξεν δυσοίστων πόνων</l>
 						<l>ἆθλ’, οἷα μηδεὶς τῶν ἐμῶν τύχοι φίλων.</l>
@@ -1059,7 +1059,7 @@ antilabe in all files
 					<l n="520">ὅταν δὲ πλησθῇς τῆς νόσου ξυνουσίᾳ,</l>
 					<l>τότ’ οὐκέθ’ αὑτὸς τοῖς λόγοις τούτοις φανῇς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἥκιστα· τοῦτ’ οὐκ ἔσθ’ ὅπως ποτ’ εἰς ἐμὲ</l>
 					<l>τοὔνειδος ἕξεις ἐνδίκως ὀνειδίσαι.</l>
@@ -1073,7 +1073,7 @@ antilabe in all files
 					<l>μόνον θεοὶ σῴζοιεν ἔκ τε τῆσδε γῆς</l>
 					<l>ἡμᾶς ὅποι τ’ ἐνθένδε βουλοίμεσθα πλεῖν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="530">ὦ φίλτατον μὲν ἦμαρ, ἥδιστος δ’ ἀνήρ,</l>
 					<l>φίλοι δὲ ναῦται, πῶς ἂν ὑμὶν ἐμφανὴς</l>
@@ -1085,7 +1085,7 @@ antilabe in all files
 					<l>ἄλλον λαβόντα πλὴν ἐμοῦ τλῆναι τάδε·</l>
 					<l>ἐγὼ δ’ ἀνάγκῃ προύμαθον στέργειν κακά.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐπίσχετον, μάθωμεν· ἄνδρε γὰρ δύο,</l>
 					<l n="540">ὁ μὲν νεὼς σῆς ναυβάτης, ὁ δ’ ἀλλόθρους,</l>
@@ -1167,7 +1167,7 @@ antilabe in all files
 					<l>μή νύν μ’ ἔρῃ τὰ πλείον’, ἀλλ’ ὅσον τάχος</l>
 					<l>ἔκπλει σεαυτὸν ξυλλαβὼν ἐκ τῆσδε γῆς.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>τί φησιν, ὦ παῖ; τί με κατὰ σκότον ποτὲ</l>
 					<l>διεμπολᾷ λόγοισι πρός σ’ ὁ ναυβάτης;</l>
@@ -1247,7 +1247,7 @@ antilabe in all files
 					<l n="620">ἤκουσας, ὦ παῖ, πάντα· τὸ σπεύδειν δέ σοι</l>
 					<l>καὐτῷ παραινῶ κεἴ τινος κήδει πέρι.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οἴμοι τάλας· ἦ κεῖνος, ἡ πᾶσα βλάβη,</l>
 					<l>ἔμ’ εἰς Ἀχαιοὺς ὤμοσεν πείσας στελεῖν;</l>
@@ -1260,7 +1260,7 @@ antilabe in all files
 					<l>ναῦν, σφῷν δ’ ὅπως ἄριστα συμφέροι θεός.</l>
 					<milestone ed="p" n="628" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὔκουν τάδ’, ὦ παῖ, δεινά, τὸν Λαερτίου</l>
 					<l>ἔμ’ ἐλπίσαι ποτ’ ἂν λόγοισι μαλθακοῖς</l>
@@ -1279,7 +1279,7 @@ antilabe in all files
 					<l>οὐκοῦν ἐπειδὰν πνεῦμα τοὐκ πρῴρας ἀνῇ,</l>
 					<l n="640">τότε στελοῦμεν· νῦν γὰρ ἀντιοστατεῖ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀεὶ καλὸς πλοῦς ἔσθ’, ὅταν φεύγῃς κακά.</l>
 				</sp>
@@ -1287,7 +1287,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὔκ, ἀλλὰ κἀκείνοισι ταῦτ’ ἐναντία.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὐκ ἔστι λῃσταῖς πνεῦμ’ ἐναντιούμενον,</l>
 					<l>ὅταν παρῇ κλέψαι τι χἀρπάσαι βίᾳ.</l>
@@ -1297,7 +1297,7 @@ antilabe in all files
 					<l n="645">ἀλλ’ εἰ δοκεῖ, χωρῶμεν, ἔνδοθεν λαβὼν</l>
 					<l>ὅτου σε χρεία καὶ πόθος μάλιστ’ ἔχει.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀλλ’ ἔστιν ὧν δεῖ, καίπερ οὐ πολλῶν ἄπο.</l>
 				</sp>
@@ -1305,7 +1305,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>τί τοῦθ’ ὃ μὴ νεώς γε τῆς ἐμῆς ἔπι;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>φύλλον τί μοι πάρεστιν, ᾧ μάλιστ’ ἀεὶ</l>
 					<l n="650">κοιμῶ τόδ’ ἕλκος, ὥστε πραΰνειν πάνυ.</l>
@@ -1314,7 +1314,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀλλ’ ἔκφερ’ αὐτό.  τί γὰρ ἔτ’ ἄλλ’ ἐρᾷς λαβεῖν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>εἴ μοί τι τόξων τῶνδ’ ἀπημελημένον</l>
 					<l>παρερρύηκεν, ὡς λίπω μή τῳ λαβεῖν.</l>
@@ -1323,7 +1323,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἦ ταῦτα γὰρ τὰ κλεινὰ τόξ’ ἃ νῦν ἔχεις;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="655">ταῦτ’, οὐ γὰρ ἄλλ’ ἔστ’, ἀλλ’ ἃ βαστάζω χεροῖν.</l>
 				</sp>
@@ -1332,7 +1332,7 @@ antilabe in all files
 					<l>ἆρ’ ἔστιν ὥστε κἀγγύθεν θέαν λαβεῖν</l>
 					<l>καὶ βαστάσαι με προσκύσαι θ’ ὥσπερ θεόν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>σοί γ’, ὦ τέκνον, καὶ τοῦτο κἄλλο τῶν ἐμῶν</l>
 					<l>ὁποῖον ἄν σοι ξυμφέρῃ γενήσεται.</l>
@@ -1342,7 +1342,7 @@ antilabe in all files
 					<l n="660">καὶ μὴν ἐρῶ γε, τὸν δ’ ἔρωθ’ οὕτως ἔχω·</l>
 					<l>εἴ μοι θέμις, θέλοιμ’ ἄν· εἰ δὲ μή, πάρες.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὅσιά τε φωνεῖς ἔστι τ’, ὦ τέκνον, θέμις,</l>
 					<l>ὅς γ’ ἡλίου τόδ’ εἰσορᾶν ἐμοὶ φάος</l>
@@ -1361,7 +1361,7 @@ antilabe in all files
 					<l>παντὸς γένοιτ’ ἂν κτήματος κρείσσων φίλος.</l>
 					<l part="I">χωροῖς ἂν εἴσω.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">καὶ σέ γ’ εἰσάξω· τὸ γὰρ</l>
 					<l n="675">νοσοῦν ποθεῖ σε ξυμπαραστάτην λαβεῖν.</l>
@@ -1370,7 +1370,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>λόγῳ μὲν ἐξήκουσ’, ὄπωπα δ’ οὐ μάλα,</l>
 						<l>τὸν πελάταν λέκτρων ποτὲ τῶν Διὸς</l>
@@ -1387,7 +1387,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἵν’ αὐτὸς ἦν πρόσουρος, οὐκ ἔχων βάσιν,</l>
 						<l>οὐδέ τιν’ ἐγχώρων κακογείτονα,</l>
@@ -1404,7 +1404,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>οὐ φορβὰν ἱερᾶς γᾶς σπόρον, οὐκ ἄλλων</l>
 						<l>αἴρων τῶν νεμόμεσθ’ ἀνέρες ἀλφησταί,</l>
@@ -1418,7 +1418,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νῦν δ’ ἀνδρῶν ἀγαθῶν παιδὸς ὑπαντήσας</l>
 						<l n="720">εὐδαίμων ἀνύσει καὶ μέγας ἐκ κείνων·</l>
@@ -1438,7 +1438,7 @@ antilabe in all files
 					<l n="730">ἕρπ’, εἰ θέλεις.  τί δή ποθ’ ὧδ’ ἐξ οὐδενὸς</l>
 					<l>λόγου σιωπᾷς κἀπόπληκτος ὧδ’ ἔχει;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="Y">ἀᾶ, ἀᾶ.</l>
 				</sp>
@@ -1446,7 +1446,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="I">τί δ’  ἔστιν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">οὐδὲν δεινόν· ἀλλ’ ἴθ’, ὦ τέκνον.</l>
 				</sp>
@@ -1454,7 +1454,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>μῶν ἄλγος ἴσχεις τῆς παρεστώσης νόσου;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="735">οὐ δῆτ’ ἔγωγ’, ἀλλ’ ἄρτι κουφίζειν δοκῶ.</l>
 					<l part="Y">ὦ θεοί.</l>
@@ -1463,7 +1463,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>τί τοὺς θεοὺς ὧδ’ ἀναστένων καλεῖς;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>σωτῆρας αὐτοὺς ἠπίους θ’ ἡμῖν μολεῖν.</l>
 					<l part="Y">ἀᾶ, ἀᾶ.</l>
@@ -1473,7 +1473,7 @@ antilabe in all files
 					<l n="740">τί ποτε πέπονθας; οὐκ ἐρεῖς, ἀλλ’ ὧδ’ ἔσει</l>
 					<l>σιγηλός; ἐν κακῷ δέ τῳ φαίνει κυρῶν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀπόλωλα, τέκνον, κοὐ δυνήσομαι κακὸν</l>
 					<l>κρύψαι παρ’ ὑμῖν, ἀτταταῖ· διέρχεται</l>
@@ -1490,7 +1490,7 @@ antilabe in all files
 					<l>τί δ’ ἔστιν οὕτω νεοχμὸν ἐξαίφνης, ὅτου</l>
 					<l>τοσήνδ’ ἰυγὴν καὶ στόνον σαυτοῦ ποεῖ;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">οἶσθ’, ὦ τέκνον;</l>
 				</sp>
@@ -1498,7 +1498,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="M">τί δ’ ἔστιν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="M">οἶσθ’, ὦ παῖ;</l>
 				</sp>
@@ -1507,7 +1507,7 @@ antilabe in all files
 					<l part="F">τί σοί;</l>
 					<l part="I">οὐκ οἶδα.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">πῶς οὐκ οἶσθα; παππαπαππαπαῖ.</l>
 				</sp>
@@ -1515,7 +1515,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="755">δεινόν γε τοὐπίσαγμα τοῦ νοσήματος.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>δεινὸν γὰρ οὐδὲ ῥητόν· ἀλλ’ οἴκτιρέ με.</l>
 				</sp>
@@ -1523,7 +1523,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="I">τί δῆτα δράσω;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">μή με ταρβήσας προδῷς·</l>
 					<l>ἥκει γὰρ αὕτη διὰ χρόνου πλάνοις ἴσως</l>
@@ -1535,7 +1535,7 @@ antilabe in all files
 					<l n="760">δύστηνε δῆτα διὰ πόνων πάντων φανείς.</l>
 					<l>βούλει λάβωμαι δῆτα καὶ θίγω τί σου;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>μὴ δῆτα τοῦτό γ’· ἀλλά μοι τὰ τόξ’ ἑλὼν</l>
 					<l>τάδ’, ὥσπερ ᾐτοῦ μ’ ἀρτίως, ἕως ἀνῇ</l>
@@ -1554,7 +1554,7 @@ antilabe in all files
 					<l>θάρσει προνοίας οὕνεκ’· οὐ δοθήσεται</l>
 					<l n="775">πλὴν σοί τε κἀμοί·  ξὺν τύχῃ δὲ πρόσφερε.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἰδοὺ δέχου, παῖ· τὸν φθόνον δὲ πρόσκυσον</l>
 					<l>μή σοι γενέσθαι πολύπον’ αὐτὰ μηδ’ ὅπως</l>
@@ -1567,7 +1567,7 @@ antilabe in all files
 					<l>θεὸς δικαιοῖ χὠ στόλος πορσύνεται.</l>
 					<milestone ed="p" n="782" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀλλ’ οὖν δέδοικα μὴ ἀτέλεστ’ εὔχῃ, τέκνον.</l>
 					<l>στάζει γὰρ αὖ μοι φοίνιον τόδ’ ἐκ βυθοῦ</l>
@@ -1599,7 +1599,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀλγῶ πάλαι δὴ τἀπὶ σοὶ στένων κακά.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀλλ’, ὦ τέκνον, καὶ θάρσος ἴσχ’· ὡς ἥδε μοι</l>
 					<l>ὀξεῖα φοιτᾷ καὶ ταχεῖ’ ἀπέρχεται.</l>
@@ -1609,7 +1609,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="810" part="I">θάρσει, μενοῦμεν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="M">ἦ μενεῖς;</l>
 				</sp>
@@ -1617,7 +1617,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="F">σαφῶς φρόνει.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὐ μήν σ’ ἔνορκόν γ’ ἀξιῶ θέσθαι, τέκνον.</l>
 				</sp>
@@ -1625,7 +1625,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ὡς οὐ θέμις γ’ ἐμοὔστι σοῦ μολεῖν ἄτερ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">ἔμβαλλε χειρὸς πίστιν.</l>
 				</sp>
@@ -1633,7 +1633,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="F">ἐμβάλλω μενεῖν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">ἐκεῖσε νῦν μ’, ἐκεῖσε</l>
 				</sp>
@@ -1641,7 +1641,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="M">ποῖ λέγεις;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">ἄνω</l>
 				</sp>
@@ -1649,7 +1649,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="815">τί παραφρονεῖς αὖ; τί τὸν ἄνω λεύσσεις κύκλον;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">μέθες μέθες με.</l>
 				</sp>
@@ -1657,7 +1657,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="M">ποῖ μεθῶ;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">μέθες ποτέ.</l>
 				</sp>
@@ -1665,7 +1665,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="I">οὔ φημ’ ἐάσειν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">ἀπό μ’ ὀλεῖς, ἢν προσθίγῃς.</l>
 				</sp>
@@ -1673,7 +1673,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>καὶ δὴ μεθίημ’, εἴ τι  δὴ πλέον φρονεῖς.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ γαῖα, δέξαι θανάσιμόν μ’ ὅπως ἔχω</l>
 					<l n="820">τὸ γὰρ κακὸν τόδ’ οὐκέτ’ ὀρθοῦσθαί μ’ ἐᾷ.</l>
@@ -1691,7 +1691,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>Ὕπν’ ὀδύνας ἀδαής, Ὕπνε δ’ ἀλγέων,</l>
 						<l>εὐαὲς  ἡμῖν ἔλθοις,</l>
@@ -1719,7 +1719,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἀλλά, τέκνον, τάδε μὲν θεὸς ὄψεται·</l>
 						<l>ὧν δ’ ἂν ἀμείβῃ μ’ αὖθις,</l>
@@ -1737,7 +1737,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="855">οὖρός τοι, τέκνον, οὖρος·</l>
 						<l>ἁνὴρ δ’ ἀνόμματος οὐδ’ ἔχων</l>
@@ -1759,7 +1759,7 @@ antilabe in all files
 					<l n="865">σιγᾶν κελεύω μηδ’ ἀφεστάναι φρενῶν·</l>
 					<l>κινεῖ γὰρ ἁνὴρ ὄμμα κἀνάγει κάρα.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ φέγγος ὕπνου διάδοχον τό τ’ ἐλπίδων</l>
 					<l>ἄπιστον οἰκούρημα τῶνδε τῶν ξένων.</l>
@@ -1787,7 +1787,7 @@ antilabe in all files
 					<l>οἴσουσί σ’ οἵδε· τοῦ πόνου γὰρ οὐκ ὄκνος,</l>
 					<l>ἐπείπερ οὕτω σοί τ’ ἔδοξ’ ἐμοί τε δρᾶν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>αἰνῶ τάδ’, ὦ παῖ, καί μ’ ἔπαιρ’, ὥσπερ νοεῖς·</l>
 					<l n="890">τούτους δ’ ἔασον, μὴ βαρυνθῶσιν κακῇ</l>
@@ -1799,7 +1799,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἔσται τάδ’· ἀλλ’ ἵστω τε καὐτὸς ἀντέχου.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>θάρσει· τό τοι σύνηθες ὀρθώσει μ’ ἔθος.</l>
 				</sp>
@@ -1807,7 +1807,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="895">παπαῖ· τί δῆτ’ ἂν δρῷμ’ ἐγὼ τοὐνθένδε γε;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>τί δ’ ἔστιν, ὦ παῖ; ποῖ ποτ’ ἐξέβης λόγῳ;</l>
 				</sp>
@@ -1815,7 +1815,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὐκ οἶδ’ ὅποι χρὴ τἄπορον τρέπειν ἔπος.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀπορεῖς δὲ τοῦ σύ; μὴ λέγ’, ὦ τέκνον, τάδε.</l>
 				</sp>
@@ -1823,7 +1823,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀλλ’ ἐνθάδ’ ἤδη τοῦδε τοῦ πάθους κυρῶ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="900">οὐ δή σε δυσχέρεια τοῦ νοσήματος</l>
 					<l>ἔπεισεν ὥστε μή μ’ ἄγειν ναύτην ἔτι;</l>
@@ -1833,7 +1833,7 @@ antilabe in all files
 					<l>ἅπαντα δυσχέρεια, τὴν αὑτοῦ φύσιν</l>
 					<l>ὅταν λιπών τις δρᾷ τὰ μὴ προσεικότα.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀλλ’ οὐδὲν ἔξω τοῦ φυτεύσαντος σύ γε</l>
 					<l n="905">δρᾷς οὐδὲ φωνεῖς, ἐσθλὸν ἄνδρ’ ἐπωφελῶν.</l>
@@ -1842,7 +1842,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>αἰσχρὸς φανοῦμαι· τοῦτ’ ἀνιῶμαι πάλαι.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὔκουν ἐν οἷς γε δρᾷς· ἐν οἷς δ’ αὐδᾷς ὀκνῶ.</l>
 				</sp>
@@ -1851,7 +1851,7 @@ antilabe in all files
 					<l>ὦ Ζεῦ, τί δράσω; δεύτερον ληφθῶ κακός,</l>
 					<l>κρύπτων θ’ ἃ μὴ δεῖ καὶ λέγων αἴσχιστ’ ἐπῶν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="910">ἁνὴρ ὅδ’, εἰ μὴ ’γὼ κακὸς γνώμων ἔφυν,</l>
 					<l>προδούς μ’ ἔοικε κἀκλιπὼν τὸν πλοῦν στελεῖν.</l>
@@ -1861,7 +1861,7 @@ antilabe in all files
 					<l>λιπὼν μὲν οὐκ ἔγωγε· λυπηρῶς δὲ μὴ</l>
 					<l>πέμπω σε μᾶλλον, τοῦτ’ ἀνιῶμαι πάλαι.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>τί ποτε λέγεις, ὦ τέκνον; ὡς οὐ μανθάνω.</l>
 				</sp>
@@ -1870,7 +1870,7 @@ antilabe in all files
 					<l n="915">οὐδέν σε κρύψω· δεῖ γὰρ ἐς Τροίαν σε πλεῖν</l>
 					<l>πρὸς τοὺς Ἀχαιοὺς καὶ τὸν Ἀτρειδῶν στόλον.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">οἴμοι, τί εἶπας;</l>
 				</sp>
@@ -1878,7 +1878,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="F">μὴ στέναζε, πρὶν μάθῃς.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ποῖον μάθημα; τί με νοεῖς δρᾶσαί ποτε;</l>
 				</sp>
@@ -1887,7 +1887,7 @@ antilabe in all files
 					<l>σῶσαι κακοῦ μὲν πρῶτα τοῦδ’, ἔπειτα δὲ</l>
 					<l n="920">ξὺν σοὶ τὰ Τροίας πεδία πορθῆσαι μολών.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">καὶ ταῦτ’ ἀληθῆ δρᾶν νοεῖς;</l>
 				</sp>
@@ -1896,7 +1896,7 @@ antilabe in all files
 					<l part="F">πολλὴ κρατεῖ</l>
 					<l>τούτων ἀνάγκη, καὶ σὺ μὴ θυμοῦ κλύων.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀπόλωλα τλήμων, προδέδομαι.  τί μ’, ὦ ξένε,</l>
 					<l>δέδρακας; ἀπόδος ὡς τάχος τὰ τόξα μοι.</l>
@@ -1907,7 +1907,7 @@ antilabe in all files
 					<l>τό τ’ ἔνδικόν με καὶ τὸ συμφέρον ποεῖ.</l>
 					<milestone ed="p" n="927" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ πῦρ σὺ καὶ πᾶν δεῖμα καὶ πανουργίας</l>
 					<l>δεινῆς τέχνημ’ ἔχθιστον, οἷά μ’ εἰργάσω,</l>
@@ -1947,7 +1947,7 @@ antilabe in all files
 					<l>γνώμην μετοίσεις· εἰ δὲ μή, θάνοις κακῶς.</l>
 					<milestone ed="p" n="963" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δρῶμεν; ἐν σοὶ καὶ τὸ πλεῖν ἡμᾶς, ἄναξ,</l>
 					<l>ἤδη ’στὶ καὶ τοῖς τοῦδε προσχωρεῖν λόγοις.</l>
@@ -1957,7 +1957,7 @@ antilabe in all files
 					<l n="965">ἐμοὶ μὲν οἶκτος δεινὸς ἐμπέπτωκέ τις</l>
 					<l>τοῦδ’ ἀνδρὸς οὐ νῦν πρῶτον, ἀλλὰ καὶ πάλαι.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἐλέησον, ὦ παῖ, πρὸς θεῶν, καὶ μὴ παρῇς</l>
 					<l>σαυτοῦ βροτοῖς ὄνειδος, ἐκκλέψας ἐμέ.</l>
@@ -1967,7 +1967,7 @@ antilabe in all files
 					<l>οἴμοι, τί δράσω; μή ποτ’ ὤφελον λιπεῖν</l>
 					<l n="970">τὴν Σκῦρον· οὕτω τοῖς παροῦσιν ἄχθομαι.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὐκ εἶ κακὸς σύ, πρὸς κακῶν δ’ ἀνδρῶν μαθὼν</l>
 					<l>ἔοικας ἥκειν αἰσχρά· νῦν δ’ ἄλλοισι δοὺς</l>
@@ -1977,105 +1977,105 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="I">τί δρῶμεν, ἄνδρες;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="F">ὦ κάκιστ’ ἀνδρῶν, τί δρᾷς;</l>
 					<l n="975">οὐκ εἶ μεθεὶς τὰ τόξα ταῦτ’ ἐμοὶ πάλιν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οἴμοι, τίς ἁνήρ; ἆρ’ Ὀδυσσέως κλύω;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>Ὀδυσσέως, σάφ’ ἴσθ’, ἐμοῦ γ’, ὃν εἰσορᾷς.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οἴμοι· πέπραμαι κἀπόλωλ’· ὅδ’ ἦν ἄρα</l>
 					<l>ὁ ξυλλαβών με κἀπονοσφίσας ὅπλων.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="980">ἐγώ, σάφ’ ἴσθ’, οὐκ ἄλλος· ὁμολογῶ τάδε.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">ἀπόδος, ἄφες μοι, παῖ, τὰ τόξα.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="F">τοῦτο μέν,</l>
 					<l>οὐδ’ ἢν θέλῃ, δράσει ποτ’· ἀλλὰ καὶ σὲ δεῖ</l>
 					<l>στείχειν ἅμ’ αὐτοῖς, ἢ βίᾳ στελοῦσί σε.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἔμ’, ὦ κακῶν κάκιστε καὶ τολμήσατε,</l>
 					<l n="985" part="I">οἵδ’ ἐκ βίας ἄξουσιν;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="F">ἢν μὴ ἕρπῃς ἑκών.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ Λημνία χθὼν καὶ τὸ παγκρατὲς σέλας</l>
 					<l>Ἡφαιστότευκτον, ταῦτα δῆτ’ ἀνασχετά,</l>
 					<l>εἴ μ’ οὗτος ἐκ τῶν σῶν ἀπάξεται βίᾳ;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>Ζεύς ἐσθ’, ἵν’ εἰδῇς, Ζεύς, ὁ τῆσδε γῆς κρατῶν,</l>
 					<l n="990">Ζεύς, ᾧ δέδοκται ταῦθ’· ὑπηρετῶ δ’ ἐγώ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ μῖσος, οἷα κἀξανευρίσκεις λέγειν·</l>
 					<l>θεοὺς προτείνων τοὺς θεοὺς ψευδεῖς τίθης.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὔκ, ἀλλ’ ἀληθεῖς· ἡ δ’ ὁδὸς πορευτέα.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="I">οὔ φημ’.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="F">ἐγὼ δέ φημι.  πειστέον τάδε.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="995">οἴμοι τάλας.  ἡμᾶς μὲν ὡς δούλους σαφῶς</l>
 					<l>πατὴρ ἄρ’ ἐξέφυσεν οὐδ’ ἐλευθέρους.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὔκ, ἀλλ’ ὁμοίους τοῖς ἀρίστοισιν, μεθ’ ὧν</l>
 					<l>Τροίαν σ’ ἑλεῖν δεῖ καὶ κατασκάψαι βίᾳ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὐδέποτέ γ’· οὐδ’ ἢν χρῇ με πᾶν παθεῖν κακόν,</l>
 					<l n="1000">ἕως ἂν ᾖ μοι γῆς τόδ’ αἰπεινὸν βάθρον.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="I">τί δ’ ἐργασείεις;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">κρᾶτ’ ἐμὸν τόδ’ αὐτίκα</l>
 					<l>πέτρᾳ πέτρας ἄνωθεν αἱμάξω πεσών.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ξυλλάβετον αὐτόν· μὴ ’πὶ τῷδ’ ἔστω τάδε.</l>
 					<milestone ed="p" n="1004" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ χεῖρες, οἷα πάσχετ’ ἐν χρείᾳ φίλης</l>
 					<l n="1005">νευρᾶς, ὑπ’ ἀνδρὸς τοῦδε συνθηρώμεναι.</l>
@@ -2121,12 +2121,12 @@ antilabe in all files
 					<l>τούτους, δοκοῖμ’ ἂν τῆς νόσου πεφευγέναι.</l>
 					<milestone ed="p" n="1045" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="1045">βαρύς τε καὶ βαρεῖαν ὁ ξένος φάτιν</l>
 					<l>τήνδ’ εἶπ’, Ὀδυσσεῦ, κοὐχ ὑπείκουσαν κακοῖς.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>πόλλ’ ἂν λέγειν ἔχοιμι πρὸς τὰ τοῦδ’ ἔπη,</l>
 					<l>εἴ μοι παρείκοι· νῦν δ’ ἑνὸς κρατῶ λόγου.</l>
@@ -2145,31 +2145,31 @@ antilabe in all files
 					<l>ἡμεῖς δ’ ἴωμεν, καὶ τάχ’ ἂν τὸ σὸν γέρας</l>
 					<l>τιμὴν ἐμοὶ νείμειεν, ἣν σὲ χρῆν ἔχειν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οἴμοι· τί δράσω δύσμορος; σὺ τοῖς ἐμοῖς</l>
 					<l>ὅπλοισι κοσμηθεὶς ἐν Ἀργείοις φανεῖ;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1065">μή μ’ ἀντιφώνει μηδέν, ὡς στείχοντα δή.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ σπέρμ’ Ἀχιλλέως, οὐδὲ σοῦ φωνῆς ἔτι</l>
 					<l>γενήσομαι προσφθεγκτός, ἀλλ’ οὕτως ἄπει;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>χώρει σύ· μὴ πρόσλευσσε, γενναῖός περ ὤν,</l>
 					<l>ἡμῶν ὅπως μὴ τὴν τύχην διαφθερεῖς.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1070">ἦ καὶ πρὸς ὑμῶν ὧδ’ ἔρημος, ὦ ξένοι,</l>
 					<l>λειφθήσομαι δὴ κοὐκ ἐποικτερεῖτέ με;</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὅδ’ ἐστὶν ἡμῶν ναυκράτωρ ὁ παῖς· ὅσ’ ἂν</l>
 					<l>οὗτος λέγῃ σοι, ταῦτά σοι χἠμεῖς φαμέν.</l>
@@ -2188,7 +2188,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>ὦ κοίλας πέτρας γύαλον</l>
 						<l>θερμὸν καὶ παγετῶδες, ὥς σ’ οὐκ ἔμελλον ἄρ’, ὦ τάλας,</l>
@@ -2205,7 +2205,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1095">σύ τοι σύ τοι κατηξίωσας,</l>
 						<l>ὦ βαρύποτμε, κοὐκ</l>
@@ -2216,7 +2216,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>ὦ τλάμων τλάμων ἄρ’ ἐγὼ</l>
 						<l>καὶ μόχθῳ λωβατός, ὃς ἤδη μετ’ οὐδενὸς ὕστερον</l>
@@ -2233,7 +2233,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πότμος, πότμος σε δαιμόνων τάδ’,</l>
 						<l>οὐδὲ σέ γε δόλος,</l>
@@ -2244,7 +2244,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>οἴμοι μοι, καί που πολιᾶς</l>
 						<l>πόντου θινὸς ἐφήμενος</l>
@@ -2264,7 +2264,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1140">ἀνδρός τοι τὰ μὲν ἔνδικ’ αἰὲν  εἰπεῖν,</l>
 						<l>εἰπόντος δὲ μὴ φθονερὰν</l>
@@ -2276,7 +2276,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>ὦ πταναὶ θῆραι χαροπῶν τ’</l>
 						<l>ἔθνη θηρῶν, οὓς ὅδ’ ἔχει</l>
@@ -2296,7 +2296,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πρὸς θεῶν, εἴ τι σέβει ξένον, πέλασσον,</l>
 						<l>εὐνοίᾳ πάσᾳ πελάταν·</l>
@@ -2308,7 +2308,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l n="1170">πάλιν πάλιν παλαιὸν ἄλγημ’ ὑπέμνασας, ὦ</l>
 						<l>λῷστε τῶν πρὶν ἐντόπων.</l>
@@ -2316,32 +2316,32 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί τοῦτ’ ἔλεξας;</l>
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>εἰ σὺ τὰν ἐμοὶ στυγερὰν</l>
 						<l n="1175">Τρῳάδα γᾶν μ’ ἤλπισας ἄξειν.</l>
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τόδε γὰρ νοῶ κράτιστον.</l>
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>ἀπό νύν με λείπετ’ ἤδη.</l>
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>φίλα μοι, φίλα ταῦτα παρήγγειλας ἑκόντι τε πράσσειν.</l>
 						<l>ἴωμεν ἴωμεν</l>
@@ -2349,24 +2349,24 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="I">μή, πρὸς ἀραίου Διός, ἔλθῃς, ἱκετεύω.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">μετρίαζ’.</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>ὦ ξένοι,</l>
 						<l n="1185" part="I">μείνατε, πρὸς θεῶν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">τί θροεῖς;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>αἰαῖ αἰαῖ, δαίμων δαίμων·</l>
 						<l>ἀπόλωλ’ ὁ τάλας·</l>
@@ -2374,22 +2374,22 @@ antilabe in all files
 						<l>τεύξω τῷ μετόπιν τάλας;</l>
 						<l n="1190">ὦ ξένοι, ἔλθετ’ ἐπήλυδες αὖθις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τί ῥέξοντες ἀλλοκότῳ</l>
 						<l>γνώμᾳ τῶν πάρος, ὧν προύφαινες;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>οὔτοι νεμεσητόν,</l>
 						<l>ἀλύοντα χειμερίῳ</l>
 						<l n="1195">λύπᾳ καὶ παρὰ νοῦν θροεῖν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>βᾶθί νυν, ὦ τάλαν, ὥς σε κελεύομεν.</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>οὐδέποτ’ οὐδέποτ’, ἴσθι τόδ’ ἔμπεδον,</l>
 						<l>οὐδ’ εἰ πυρφόρος ἀστεροπητὴς</l>
@@ -2398,37 +2398,37 @@ antilabe in all files
 						<l>πάντες ὅσοι τόδ’ ἔτλασαν ἐμοῦ ποδὸς ἄρθρον ἀπῶσαι.</l>
 						<l>ἀλλ’, ὦ ξένοι, ἕν γέ μοι εὖχος ὀρέξατε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">ποῖον ἐρεῖς τόδ’ ἔπος;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">ξίφος, εἴ ποθεν,</l>
 						<l n="1205">ἢ γένυν ἢ βελέων τι προπέμψατε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὡς τίνα δὴ ῥέξῃς παλάμαν ποτέ;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>χρῶτ’  ἀπὸ πάντα καὶ ἄρθρα τέμω χερί·</l>
 						<l>φονᾷ φονᾷ νόος ἤδη.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">τί ποτε;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">πατέρα ματεύων.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="1210" part="I">ποῖ γᾶς;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">ἐς Ἅιδου·</l>
 						<l>οὐ γάρ ἐστ’ ἐν φάει γ’ ἔτι.</l>
@@ -2442,14 +2442,14 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἐγὼ μὲν ἤδη καὶ πάλαι νεὼς ὁμοῦ</l>
 					<l>στείχων ἂν ἦ σοι τῆς ἐμῆς, εἰ μὴ πέλας</l>
 					<l>Ὀδυσσέα στείχοντα τόν τ’ Ἀχιλλέως</l>
 					<l n="1220">γόνον πρὸς ἡμᾶς δεῦρ’ ἰόντ’ ἐλεύσσομεν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὐκ ἂν φράσειας ἥντιν’ αὖ παλίντροπος</l>
 					<l>κέλευθον ἕρπεις ὧδε σὺν σπουδῇ ταχύς;</l>
@@ -2458,7 +2458,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>λύσων ὅσ’ ἐξήμαρτον ἐν τῷ πρὶν χρόνῳ.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>δεινόν γε φωνεῖς· ἡ δ’ ἁμαρτία τίς ἦν;</l>
 				</sp>
@@ -2466,7 +2466,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="1225">ἣν σοὶ πιθόμενος τῷ τε σύμπαντι στρατῷ</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἔπραξας ἔργον ποῖον ὧν οὔ σοι πρέπον;</l>
 				</sp>
@@ -2474,7 +2474,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀπάταισιν αἰσχραῖς ἄνδρα καὶ δόλοις ἑλών.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τὸν ποῖον; ὤμοι· μῶν τι βουλεύει νέον;</l>
 				</sp>
@@ -2482,7 +2482,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="1230">νέον μὲν οὐδέν, τῷ δὲ Ποίαντος τόκῳ,</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τί χρῆμα δράσεις; ὥς μ’ ὑπῆλθέ τις φόβος.</l>
 				</sp>
@@ -2490,7 +2490,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>παρ’ οὗπερ ἔλαβον τάδε τὰ τόξ’, αὖθις πάλιν</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ὦ Ζεῦ, τί λέξεις; οὔ τί που δοῦναι νοεῖς;</l>
 				</sp>
@@ -2498,7 +2498,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>αἰσχρῶς γὰρ αὐτὰ κοὐ δίκῃ λαβὼν ἔχω.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1235">πρὸς θεῶν, πότερα δὴ κερτομῶν λέγεις τάδε;</l>
 				</sp>
@@ -2506,7 +2506,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>εἰ κερτόμησίς ἐστι τἀληθῆ λέγειν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>τί φής, Ἀχιλλέως παῖ; τίν’ εἴρηκας λόγον;</l>
 				</sp>
@@ -2514,7 +2514,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>δὶς ταὐτὰ βούλει καὶ τρὶς ἀναπολεῖν μ’ ἔπη;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἀρχὴν κλύειν ἂν οὐδ’ ἅπαξ ἐβουλόμην.</l>
 				</sp>
@@ -2522,7 +2522,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="1240">εὖ νῦν ἐπίστω πάντ’ ἀκηκοὼς λόγον.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἔστιν τις, ἔστιν ὅς σε κωλύσει τὸ δρᾶν.</l>
 				</sp>
@@ -2530,7 +2530,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>τί φής; τίς ἔσται μ’ οὑπικωλύσων τάδε;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ξύμπας Ἀχαιῶν λαός, ἐν δὲ τοῖς ἐγώ.</l>
 				</sp>
@@ -2538,7 +2538,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>σοφὸς πεφυκὼς οὐδὲν ἐξαυδᾷς σοφόν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1245">σὺ δ’ οὔτε φωνεῖς οὔτε δρασείεις σοφά.</l>
 				</sp>
@@ -2546,7 +2546,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀλλ’ εἰ δίκαια, τῶν σοφῶν κρείσσω τάδε.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>καὶ πῶς δίκαιον, ἅ γ’ ἔλαβες βουλαῖς ἐμαῖς,</l>
 					<l part="I">πάλιν μεθεῖναι ταῦτα;</l>
@@ -2556,7 +2556,7 @@ antilabe in all files
 					<l part="F">τὴν ἁμαρτίαν</l>
 					<l>αἰσχρὰν ἁμαρτὼν ἀναλαβεῖν πειράσομαι.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l n="1250">στρατὸν δ’ Ἀχαιῶν οὐ φοβεῖ, πράσσων τάδε;</l>
 				</sp>
@@ -2564,7 +2564,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ξὺν τῷ δικαίῳ τὸν σὸν οὐ ταρβῶ φόβον.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>[ξὺν τῷ δικαίῳ χεὶρ ἐμή σ’ ἀναγκάσει.]</l>
 				</sp>
@@ -2572,7 +2572,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀλλ’ οὐδέ τοι σῇ χειρὶ πείθομαι τὸ δρᾶν.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>οὔ τἄρα Τρωσίν, ἀλλὰ σοὶ μαχούμεθα.</l>
 				</sp>
@@ -2580,7 +2580,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="1255" part="I">ἴτω  τὸ μέλλον.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="F">χεῖρα δεξιὰν ὁρᾷς</l>
 					<l part="I">κώπης ἐπιψαύουσαν;</l>
@@ -2591,7 +2591,7 @@ antilabe in all files
 					<l>ταὐτὸν τόδ’ ὄψει δρῶντα κοὐ μέλλοντ’ ἔτι.</l>
 					<milestone ed="p" n="1258" unit="card"/>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>καίτοι σ’ ἐάσω· τῷ δὲ σύμπαντι στρατῷ</l>
 					<l>λέξω τάδ’ ἐλθών, ὅς σε τιμωρήσεται.</l>
@@ -2603,7 +2603,7 @@ antilabe in all files
 					<l>σὺ δ’, ὦ Ποίαντος παῖ, Φιλοκτήτην λέγω,</l>
 					<l>ἔξελθ’, ἀμείψας τάσδε πετρήρεις στέγας.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>τίς αὖ παρ’ ἄντροις θόρυβος ἵσταται βοῆς;</l>
 					<l n="1265">τί μ’ ἐκκαλεῖσθε; τοῦ κεχρημένοι, ξένοι;</l>
@@ -2614,7 +2614,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>θάρσει· λόγους δ’ ἄκουσον οὓς ἥκω φέρων.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>δέδοικ’ ἔγωγε· καὶ τὰ πρὶν γὰρ ἐκ λόγων</l>
 					<l n="1270">καλῶν κακῶς ἔπραξα, σοῖς πεισθεὶς λόγοις.</l>
@@ -2623,7 +2623,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὔκουν ἔνεστι καὶ μεταγνῶναι πάλιν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>τοιοῦτος ἦσθα τοῖς λόγοισι χὤτε μου</l>
 					<l>τὰ τόξ’ ἔκλεπτες, πιστός, ἀτηρὸς λάθρᾳ.</l>
@@ -2634,7 +2634,7 @@ antilabe in all files
 					<l n="1275">πότερα δέδοκταί σοι μένοντι καρτερεῖν</l>
 					<l part="I">ἢ πλεῖν μεθ’ ἡμῶν;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">παῦε, μὴ λέξῃς πέρα·</l>
 					<l>μάτην γὰρ ἃν εἴπῃς γε πάντ’ εἰρήσεται.</l>
@@ -2643,7 +2643,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="I">οὕτω δέδοκται;</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">καὶ πέρα γ’ ἴσθ’ ἢ λέγω.</l>
 				</sp>
@@ -2653,7 +2653,7 @@ antilabe in all files
 					<l>ἐμοῖσιν· εἰ δὲ μή τι πρὸς καιρὸν λέγων</l>
 					<l part="I">κυρῶ, πέπαυμαι.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1280" part="F">πάντα γὰρ φράσεις μάτην.</l>
 					<l>οὐ γάρ ποτ’ εὔνουν τὴν ἐμὴν κτήσει φρένα,</l>
@@ -2669,7 +2669,7 @@ antilabe in all files
 					<l>δέχου δὲ χειρὸς ἐξ ἐμῆς βέλη τάδε.</l>
 					<milestone ed="p" n="1288" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>πῶς εἶπας; ἆρα δεύτερον δολούμεθα;</l>
 				</sp>
@@ -2677,7 +2677,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀπώμοσ’ ἁγνὸν Ζηνὸς ὑψίστου σέβας.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1290">ὦ φίλτατ’ εἰπών, εἰ λέγεις ἐτήτυμα.</l>
 				</sp>
@@ -2686,23 +2686,23 @@ antilabe in all files
 					<l>τοὔργον παρέσται φανερόν· ἀλλὰ δεξιὰν</l>
 					<l>πρότεινε χεῖρα, καὶ κράτει τῶν σῶν ὅπλων.</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l>ἐγὼ δ’ ἀπαυδῶ γ’, ᾧ θεοὶ ξυνίστορες,</l>
 					<l>ὑπέρ τ’ Ἀτρειδῶν τοῦ τε σύμπαντος στρατοῦ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1295">τέκνον, τίνος φώνημα, μῶν Ὀδυσσέως,</l>
 					<l part="I">ἐπῃσθόμην;</l>
 				</sp>
-				<sp who="#odysseys">
+				<sp who="#odysseus">
 					<speaker>Ὀδυσσεύς</speaker>
 					<l part="F">σάφ’ ἴσθι· καὶ πέλας γ’ ὁρᾷς,</l>
 					<l>ὅς σ’ ἐς τὰ Τροίας πεδί’ ἀποστελῶ βίᾳ,</l>
 					<l>ἐάν τ’ Ἀχιλλέως παῖς ἐάν τε μὴ θέλῃ·</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1300">ἀλλ’ οὔ τι χαίρων, ἢν τόδ’ ὀρθωθῇ βέλος.</l>
 				</sp>
@@ -2710,7 +2710,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἆ, μηδαμῶς, μή, πρὸς θεῶν, μεθῇς βέλος.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>μέθες με, πρὸς θεῶν, χεῖρα, φίλτατον τέκνον.</l>
 				</sp>
@@ -2718,7 +2718,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l part="I">οὐκ ἂν μεθείην.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l part="F">φεῦ· τί μ’ ἄνδρα πολέμιον</l>
 					<l>ἐχθρόν τ’ ἀφείλου μὴ κτανεῖν τόξοις ἐμοῖς;</l>
@@ -2727,7 +2727,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="1305">ἀλλ’ οὔτ’ ἐμοὶ τοῦτ’ ἐστὶν οὔτε σοὶ καλόν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἀλλ’ οὖν τοσοῦτόν γ’ ἴσθι, τοὺς πρώτους στρατοῦ,</l>
 					<l>τοὺς τῶν Ἀχαιῶν ψευδοκήρυκας, κακοὺς</l>
@@ -2738,7 +2738,7 @@ antilabe in all files
 					<l>εἶεν· τὰ μὲν δὴ τόξ’ ἔχεις, κοὐκ ἔσθ’ ὅτου</l>
 					<l>ὀργὴν ἔχοις ἂν οὐδὲ μέμψιν εἰς ἐμέ.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1310">ξύμφημι· τὴν φύσιν δ’ ἔδειξας, ὦ τέκνον,</l>
 					<l>ἐξ ἧς ἔβλαστες, οὐχὶ Σισύφου πατρός,</l>
@@ -2784,7 +2784,7 @@ antilabe in all files
 					<l>Τροίαν ἑλόντα κλέος ὑπέρτατον λαβεῖν.</l>
 					<milestone ed="p" n="1348" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὦ στυγνὸς αἰών, τί με, τί δῆτ’ ἔχεις ἄνω</l>
 					<l>βλέποντα κοὐκ ἀφῆκας εἰς Ἅιδου μολεῖν;</l>
@@ -2818,7 +2818,7 @@ antilabe in all files
 					<l>θεοῖς τε πιστεύσαντα τοῖς τ’ ἐμοῖς λόγοις</l>
 					<l n="1375">φίλου μετ’ ἀνδρὸς τοῦδε τῆσδ’ ἐκπλεῖν χθονός.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἦ πρὸς τὰ Τροίας πεδία καὶ τὸν Ἀτρέως</l>
 					<l>ἔχθιστον υἱὸν τῷδε δυστήνῳ ποδί;</l>
@@ -2829,7 +2829,7 @@ antilabe in all files
 					<l>παύσοντας ἄλγους κἀποσώσοντας νόσου.</l>
 					<milestone ed="p" n="1380" unit="card"/>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1380">ὦ δεινὸν αἶνον αἰνέσας, τί φής ποτε;</l>
 				</sp>
@@ -2837,7 +2837,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἃ σοί τε κἀμοὶ λῷσθ’ ὁρῶ τελούμενα.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>καὶ ταῦτα λέξας οὐ καταισχύνει θεούς;</l>
 				</sp>
@@ -2845,7 +2845,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>πῶς γάρ τις αἰσχύνοιτ’ ἂν ὠφελῶν φίλους·</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>λέγεις δ’ Ἀτρείδαις ὄφελος ἢ ’π’ ἐμοὶ τόδε;</l>
 				</sp>
@@ -2853,7 +2853,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l n="1385">σοί που, φίλος γ’ ὤν, χὠ λόγος τοιόσδε μου.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>πῶς, ὅς γε τοῖς ἐχθροῖσί μ’ ἐκδοῦναι θέλεις;</l>
 				</sp>
@@ -2861,7 +2861,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ὦ τᾶν, διδάσκου μὴ θρασύνεσθαι κακοῖς.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ὀλεῖς με, γιγνώσκω σε, τοῖσδε τοῖς λόγοις.</l>
 				</sp>
@@ -2869,7 +2869,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>οὔκουν ἔγωγε· φημὶ δ’ οὔ σε μανθάνειν.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l n="1390">ἐγὼ οὐκ Ἀτρείδας ἐκβαλόντας οἶδά με;</l>
 				</sp>
@@ -2877,7 +2877,7 @@ antilabe in all files
 					<speaker>Νεοπτόλεμος</speaker>
 					<l>ἀλλ’ ἐκβαλόντες εἰ πάλιν σώσουσ’ ὅρα.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>οὐδέποθ’ ἑκόντα γ’ ὥστε τὴν Τροίαν ἰδεῖν.</l>
 				</sp>
@@ -2888,7 +2888,7 @@ antilabe in all files
 					<l n="1395">ὡς ῥᾷστ’ ἐμοὶ μὲν τῶν λόγων λῆξαι, σὲ δὲ</l>
 					<l>ζῆν, ὥσπερ ἤδη ζῇς, ἄνευ σωτηρίας.</l>
 				</sp>
-				<sp who="#filoktetes">
+				<sp who="#philoktetes">
 					<speaker>Φιλοκτήτης</speaker>
 					<l>ἔα με πάσχειν ταῦθ’ ἅπερ παθεῖν με δεῖ·</l>
 					<l>ἃ δ’ ᾔνεσάς μοι δεξιᾶς ἐμῆς θιγών,</l>
@@ -2902,7 +2902,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l part="I">εἰ δοκεῖ, στείχωμεν.</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">ὦ γενναῖον εἰρηκὼς ἔπος.</l>
 					</sp>
@@ -2910,7 +2910,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l part="I">ἀντέρειδε νῦν βάσιν σήν.</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">εἰς ὅσον γ’ ἐγὼ σθένω.</l>
 					</sp>
@@ -2918,7 +2918,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l part="I">αἰτίαν δὲ πῶς Ἀχαιῶν φεύξομαι;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">μὴ φροντίσῃς.</l>
 					</sp>
@@ -2926,7 +2926,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l part="I">τί γάρ, ἐὰν πορθῶσι χώραν τὴν ἐμήν;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">ἐγὼ παρὼν</l>
 					</sp>
@@ -2934,7 +2934,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l n="1405" part="I">τίνα προσωφέλησιν ἔρξεις;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="F">βέλεσι τοῖς Ἡρακλέους</l>
 					</sp>
@@ -2942,7 +2942,7 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l part="I">πῶς λέγεις;</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l part="M">εἴρξω πελάζειν.</l>
 					</sp>
@@ -2953,7 +2953,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>μήπω γε, πρὶν ἂν τῶν ἡμετέρων</l>
 						<l>ἀίῃς μύθων, παῖ Ποίαντος·</l>
@@ -2995,7 +2995,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="anapests">
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l n="1445">ὦ φθέγμα ποθεινὸν ἐμοὶ πέμψας</l>
 						<l>χρόνιός τε φανείς,</l>
@@ -3005,13 +3005,13 @@ antilabe in all files
 						<speaker>Νεοπτόλεμος</speaker>
 						<l>κἀγὼ γνώμην ταύτῃ τίθεμαι.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>μή νυν χρόνιοι μέλλετε πράσσειν·</l>
 						<l n="1450">καιρὸς καὶ πλοῦς</l>
 						<l>ὅδ’ ἐπείγει γὰρ κατὰ πρύμνην.</l>
 					</sp>
-					<sp who="#filoktetes">
+					<sp who="#philoktetes">
 						<speaker>Φιλοκτήτης</speaker>
 						<l>φέρε νυν στείχων χώραν καλέσω.</l>
 						<l>χαῖρ’, ὦ μέλαθρον ξύμφρουρον ἐμοί,</l>
@@ -3031,7 +3031,7 @@ antilabe in all files
 						<l>γνώμη τε φίλων χὠ πανδαμάτωρ</l>
 						<l>δαίμων, ὃς ταῦτ’ ἐπέκρανεν.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>χωρῶμεν δὴ πάντες ἀολλεῖς,</l>
 						<l n="1470">νύμφαις ἁλίαισιν ἐπευξάμενοι</l>

--- a/tei/sophocles-trachiniae.xml
+++ b/tei/sophocles-trachiniae.xml
@@ -57,34 +57,34 @@
 					<person xml:id="presbys">
 						<persName>Πρέσβυς</persName>
 					</person>
-					<person xml:id="aggelos">
+					<person xml:id="angelos">
 						<persName>Ἄγγελος</persName>
 					</person>
-					<person xml:id="emixorion">
-						<persName>Ἡμιχόριον</persName>
-					</person>
-					<person xml:id="emixorion2">
-						<persName>Ἡμιχόριον 2</persName>
-					</person>
-					<person xml:id="trofos">
+					<personGrp xml:id="hemichorion">
+						<name>Ἡμιχόριον</name>
+					</personGrp>
+					<personGrp xml:id="hemichorion_1">
+						<name>Ἡμιχόριον 1</name>
+					</personGrp>
+					<personGrp xml:id="hemichorion_2">
+						<name>Ἡμιχόριον 2</name>
+					</personGrp>
+					<person xml:id="trophos">
 						<persName>Τροφός</persName>
 					</person>
-					<person xml:id="yllos">
+					<person xml:id="hyllos">
 						<persName>Ὕλλος</persName>
 					</person>
-					<person xml:id="erakles">
+					<person xml:id="herakles">
 						<persName>Ἡρακλῆς</persName>
 					</person>
 					<person xml:id="deianeira">
 						<persName>Δηιάνειρα</persName>
 					</person>
-					<person xml:id="emixorion1">
-						<persName>Ἡμιχόριον 1</persName>
-					</person>
-					<person xml:id="lixas">
+					<person xml:id="lichas">
 						<persName>Λίχας</persName>
 					</person>
-					<personGrp xml:id="xoros">
+					<personGrp xml:id="choros">
 						<name>Χορός</name>
 					</personGrp>
 				</listPerson>
@@ -261,7 +261,7 @@ antilabe in all files
 					<l>μῦθοι καλῶς πίπτουσιν· ἥδε γὰρ γυνὴ</l>
 					<l>δούλη μέν, εἴρηκεν δ’ ἐλεύθερον λόγον.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ποῖον; δίδαξον, μῆτερ, εἰ διδακτά μοι.</l>
 				</sp>
@@ -270,7 +270,7 @@ antilabe in all files
 					<l n="65">σὲ πατρὸς οὕτω δαρὸν ἐξενωμένου</l>
 					<l>τὸ μὴ πυθέσθαι ποῦ ’στιν, αἰσχύνην φέρειν.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἀλλ’ οἶδα, μύθοις εἴ τι πιστεύειν χρεών.</l>
 				</sp>
@@ -278,7 +278,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>καὶ ποῦ κλύεις νιν, τέκνον, ἱδρῦσθαι χθονός;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>τὸν μὲν παρελθόντ’ ἄροτον ἐν μήκει χρόνου</l>
 					<l n="70">Λυδῇ γυναικί φασί νιν λάτριν πονεῖν.</l>
@@ -287,7 +287,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>πᾶν τοίνυν, εἰ καὶ τοῦτ’ ἔτλη, κλύοι τις ἄν.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἀλλ’ ἐξαφεῖται τοῦδέ γ’, ὡς ἐγὼ κλύω.</l>
 				</sp>
@@ -295,7 +295,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>ποῦ δῆτα νῦν ζῶν ἢ θανὼν ἀγγέλλεται;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>Εὐβοΐδα χώραν φασίν, Εὐρύτου πόλιν,</l>
 					<l n="75">ἐπιστρατεύειν αὐτὸν ἢ μέλλειν ἔτι.</l>
@@ -305,7 +305,7 @@ antilabe in all files
 					<l>ἆρ’ οἶσθα δῆτ’, ὦ τέκνον, ὡς ἔλειπέ μοι</l>
 					<l>μαντεῖα πιστὰ τῆσδε τῆς χώρας πέρι;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>τὰ ποῖα, μῆτερ; τὸν λόγον γὰρ ἀγνοῶ.</l>
 					<milestone ed="p" n="79" unit="card"/>
@@ -320,7 +320,7 @@ antilabe in all files
 					<l>[ἢ πίπτομεν σοῦ πατρὸς ἐξολωλότος]</l>
 					<l n="85">κείνου βίον σώσαντος, ἢ οἰχόμεσθ’ ἅμα;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἀλλ’ εἶμι, μῆτερ· εἰ δὲ θεσφάτων ἐγὼ</l>
 					<l>βάξιν κατῄδη τῶνδε, κἂν πάλαι παρῆ·</l>
@@ -338,7 +338,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὃν αἰόλα νὺξ ἐναριζομένα</l>
 						<l n="95">τίκτει κατευνάζει τε, φλογιζόμενον</l>
@@ -351,7 +351,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ποθουμένᾳ γὰρ φρενὶ πυνθάνομαι</l>
 						<l>τὰν ἀμφινεικῆ Δηιάνειραν ἀεί,</l>
@@ -364,7 +364,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πολλὰ γὰρ ὥστ’ ἀκάμαντος ἢ νότου ἢ βορέα τις</l>
 						<l>κύματ’ ἂν εὐρέϊ πόντῳ βάντ’ ἐπιόντα τ’ ἴδοι,</l>
@@ -376,7 +376,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὧν ἐπιμεμφομένα σ’ αἰδοῖα  μέν, ἀντία δ’ οἴσω.</l>
 						<l n="125">φαμὶ γὰρ οὐκ ἀποτρύειν ἐλπίδα τὰν ἀγαθὰν</l>
@@ -388,7 +388,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>νὺξ βροτοῖσιν οὔτε κῆρες</l>
 						<l>οὔτε πλοῦτος, ἀλλ’ ἄφαρ</l>
@@ -443,13 +443,13 @@ antilabe in all files
 					<l>πάντων ἀρίστου φωτὸς ἐστερημένην.</l>
 				</sp>
 				<milestone ed="p" n="180" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>εὐφημίαν νῦν ἴσχ’· ἐπεὶ καταστεφῆ</l>
 					<l>στείχονθ’ ὁρῶ τιν’ ἄνδρα πρὸς χαρὰν λόγων.</l>
 					<milestone ed="p" n="180" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="180">δέσποινα Δῃάνειρα, πρῶτος ἀγγέλων</l>
 					<l>ὄκνου σε λύσω· τὸν γὰρ Ἀλκμήνης τόκον</l>
@@ -460,7 +460,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>τίν’ εἶπας, ὦ γεραιέ, τόνδε μοι λόγον;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="185">τάχ’ ἐς δόμους σοὺς τὸν πολύζηλον πόσιν</l>
 					<l>ἥξειν φανέντα σὺν κράτει νικηφόρῳ.</l>
@@ -469,7 +469,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>καὶ τοῦ τόδ’ ἀστῶν ἢ ξένων μαθὼν λέγεις;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἐν βουθερεῖ λειμῶνι πρὸς πολλοὺς θροεῖ</l>
 					<l n="190">Λίχας ὁ κῆρυξ ταῦτα· τοῦδ’ ἐγὼ κλύων</l>
@@ -480,7 +480,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>αὐτὸς δὲ πῶς ἄπεστιν, εἴπερ εὐτυχεῖ;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐκ εὐμαρείᾳ χρώμενος πολλῇ, γύναι.</l>
 					<l n="195">κύκλῳ γὰρ αὐτὸν Μηλιεὺς ἅπας λεὼς</l>
@@ -501,7 +501,7 @@ antilabe in all files
 				</sp>
 			</div1>
 			<div1 type="choral">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="205">ἀνολολυξάτω  δόμοις ἐφεστίοις</l>
 					<l>ἀλαλαγαῖς ἁ  μελλόνυμφος, ἐν δὲ</l>
@@ -531,7 +531,7 @@ antilabe in all files
 					<l>χαίρειν δὲ τὸν κήρυκα προυννέπω, χρόνῳ</l>
 					<l>πολλῷ φανέντα, χαρτὸν εἴ τι καὶ φέρεις.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἀλλ’ εὖ μὲν ἵγμεθ’, εὖ δὲ προσφωνούμεθα,</l>
 					<l n="230">γύναι, κατ’ ἔργου κτῆσιν· ἄνδρα γὰρ καλῶς</l>
@@ -542,7 +542,7 @@ antilabe in all files
 					<l>ὦ φίλτατ’ ἀνδρῶν, πρῶθ’ ἃ πρῶτα βούλομαι</l>
 					<l>δίδαξον, εἰ ζῶνθ’ Ἡρακλῆ προσδέξομαι.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἔγωγέ τοι σφ’ ἔλειπον ἰσχύοντά τε</l>
 					<l n="235">καὶ ζῶντα καὶ θάλλοντα κοὐ νόσῳ βαρύν.</l>
@@ -551,7 +551,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>ποῦ γῆς; πατρῴας εἴτε βαρβάρου; λέγε.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἀκτή τις ἔστ’ Εὐβοιίς, ἔνθ’ ὁρίζεται</l>
 					<l>βωμοὺς τέλη τ’ ἔγκαρπα Κηναίῳ Διί.</l>
@@ -560,7 +560,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>εὐκταῖα φαίνων ἢ ἀπὸ μαντείας τινός;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l n="240">εὐχαῖς ὅθ’ ᾕρει τῶνδ’ ἀνάστατον δορὶ</l>
 					<l>χώραν γυναικῶν ὧν ὁρᾷς ἐν ὄμμασιν.</l>
@@ -570,7 +570,7 @@ antilabe in all files
 					<l>αὗται δέ, πρὸς θεῶν, τοῦ ποτ’ εἰσὶ καὶ τίνες;</l>
 					<l>οἰκτραὶ γάρ, εἰ μὴ ξυμφοραὶ κλέπτουσί με.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ταύτας ἐκεῖνος Εὐρύτου πέρσας πόλιν</l>
 					<l n="245">ἐξείλεθ’ αὑτῷ κτῆμα καὶ θεοῖς κριτόν.</l>
@@ -581,7 +581,7 @@ antilabe in all files
 					<l>χρόνον βεβὼς ἦν ἡμερῶν ἀνήριθμον;</l>
 					<milestone ed="p" n="248" unit="card"/>
 				</sp>
-				<sp n="Λίχας" who="#lixas">
+				<sp n="Λίχας" who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>οὔκ, ἀλλὰ τὸν μὲν πλεῖστον ἐν Λυδοῖς χρόνον</l>
 					<l>κατείχεθ’, ὥς φησ’ αὐτός, οὐκ ἐλεύθερος,</l>
@@ -629,7 +629,7 @@ antilabe in all files
 					<l n="290">πολλοῦ καλῶς λεχθέντος ἥδιστον κλύειν.</l>
 				</sp>
 				<milestone ed="p" n="291" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἄνασσα, νῦν σοι τέρψις ἐμφανὴς κυρεῖ,</l>
 					<l>τῶν μὲν παρόντων, τὰ δὲ πεπυσμένῃ λόγῳ.</l>
@@ -659,7 +659,7 @@ antilabe in all files
 					<l>βλέπουσ’, ὅσῳπερ καὶ φρονεῖν οἶδεν μόνη.</l>
 					<milestone ed="p" n="314" unit="card"/>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>τί δ’ οἶδ’ ἐγώ, τί δ’ ἄν με καὶ κρίνοις; ἴσως</l>
 					<l n="315">γέννημα τῶν ἐκεῖθεν οὐκ ἐν ὑστάτοις.</l>
@@ -668,7 +668,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>μὴ τῶν τυράννων; Εὐρύτου σπορά τις ἦν;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>οὐκ οἶδα· καὶ γὰρ οὐδ’ ἀνιστόρουν μακράν.</l>
 				</sp>
@@ -676,7 +676,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>οὐδ’ ὄνομα πρός του τῶν ξυνεμπόρων ἔχεις;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἥκιστα·  σιγῇ τοὐμὸν ἔργον ἤνυτον.</l>
 				</sp>
@@ -685,7 +685,7 @@ antilabe in all files
 					<l n="320">εἴπ’, ὦ τάλαιν’, ἀλλ’ ἡμὶν ἐκ σαυτῆς, ἐπεὶ</l>
 					<l>καὶ ξυμφορά τοι μὴ εἰδέναι σέ γ’ ἥτις εἶ.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>οὔ τἄρα τῷ γε πρόσθεν οὐδὲν ἐξ ἴσου</l>
 					<l>χρόνῳ διήσει  γλῶσσαν, ἥτις οὐδαμὰ</l>
@@ -705,7 +705,7 @@ antilabe in all files
 					<l>σπεύδῃς, ἐγώ τε τἄνδον ἐξαρκῆ τιθῶ.</l>
 					<milestone ed="p" n="335" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="335">αὐτοῦ γε πρῶτον βαιὸν ἀμμείνασ’, ὅπως</l>
 					<l>μάθῃς ἄνευ τῶνδ’, οὕστινάς τ’ ἄγεις ἔσω,</l>
@@ -716,7 +716,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>τί δ’ ἐστί; τοῦ με τήνδ’ ἐφίστασαι βάσιν;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="340">σταθεῖσ’ ἄκουσον· καὶ γὰρ οὐδὲ τὸν πάρος</l>
 					<l>μῦθον μάτην ἤκουσας, οὐδὲ νῦν δοκῶ.</l>
@@ -726,7 +726,7 @@ antilabe in all files
 					<l>πότερον ἐκείνους δῆτα δεῦρ’ αὖθις πάλιν</l>
 					<l>καλῶμεν, ἢ ’μοὶ ταῖσδέ τ’ ἐξειπεῖν θέλεις;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>σοὶ ταῖσδέ τ’ οὐδὲν εἴργεται, τούτους δ’ ἔα.</l>
 				</sp>
@@ -734,7 +734,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l n="345">καὶ δὴ βεβᾶσι, χὠ λόγος σημαινέτω.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἁνὴρ ὅδ’ οὐδὲν ὧν ἔλεξεν ἀρτίως</l>
 					<l>φωνεῖ δίκης ἐς ὀρθόν, ἀλλ’ ἢ νῦν κακὸς</l>
@@ -746,7 +746,7 @@ antilabe in all files
 					<l n="350">ἃ μὲν γὰρ ἐξείρηκας ἀγνοία μ’ ἔχει.</l>
 					<milestone ed="p" n="351" unit="card"/>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τούτου λέγοντος τἀνδρὸς εἰσήκουσ’ ἐγώ,</l>
 					<l>πολλῶν παρόντων μαρτύρων, ὡς τῆς κόρης</l>
@@ -781,14 +781,14 @@ antilabe in all files
 					<l>λαθραῖον; ὦ δύστηνος· ἆρ’ ἀνώνυμος</l>
 					<l>πέφυκεν, ὥσπερ οὑπάγων διώμνυτο;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ἦ κάρτα λαμπρὰ καὶ κατ’ ὄνομα καὶ φύσιν,</l>
 					<l n="380">πατρὸς μὲν οὖσα γένεσιν Εὐρύτου ποτὲ</l>
 					<l>Ἰόλη ’καλεῖτο, τῆς ἐκεῖνος οὐδαμὰ</l>
 					<l>βλάστας ἐφώνει, δῆθεν οὐδὲν ἱστορῶν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὄλοιντο—μή τι πάντες οἱ κακοί, τὰ δὲ</l>
 					<l>λαθραῖ’ ὃς ἀσκεῖ μὴ πρέποντ’ αὐτῷ κακά.</l>
@@ -798,7 +798,7 @@ antilabe in all files
 					<l n="385">τί χρὴ ποεῖν, γυναῖκες; ὡς ἐγὼ λόγοις</l>
 					<l>τοῖς νῦν παροῦσιν ἐκπεπληγμένη κυρῶ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>πεύθου μολοῦσα τἀνδρός, ὡς τάχ’ ἂν σαφῆ</l>
 					<l>λέξειεν, εἴ νιν πρὸς βίαν κρίνειν θέλοις.</l>
@@ -807,7 +807,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>ἀλλ’ εἶμι· καὶ γὰρ οὐκ ἀπὸ γνώμης λέγεις.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="390">ἡμεῖς δὲ προσμένωμεν; ἢ τί χρὴ ποεῖν;</l>
 				</sp>
@@ -817,7 +817,7 @@ antilabe in all files
 					<l>ἀλλ’ αὐτόκλητος ἐκ δόμων πορεύεται.</l>
 					<milestone ed="p" n="393" unit="card"/>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>τί χρή, γύναι, μολόντα μ’ Ἡρακλεῖ λέγειν;</l>
 					<l>δίδαξον, ὡς ἕρποντος, ὡς ὁρᾷς, ἐμοῦ.</l>
@@ -827,7 +827,7 @@ antilabe in all files
 					<l n="395">ὡς ἐκ ταχείας σὺν χρόνῳ βραδεῖ μολὼν</l>
 					<l>ᾄσσεις, πρὶν ἡμᾶς κἀννεώσασθαι λόγους.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἀλλ’ εἴ τι χρῄζεις ἱστορεῖν, πάρειμ’ ἐγώ.</l>
 				</sp>
@@ -835,7 +835,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>ἦ καὶ τὸ πιστὸν τῆς ἀληθείας νέμεις;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἴστω μέγας Ζεύς, ὧν γ’ ἂν ἐξειδὼς κυρῶ.</l>
 				</sp>
@@ -843,108 +843,108 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l n="400">τίς ἡ γυνὴ δῆτ’ ἐστὶν ἣν ἥκεις ἄγων;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>Εὐβοιίς·  ὧν δ’ ἔβλαστεν οὐκ ἔχω λέγειν.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὗτος, βλέφ’ ὧδε· πρὸς τίν’ ἐννέπειν δοκεῖς;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>σὺ δ’ εἰς τί δή με τοῦτ’ ἐρωτήσας ἔχεις;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τόλμησον εἰπεῖν, εἰ φρονεῖς, ὅ σ’ ἱστορῶ.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l n="405">πρὸς τὴν κρατοῦσαν Δῃάνειραν, Οἰνέως</l>
 					<l>κόρην δάμαρτά θ’ Ἡρακλέους, εἰ μὴ κυρῶ</l>
 					<l>λεύσσων μάταια, δεσπότιν τε τὴν ἐμήν.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τοῦτ’ αὔτ’ ἔχρῃζον, τοῦτό σου μαθεῖν· λέγεις</l>
 					<l part="I">δέσποιναν εἶναι τήνδε σήν;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l part="F">δίκαια γάρ.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="410">τί δῆτα; ποίαν ἀξιοῖς δοῦναι δίκην,</l>
 					<l>ἢν εὑρεθῇς ἐς τήνδε μὴ δίκαιος ὤν;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>πῶς μὴ δίκαιος; τί ποτε ποικίλας ἔχεις;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὐδέν· σὺ μέντοι κάρτα τοῦτο δρῶν κυρεῖς.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἄπειμι· μῶρος δ’ ἦ πάλαι κλύων σέθεν.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l n="415">οὔ, πρίν γ’ ἂν εἴπῃς ἱστορούμενος βραχύ.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>λέγ’, εἴ τι χρῄζεις· καὶ γὰρ οὐ σιγηλὸς εἶ.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>τὴν αἰχμάλωτον, ἣν ἔπεμψας ἐς δόμους,</l>
 					<l part="I">κάτοισθα δήπου;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l part="F">φημί· πρὸς τί δ’ ἱστορεῖς;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>οὔκουν σὺ ταύτην, ἣν ὑπ’ ἀγνοίας ὁρᾷς,</l>
 					<l n="420">Ἰόλην ἔφασκες Εὐρύτου σπορὰν ἄγειν;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ποίοις ἐν ἀνθρώποισι; τίς πόθεν μολὼν</l>
 					<l>σοὶ μαρτυρήσει ταῦτ’ ἐμοῦ κλύειν πάρα;</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>πολλοῖσιν ἀστῶν· ἐν μέσῃ Τραχινίων</l>
 					<l>ἀγορᾷ πολύς σου ταῦτά γ’ εἰσήκουσ’ ὄχλος.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l n="425">κλύειν γ’ ἔφασκον· ταὐτὸ δ’ οὐχὶ γίγνεται</l>
 					<l>δόκησιν εἰπεῖν κἀξακριβῶσαι λόγον.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ποίαν δόκησιν; οὐκ ἐπώμοτος λέγων</l>
 					<l>δάμαρτ’ ἔφασκες Ἡρακλεῖ ταύτην ἄγειν;</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἐγὼ δάμαρτα; πρὸς θεῶν, φράσον, φίλη</l>
 					<l n="430">δέσποινα, τόνδε τίς ποτ’ ἐστὶν ὁ ξένος.</l>
 				</sp>
-				<sp who="#aggelos">
+				<sp who="#angelos">
 					<speaker>Ἄγγελος</speaker>
 					<l>ὃς σοῦ παρὼν ἤκουσεν, ὡς ταύτης πόθῳ</l>
 					<l>πόλις δαμείη πᾶσα, κοὐχ ἡ Λυδία</l>
 					<l>πέρσειεν αὐτήν, ἀλλ’ ὁ τῆσδ’ ἔρως φανείς.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἅνθρωπος, ὦ δέσποιν’, ἀποστήτω· τὸ γὰρ</l>
 					<l n="435">νοσοῦντι ληρεῖν ἀνδρὸς οὐχὶ σώφρονος.</l>
@@ -988,12 +988,12 @@ antilabe in all files
 					<l>πρὸς ἄλλον εἶναι, πρὸς δ’ ἔμ’ ἀψευδεῖν ἀεί.</l>
 					<milestone ed="p" n="470" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="470">πείθου λεγούσῃ χρηστά, κοὐ μέμψει χρόνῳ</l>
 					<l>γυναικὶ τῇδε κἀπ’ ἐμοῦ κτήσει χάριν.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἀλλ’, ὦ φίλη δέσποιν’, ἐπεί σε μανθάνω</l>
 					<l>θνητὴν φρονοῦσαν θνητὰ κοὐκ ἀγνώμονα,</l>
@@ -1028,7 +1028,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>μέγα τι σθένος ἁ Κύπρις ἐκφέρεται νίκας ἀεί.</l>
 						<l>καὶ τὰ μὲν θεῶν</l>
@@ -1042,7 +1042,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὁ μὲν ἦν ποταμοῦ σθένος, ὑψίκερω τετραόρου</l>
 						<l>φάσμα ταύρου,</l>
@@ -1056,7 +1056,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="epode">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>τότ’ ἦν χερός, ἦν δὲ τόξων πάταγος,</l>
 						<l>ταυρείων τ’ ἀνάμιγδα κεράτων·</l>
@@ -1137,7 +1137,7 @@ antilabe in all files
 					<l>πράσσειν μάταιον· εἰ δὲ μή, πεπαύσομαι.</l>
 					<milestone ed="p" n="588" unit="card"/>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εἴ τις ἐστὶ πίστις ἐν τοῖς δρωμένοις,</l>
 					<l>δοκεῖς παρ’ ἡμῖν οὐ βεβουλεῦσθαι κακῶς.</l>
@@ -1147,7 +1147,7 @@ antilabe in all files
 					<l n="590">οὕτως ἔχει γ’ ἡ πίστις, ὡς τὸ μὲν δοκεῖν</l>
 					<l>ἔνεστι, πείρᾳ δ’ οὐ προσωμίλησά πω·</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ εἰδέναι χρὴ δρῶσαν, ὡς οὐδ’ εἰ δοκεῖς</l>
 					<l>ἔχειν, ἔχοις ἂν γνῶμα, μὴ πειρωμένη.</l>
@@ -1159,7 +1159,7 @@ antilabe in all files
 					<l>μόνον παρ’ ὑμῶν εὖ στεγοίμεθ’·  ὡς σκότῳ</l>
 					<l>κἂν αἰσχρὰ πράσσῃς, οὔποτ’ αἰσχύνῃ πεσεῖ.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>τί χρὴ ποεῖν; σήμαινε, τέκνον Οἰνέως,</l>
 					<l>ὡς ἐσμὲν ἤδη τῷ μακρῷ χρόνῳ βραδεῖς.</l>
@@ -1189,7 +1189,7 @@ antilabe in all files
 					<l>κἀμοῦ ξυνελθοῦσ’ ἐξ ἁπλῆς διπλῆ φανῇ.</l>
 					<milestone ed="p" n="620" unit="card"/>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l n="620">ἀλλ’ εἴπερ Ἑρμοῦ τήνδε πομπεύω τέχνην</l>
 					<l>βέβαιον, οὔ τι μὴ σφαλῶ γ’ ἐν σοί ποτε,</l>
@@ -1201,7 +1201,7 @@ antilabe in all files
 					<l>στείχοις ἂν ἤδη· καὶ γὰρ ἐξεπίστασαι</l>
 					<l n="625">τά γ’ ἐν δόμοισιν ὡς ἔχοντα τυγχάνει.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ἐπίσταμαί τε καὶ φράσω σεσωσμένα.</l>
 				</sp>
@@ -1210,7 +1210,7 @@ antilabe in all files
 					<l>ἀλλ’ οἶσθα μὲν δὴ καὶ τὰ τῆς ξένης ὁρῶν</l>
 					<l>προσδέγματ’, αὐτὴν ὡς ἐδεξάμην φίλως.</l>
 				</sp>
-				<sp who="#lixas">
+				<sp who="#lichas">
 					<speaker>Λίχας</speaker>
 					<l>ὥστ’ ἐκπλαγῆναι τοὐμὸν ἡδονῇ κέαρ.</l>
 				</sp>
@@ -1224,7 +1224,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὦ ναύλοχα καὶ πετραῖα</l>
 						<l>θερμὰ λουτρὰ καὶ πάγους</l>
@@ -1236,7 +1236,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="640">ὁ καλλιβόας τάχ’ ὑμῖν</l>
 						<l>αὐλὸς οὐκ ἀναρσίαν</l>
@@ -1248,7 +1248,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὃν ἀπόπτολιν εἴχομεν παντᾷ,</l>
 						<l>δυοκαιδεκάμηνον ἀμμένουσαι</l>
@@ -1262,7 +1262,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="655">ἀφίκοιτ’ ἀφίκοιτο· μὴ σταίη</l>
 						<l>πολύκωπον ὄχημα ναὸς αὐτῷ,</l>
@@ -1282,7 +1282,7 @@ antilabe in all files
 					<l>γυναῖκες, ὡς δέδοικα μὴ περαιτέρω</l>
 					<l>πεπραγμέν’ ᾖ μοι πάνθ’ ὅσ’ ἀρτίως ἔδρων.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l n="665">τί δ’ ἔστι, Δῃάνειρα, τέκνον Οἰνέως;</l>
 				</sp>
@@ -1291,7 +1291,7 @@ antilabe in all files
 					<l>οὐκ οἶδ’· ἀθυμῶ δ’, εἰ φανήσομαι τάχα</l>
 					<l>κακὸν μέγ’ ἐκπράξασ’ ἀπ’ ἐλπίδος καλῆς.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>οὐ δή τι τῶν σῶν Ἡρακλεῖ δωρημάτων;</l>
 				</sp>
@@ -1300,7 +1300,7 @@ antilabe in all files
 					<l>μάλιστά γ’, ὥστε μήποτ’ ἂν προθυμίαν</l>
 					<l n="670">ἄδηλον ἔργου τῳ παραινέσαι λαβεῖν.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>δίδαξον, εἰ διδακτόν, ἐξ ὅτου φοβεῖ.</l>
 					<milestone ed="p" n="672" unit="card"/>
@@ -1361,7 +1361,7 @@ antilabe in all files
 					<l>ἥτις προτιμᾷ μὴ κακὴ πεφυκέναι.</l>
 				</sp>
 				<milestone ed="p" n="723" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ταρβεῖν μὲν ἔργα δείν’ ἀναγκαίως ἔχει,</l>
 					<l>τὴν δ’ ἐλπίδ’ οὐ χρὴ τῆς τύχης κρίνειν πάρος.</l>
@@ -1371,7 +1371,7 @@ antilabe in all files
 					<l n="725">οὐκ ἔστιν ἐν τοῖς μὴ καλοῖς βουλεύμασιν</l>
 					<l>οὐδ’ ἐλπίς, ἥτις καὶ θράσος τι προξενεῖ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ἀλλ’ ἀμφὶ τοῖς σφαλεῖσι μὴ ’ξ ἑκουσίας</l>
 					<l>ὀργὴ πέπειρα, τῆς σε τυγχάνειν πρέπει.</l>
@@ -1381,13 +1381,13 @@ antilabe in all files
 					<l>τοιαῦτα δ’ ἂν λέξειεν οὐχ ὁ τοῦ κακοῦ</l>
 					<l n="730">κοινωνός, ἀλλ’ ᾧ μηδέν ἐστ’ οἴκοι βαρύ.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>σιγᾶν ἂν ἁρμόζοι σε τὸν πλείω λόγον,</l>
 					<l>εἰ μή τι λέξεις παιδὶ τῷ σαυτῆς· ἐπεὶ</l>
 					<l>πάρεστι, μαστὴρ πατρὸς ὃς πρὶν ᾤχετο.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ὦ μῆτερ, ὡς ἂν ἐκ τριῶν σ’ ἓν εἱλόμην,</l>
 					<l n="735">ἢ μηκέτ’ εἶναι ζῶσαν, ἢ σεσωσμένην</l>
@@ -1398,7 +1398,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>τί δ’ ἐστίν, ὦ παῖ, πρός γ’ ἐμοῦ στυγούμενον;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>τὸν ἄνδρα τὸν σὸν ἴσθι, τὸν δ’ ἐμὸν λέγω</l>
 					<l n="740">πατέρα, κατακτείνασα τῇδ’ ἐν ἡμέρᾳ.</l>
@@ -1407,7 +1407,7 @@ antilabe in all files
 					<speaker>Δηιάνειρα</speaker>
 					<l>οἴμοι, τιν’ ἐξήνεγκας, ὦ τέκνον, λόγον;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ὃν οὐχ οἷόν τε μὴ οὐ τελεσθῆναι· τὸ γὰρ</l>
 					<l>φανθὲν τίς ἂν δύναιτ’ ἂν ἀγένητον ποεῖν;</l>
@@ -1417,7 +1417,7 @@ antilabe in all files
 					<l>πῶς εἶπας, ὦ παῖ; τοῦ παρ’ ἀνθρώπων μαθὼν</l>
 					<l n="745">ἄζηλον οὕτως ἔργον εἰργάσθαι με φής;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>αὐτὸς βαρεῖαν ξυμφορὰν ἐν ὄμμασιν</l>
 					<l>πατρὸς δεδορκὼς κοὐ κατὰ γλῶσσαν κλύων.</l>
@@ -1427,7 +1427,7 @@ antilabe in all files
 					<l>ποῦ δ’ ἐμπελάζεις τἀνδρὶ καὶ παρίστασαι;</l>
 					<milestone ed="p" n="749" unit="card"/>
 				</sp>
-				<sp n="Ὕλλος" who="#yllos">
+				<sp n="Ὕλλος" who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>εἰ χρὴ μαθεῖν σε, πάντα δὴ φωνεῖν χρεών.</l>
 					<l n="750">ὅθ’ εἷρπε κλεινὴν Εὐρύτου πέρσας πόλιν,</l>
@@ -1496,12 +1496,12 @@ antilabe in all files
 					<l>κτείνασ’, ὁποῖον ἄλλον οὐκ ὄψει ποτέ.</l>
 				</sp>
 				<milestone ed="p" n="813" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί σῖγ’ ἀφέρπεις; οὐ κάτοισθ’ ὁθούνεκα</l>
 					<l>ξυνηγορεῖς σιγῶσα τῷ κατηγόρῳ;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l n="815">ἐᾶτ’ ἀφέρπειν· οὖρος ὀφθαλμῶν ἐμῶν</l>
 					<l>αὐτῇ γένοιτ’ ἄπωθεν ἑρπούσῃ καλός.</l>
@@ -1514,7 +1514,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἴδ’ οἷον, ὦ παῖδες, προσέμιξεν ἄφαρ</l>
 						<l>τοὔπος τὸ θεοπρόπον ἡμῖν</l>
@@ -1528,7 +1528,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἰ γάρ σφε Κενταύρου φονίᾳ νεφέλᾳ</l>
 						<l>χρίει δολοποιὸς ἀνάγκα</l>
@@ -1542,7 +1542,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ὧν ἅδ’ ἁ τλάμων ἄοκνος μεγάλαν προορῶσα</l>
 						<l>δόμοισι βλάβαν νέων</l>
@@ -1558,7 +1558,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔρρωγεν παγὰ δακρύων·  κέχυται νόσος, ὦ πόποι,</l>
 						<l>οἷον ἀναρσίων</l>
@@ -1574,106 +1574,106 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#emixorion">
+				<sp who="#hemichorion_1">
 					<speaker>Ἡμιχόριον 1</speaker>
 					<l>πότερον ἐγὼ μάταιος, ἢ κλύω τινὸς</l>
 					<l>οἴκτου δῑ οἴκων ἀρτίως ὁρμωμένου;</l>
 					<l n="865" part="Y">τί φημι;</l>
 				</sp>
-				<sp who="#emixorion">
+				<sp who="#hemichorion_2">
 					<speaker>Ἡμιχόριον 2</speaker>
 					<l>ἠχεῖ τις οὐκ ἄσημον, ἀλλὰ δυστυχῆ</l>
 					<l>κωκυτὸν εἴσω, καί τι καινίζει στέγη.</l>
 				</sp>
-				<sp who="#emixorion">
+				<sp who="#hemichorion">
 					<speaker>Ἡμιχόριον</speaker>
 					<l part="Y">ξύνες δὲ</l>
 					<l>τήνδ’ ὡς κατηφὴς  καὶ συνωφρυωμένη</l>
 					<l n="870">χωρεῖ πρὸς ἡμᾶς γραῖα σημανοῦσά τι.</l>
 				</sp>
-				<sp who="#trofos">
+				<sp who="#trophos">
 					<speaker>Τροφός</speaker>
 					<l>ὦ παῖδες, ὡς ἄρ’ ἡμὶν οὐ σμικρῶν κακῶν</l>
 					<l>ἦρξεν τὸ δῶρον Ἡρακλεῖ τὸ πόμπιμον.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τί δ’, ὦ γεραιά, καινοποιηθὲν λέγεις;</l>
 				</sp>
-				<sp who="#trofos">
+				<sp who="#trophos">
 					<speaker>Τροφός</speaker>
 					<l>βέβηκε Δῃάνειρα τὴν πανυστάτην</l>
 					<l n="875">ὁδῶν ἁπασῶν ἐξ ἀκινήτου ποδός.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">οὐ δή ποθ’ ὡς θανοῦσα;</l>
 				</sp>
-				<sp who="#trofos">
+				<sp who="#trophos">
 					<speaker>Τροφός</speaker>
 					<l part="F">πάντ’ ἀκήκοας.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l part="I">τέθνηκεν ἡ τάλαινα;</l>
 				</sp>
-				<sp who="#trofos">
+				<sp who="#trophos">
 					<speaker>Τροφός</speaker>
 					<l part="F">δεύτερον κλύεις.</l>
 				</sp>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>τάλαιν’ ὀλεθρία· τίνι τρόπῳ θανεῖν σφε φής;</l>
 				</sp>
-				<sp who="#trofos">
+				<sp who="#trophos">
 					<speaker>Τροφός</speaker>
 					<l part="I">σχετλιώτατά γε πρὸς πρᾶξιν.</l>
 				</sp>
 				<div2 type="lyric">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">εἰπὲ τῷ μόρῳ,</l>
 						<l n="880">γύναι, ξυντρέχει.</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l part="I">αὑτὴν διηΐστωσε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="F">τίς θυμὸς ἢ τίνες νόσοι</l>
 						<l>τάνδ’ αἰχμᾷ  βέλεος κακοῦ ξυνεῖλε; πως ἐμήσατο</l>
 						<l n="885">πρὸς θανάτῳ θάνατον ἀνύσασα μόνα;</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>στονόεντος ἐν τομᾷ σιδάρου.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἐπεῖδες, ὦ ματαία, τάνδε τὴν ὕβριν;</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>ἐπεῖδον, ὡς δὴ πλησία παραστάτις.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="890">τίς ἦν; πῶς; φέρ’ εἰπέ.</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>αὐτὴ πρὸς αὑτῆς χειροποιεῖται τάδε.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l part="I">τί φωνεῖς;</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l part="F">σαφηνῆ.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>ἔτεκεν ἔτεκε δὴ μεγάλαν</l>
 						<l>ἁ νέορτος ἅδε νύμφα</l>
@@ -1682,16 +1682,16 @@ antilabe in all files
 				</div2>
 				<div2 type="dialogue">
 					<milestone ed="p" n="896" unit="card"/>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>ἄγαν γε· μᾶλλον δ’, εἰ παροῦσα πλησία</l>
 						<l>ἔλευσσες οἷ’ ἔδρασε, κάρτ’ ἂν ᾤκτισας.</l>
 					</sp>
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>καὶ ταῦτ’ ἔτλη τις χεὶρ γυναικεία κτίσαι;</l>
 					</sp>
-					<sp who="#trofos">
+					<sp who="#trophos">
 						<speaker>Τροφός</speaker>
 						<l>δεινῶς γε· πεύσει δ’, ὥστε μαρτυρεῖν ἐμοί.</l>
 						<l n="900">ἐπεὶ γὰρ ἦλθε δωμάτων εἴσω μόνη</l>
@@ -1747,7 +1747,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>πότερα πρότερον ἐπιστένω,</l>
 						<l>πότερα μέλεα  περαιτέρω,</l>
@@ -1756,7 +1756,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="950">τάδε μὲν ἔχομεν ὁρᾶν δόμοις,</l>
 						<l>τάδε δὲ μένομεν ἐπ’ ἐλπίσιν·</l>
@@ -1765,7 +1765,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="strophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l>εἴθ’ ἀνεμόεσσά τις</l>
 						<l n="955">γένοιτ’ ἔπουρος ἑστιῶτις αὔρα,</l>
@@ -1780,7 +1780,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="2" type="antistrophe">
-					<sp who="#xoros">
+					<sp who="#choros">
 						<speaker>Χορός</speaker>
 						<l n="965">ἀγχοῦ δ’ ἄρα κοὐ μακρὰν</l>
 						<l>προύκλαιον, ὀξύφωνος ὡς ἀηδών.</l>
@@ -1797,7 +1797,7 @@ antilabe in all files
 			</div1>
 			<div1 type="episode">
 				<div2 type="anapests">
-					<sp who="#yllos">
+					<sp who="#hyllos">
 						<speaker>Ὕλλος</speaker>
 						<l>οἴμοι ἐγὼ σοῦ,</l>
 						<l>πάτερ, οἴμοι ἐγὼ σοῦ μέλεος.</l>
@@ -1810,7 +1810,7 @@ antilabe in all files
 						<l>ζῇ γὰρ προπετής· ἀλλ’ ἴσχε δακὼν</l>
 						<l part="I">στόμα σόν.</l>
 					</sp>
-					<sp who="#yllos">
+					<sp who="#hyllos">
 						<speaker>Ὕλλος</speaker>
 						<l part="F">πῶς φής, γέρον; ἦ ζῇ;</l>
 					</sp>
@@ -1821,12 +1821,12 @@ antilabe in all files
 						<l n="980">φοιτάδα δεινὴν</l>
 						<l part="I">νόσον, ὦ τέκνον.</l>
 					</sp>
-					<sp who="#yllos">
+					<sp who="#hyllos">
 						<speaker>Ὕλλος</speaker>
 						<l part="F">ἀλλ’ ἐπί μοι μελέῳ</l>
 						<l>βάρος ἄπλετον· ἐμμέμονεν φρήν.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ὦ Ζεῦ,</l>
 						<l>ποῖ γᾶς ἥκω; παρὰ τοῖσι βροτῶν</l>
@@ -1841,12 +1841,12 @@ antilabe in all files
 						<l n="990">τῷδ’ ἀπὸ κρατὸς</l>
 						<l part="I">βλεφάρων θ’ ὕπνον;</l>
 					</sp>
-					<sp who="#yllos">
+					<sp who="#hyllos">
 						<speaker>Ὕλλος</speaker>
 						<l part="F">οὐ γὰρ ἔχω πῶς ἂν</l>
 						<l>στέρξαιμι κακὸν τόδε λεύσσων.</l>
 					</sp>
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ὦ Κηναία κρηπὶς βωμῶν,</l>
 						<l>ἱερῶν οἵαν οἵων ἐπί μοι</l>
@@ -1865,7 +1865,7 @@ antilabe in all files
 			</div1>
 			<div1 type="choral">
 				<div2 n="1" type="strophe">
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ἒ ἔ,</l>
 						<l n="1005">ἐᾶτέ μ’, ἐᾶτέ με δύσμορον ὕστατον,</l>
@@ -1893,7 +1893,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 type="mesode">
-					<sp who="#yllos">
+					<sp who="#hyllos">
 						<speaker>Ὕλλος</speaker>
 						<l n="1020">ψαύω μὲν ἔγωγε,</l>
 						<l>λαθίπονον δ’ ὀδυνᾶν οὔτ’ ἔνδοθεν οὔτε θύραθεν</l>
@@ -1902,7 +1902,7 @@ antilabe in all files
 					</sp>
 				</div2>
 				<div2 n="1" type="antistrophe">
-					<sp who="#erakles">
+					<sp who="#herakles">
 						<speaker>Ἡρακλῆς</speaker>
 						<l>ὦ παῖ, ποῦ ποτ’ εἶ; τᾷδέ με τᾷδέ με</l>
 						<l n="1025">πρόσλαβε κουφίσας. ἒ ἔ, ἰὼ δαῖμον.</l>
@@ -1921,12 +1921,12 @@ antilabe in all files
 				</div2>
 			</div1>
 			<div1 type="episode">
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>κλύουσ’ ἔφριξα τάσδε συμφοράς, φίλαι,</l>
 					<l n="1045">ἄνακτος, οἵαις οἷος ὢν ἐλαύνεται.</l>
 				</sp>
-				<sp n="Ἡρακλῆς" who="#erakles">
+				<sp n="Ἡρακλῆς" who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ὦ πολλὰ δὴ καὶ θερμὰ κοὐ λόγῳ  κακὰ</l>
 					<l>καὶ χερσὶ καὶ νώτοισι μοχθήσας ἐγώ·</l>
@@ -1997,12 +1997,12 @@ antilabe in all files
 					<l>καὶ ζῶν κακούς γε καὶ θανὼν ἐτισάμην.</l>
 				</sp>
 				<milestone ed="p" n="1112" unit="card"/>
-				<sp who="#xoros">
+				<sp who="#choros">
 					<speaker>Χορός</speaker>
 					<l>ὦ τλῆμον Ἑλλάς, πένθος οἷον εἰσορῶ</l>
 					<l>ἕξουσαν, ἀνδρὸς τοῦδέ γ’ εἰ σφαλήσεται.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἐπεὶ παρέσχες ἀντιφωνῆσαι, πάτερ,</l>
 					<l n="1115">σιγὴν παρασχὼν κλῦθί μου, νοσῶν ὅμως·</l>
@@ -2011,85 +2011,85 @@ antilabe in all files
 					<l>θυμῷ δύσοργος· οὐ γὰρ ἂν γνοίης ἐν οἷς</l>
 					<l>χαίρειν προθυμεῖ κἀν ὅτοις ἀλγεῖς μάτην.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="1120">εἰπὼν ὃ χρῄζεις λῆξον· ὡς ἐγὼ νοσῶν</l>
 					<l>οὐδὲν ξυνίημ’ ὧν σὺ ποικίλλεις πάλαι.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>τῆς μητρὸς ἥκω τῆς ἐμῆς φράσων ἐν οἷς</l>
 					<l>νῦν ἐστιν ὥς θ’ ἥμαρτεν οὐχ ἑκουσία.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ὦ παγκάκιστε, καὶ παρεμνήσω γὰρ αὖ</l>
 					<l n="1125">τῆς πατροφόντου μητρός, ὡς κλύειν ἐμέ;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἔχει γὰρ οὕτως ὥστε μὴ σιγᾶν πρέπειν.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οὐ δῆτα τοῖς γε πρόσθεν ἡμαρτημένοις.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἀλλ’ οὐδὲ μὲν δὴ τοῖς γ’ ἐφ’ ἡμέραν ἐρεῖς.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>λέγ’, εὐλαβοῦ δὲ μὴ φανῇς κακὸς γεγώς.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l n="1130">λέγω· τέθνηκεν ἀρτίως νεοσφαγής.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>πρὸς τοῦ; τέρας τοι διὰ κακῶν ἐθέσπισας.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>αὐτὴ πρὸς αὑτῆς, οὐδενὸς πρὸς ἐκτόπου.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οἴμοι· πρὶν ὡς χρῆν σφ’ ἐξ ἐμῆς θανεῖν χερός;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>κἂν σοῦ στραφείη θυμός, εἰ τὸ πᾶν μάθοις.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="1135">δεινοῦ λόγου κατῆρξας· εἰπὲ δ’ ᾗ νοεῖς.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἅπαν τὸ χρῆμ’, ἥμαρτε χρηστὰ μωμένη.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>χρήστ’, ὦ κάκιστε, πατέρα σὸν κτείνασα δρᾷ;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>στέργημα γὰρ δοκοῦσα προσβαλεῖν σέθεν</l>
 					<l>ἀπήμπλαχ’, ὡς προσεῖδε τοὺς ἔνδον γάμους.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="1140">καὶ τίς τοσοῦτος φαρμακεὺς Τραχινίων;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>Νέσσος πάλαι Κένταυρος ἐξέπεισέ νιν</l>
 					<l>τοιῷδε φίλτρῳ τὸν σὸν ἐκμῆναι πόθον.</l>
 					<milestone ed="p" n="1143" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἰοὺ ἰοὺ δύστηνος, οἴχομαι τάλας·</l>
 					<l>ὄλωλ’ ὄλωλα, φέγγος οὐκέτ’ ἔστι μοι.</l>
@@ -2100,7 +2100,7 @@ antilabe in all files
 					<l>μάτην ἄκοιτιν, ὡς τελευταίαν ἐμοῦ</l>
 					<l n="1150">φήμην πύθησθε θεσφάτων ὅσ’ οἶδ’ ἐγώ.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἀλλ’ οὔτε μήτηρ ἐνθάδ’, ἀλλ’ ἐπακτίᾳ</l>
 					<l>Τίρυνθι συμβέβηκεν ὥστ’ ἔχειν ἕδραν.</l>
@@ -2110,7 +2110,7 @@ antilabe in all files
 					<l>πράσσειν, κλύοντες ἐξυπηρετήσομεν.</l>
 					<milestone ed="p" n="1157" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>σὺ δ’ οὖν ἄκουε τοὔργον·  ἐξήκεις δ’ ἵνα</l>
 					<l>φανεῖς ὁποῖος ὢν ἀνὴρ ἐμὸς καλεῖ.</l>
@@ -2136,60 +2136,60 @@ antilabe in all files
 					<l>κάλλιστον ἐξευρόντα, πειθαρχεῖν πατρί.</l>
 					<milestone ed="p" n="1179" unit="card"/>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἀλλ’, ὦ πάτερ, ταρβῶ μὲν εἰς λόγου στάσιν</l>
 					<l n="1180">τοιάνδ’ ἐπελθών, πείσομαι δ’ ἅ σοι δοκεῖ.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἔμβαλλε χεῖρα δεξιὰν πρώτιστά μοι·</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ὡς πρὸς τί πίστιν τήνδ’ ἄγαν ἐπιστρέφεις;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οὐ θᾶσσον οἴσεις μηδ’ ἀπιστήσεις ἐμοί;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἰδοὺ προτείνω, κοὐδὲν ἀντειρήσεται.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l n="1185">ὄμνυ Διός νυν τοῦ με φύσαντος κάρα,</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἦ μὴν τί δράσειν; καὶ τόδ’ ἐξειρήσεται;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἦ μὴν ἐμοὶ τὸ λεχθὲν ἔργον ἐκτελεῖν.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ὄμνυμ’ ἔγωγε, Ζῆν’ ἔχων ἐπώμοτον.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>εἰ δ’ ἐκτὸς ἔλθοις, πημονὰς εὔχου λαβεῖν.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l n="1190">οὐ μὴ λάβω· δράσω γάρ· εὔχομαι δ’ ὅμως·</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οἶσθ’ οὖν τὸν Οἴτης Ζηνὸς ὕψιστον πάγον;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>οἶδ’, ὡς θυτήρ γε πολλὰ δὴ σταθεὶς ἄνω.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἐνταῦθά νυν χρὴ τοὐμὸν ἐξάραντά σε</l>
 					<l>σῶμ’ αὐτόχειρα καὶ ξὺν οἷς χρῄζεις φίλων.</l>
@@ -2203,65 +2203,65 @@ antilabe in all files
 					<l>καὶ νέρθεν ὢν ἀραῖος εἰσαεὶ βαρύς.</l>
 					<milestone ed="p" n="1203" unit="card"/>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>οἴμοι, πάτερ, τί δ’ εἶπας; οἷά μ’ εἴργασαι.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ὁποῖα δραστέ’ ἐστίν· εἰ δὲ μή, πατρὸς</l>
 					<l n="1205">ἄλλου γενοῦ του μηδ’ ἐμὸς κληθῇς ἔτι.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>οἴμοι μάλ’ αὖθις, οἷά μ’ ἐκκαλεῖ, πάτερ,</l>
 					<l>φονέα γενέσθαι καὶ παλαμναῖον σέθεν.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οὐ δῆτ’ ἔγωγ’, ἀλλ’ ὧν ἔχω παιώνιον</l>
 					<l>καὶ μοῦνον ἰατῆρα τῶν ἐμῶν κακῶν.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l n="1210">καὶ πῶς ὑπαίθων σῶμ’ ἂν ἰῴμην τὸ σόν;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἀλλ’ εἰ φοβεῖ πρὸς τοῦτο, τἄλλα γ’ ἔργασαι.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>φορᾶς γέ τοι φθόνησις οὐ γενήσεται.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἦ καὶ πυρᾶς πλήρωμα τῆς εἰρημένης;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ὅσον γ’ ἂν αὐτὸς μὴ ποτιψαύων χεροῖν·</l>
 					<l n="1215">τὰ δ’ ἄλλα πράξω κοὐ καμεῖ τοὐμὸν μέρος.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἀλλ’ ἀρκέσει καὶ ταῦτα· πρόσνειμαι δέ μοι</l>
 					<l>χάριν βραχεῖαν πρὸς μακροῖς ἄλλοις διδούς.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>εἰ καὶ μακρὰ κάρτ’ ἐστίν, ἐργασθήσεται.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>τὴν Εὐρυτείαν οἶσθα δῆτα παρθένον;</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l n="1220">Ἰόλην ἔλεξας, ὥς γ’ ἐπεικάζειν ἐμέ.</l>
 					<milestone ed="p" n="1221" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἔγνως.  τοσοῦτον δή σ’ ἐπισκήπτω, τέκνον·</l>
 					<l>ταύτην ἐμοῦ θανόντος, εἴπερ εὐσεβεῖν</l>
@@ -2274,16 +2274,16 @@ antilabe in all files
 					<l>σμικροῖς ἀπιστεῖν τὴν πάρος συγχεῖ χάριν.</l>
 					<milestone ed="p" n="1230" unit="card"/>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l n="1230">οἴμοι· τὸ μὲν νοσοῦντι θυμοῦσθαι κακόν,</l>
 					<l>τὸ δ’ ὧδ’ ὁρᾶν φρονοῦντα τίς ποτ’ ἂν φέροι;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ὡς ἐργασείων οὐδὲν ὧν λέγω θροεῖς.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>τίς γάρ ποθ’, ἥ μοι μητρὶ μὲν θανεῖν μόνη</l>
 					<l>μεταίτιος σοί τ’ αὖθις ὡς ἔχεις ἔχειν,</l>
@@ -2291,51 +2291,51 @@ antilabe in all files
 					<l>ἕλοιτο; κρεῖσσον κἀμέ γ’, ὦ πάτερ, θανεῖν</l>
 					<l>ἢ τοῖσιν ἐχθίστοισι συνναίειν ὁμοῦ.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἁνὴρ ὅδ’, ὡς ἔοικεν, οὐ νεμεῖν ἐμοὶ</l>
 					<l>φθίνοντι μοῖραν· ἀλλά τοι θεῶν ἀρὰ</l>
 					<l n="1240">μενεῖ σ’ ἀπιστήσαντα τοῖς ἐμοῖς λόγοις.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ὤμοι, τάχ’, ὡς ἔοικας, ὡς νοσεῖς φράσεις.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>σὺ γάρ μ’ ἀπ’ εὐνασθέντος ἐκκινεῖς κακοῦ.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>δείλαιος, ὡς ἐς πολλὰ τἀπορεῖν ἔχω.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οὐ γὰρ δικαιοῖς τοῦ φυτεύσαντος κλύειν.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l n="1245">ἀλλ’ ἐκδιδαχθῶ δῆτα δυσσεβεῖν, πάτερ;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>οὐ δυσσέβεια, τοὐμὸν εἰ τέρψεις κέαρ.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>πράσσειν ἄνωγας οὖν με πανδίκως τάδε;</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἔγωγε· τούτων μάρτυρας καλῶ θεούς.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>τοιγὰρ ποήσω κοὐκ ἀπώσομαι, τὸ σὸν</l>
 					<l n="1250">θεοῖσι δεικνὺς ἔργον· οὐ γὰρ ἄν ποτε</l>
 					<l>κακὸς φανείην σοί γε πιστεύσας, πάτερ.</l>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>καλῶς τελευτᾷς, κἀπὶ τοῖσδε τὴν χάριν</l>
 					<l>ταχεῖαν, ὦ παῖ, πρόσθες, ὡς πρὶν ἐμπεσεῖν</l>
@@ -2343,13 +2343,13 @@ antilabe in all files
 					<l n="1255">ἄγ’ ἐγκονεῖτ’, αἴρεσθε· παῦλά τοι κακῶν</l>
 					<l>αὕτη, τελευτὴ τοῦδε τἀνδρὸς ὑστάτη.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>ἀλλ’ οὐδὲν εἴργει σοὶ τελειοῦσθαι τάδε,</l>
 					<l>ἐπεὶ κελεύεις κἀξαναγκάζεις, πάτερ.</l>
 					<milestone ed="p" n="1259" unit="card"/>
 				</sp>
-				<sp who="#erakles">
+				<sp who="#herakles">
 					<speaker>Ἡρακλῆς</speaker>
 					<l>ἄγε νυν, πρὶν τήνδ’ ἀνακινῆσαι</l>
 					<l n="1260">νόσον, ὦ ψυχὴ σκληρά, χάλυβος</l>
@@ -2357,7 +2357,7 @@ antilabe in all files
 					<l>ἀνάπαυε βοήν, ὡς ἐπίχαρτον</l>
 					<l>τελέουσ’ ἀεκούσιον ἔργον.</l>
 				</sp>
-				<sp who="#yllos">
+				<sp who="#hyllos">
 					<speaker>Ὕλλος</speaker>
 					<l>αἴρετ’, ὀπαδοί, μεγάλην μὲν ἐμοὶ</l>
 					<l n="1265">τούτων θέμενοι συγγνωμοσύνην,</l>


### PR DESCRIPTION
I went through all IDs used in `<particDesc>` and adjusted them to the conventional latin transcription of the Greek names.